### PR TITLE
added exchange_rank to allow tomopy to process exchange1, exchange 2 etc...

### DIFF
--- a/tomopy/xtomo/xtomo_io.py
+++ b/tomopy/xtomo/xtomo_io.py
@@ -120,7 +120,7 @@ def xtomo_reader(file_name,
         
     try:
         # Now read dark fields. 
-        hdfdata = f[exchange_rank + "data_dark"]
+        hdfdata = f[exchange_rank + "/data_dark"]
         if dark_end is None:
             dark_end = num_x
         data_dark = hdfdata[dark_start:dark_end,
@@ -132,7 +132,7 @@ def xtomo_reader(file_name,
     
     try:
         # Read projection angles.
-        hdfdata = f[exchange_rank + "theta"]
+        hdfdata = f[exchange_rank + "/theta"]
         theta = hdfdata[projections_start:projections_end:projections_step]
         theta = np.nan_to_num(theta)
     except KeyError:


### PR DESCRIPTION
We are prepocessing the raw txm data to generate realigned projections. Once done with the preprocessing we are saving the new data in the same Data Exchange HDF5 under \exchange1. This modification will allow to point tomopy to reconstruct \exchange1
