### PR TITLE
BUG : fix imports during sphinx build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -295,6 +295,7 @@ class Mock(object):
             return Mock()
 
 MOCK_MODULES = ['ctypes', 'h5py', 'numpy', 'scipy',
-                'scipy.ndimage', 'pywt', 'scipy.optimize']
+                'scipy.ndimage', 'pywt', 'scipy.optimize', 'skimage',
+                'skimage.filter', 'skimage.morphology']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()


### PR DESCRIPTION
added scikit and sub-modules to mock list

closes #13

I was getting errors due to import failures of skimage which this silences
