### PR TITLE
Fixed deprecated char* string conversion error message.

### DIFF
--- a/tomopy/algorithms/recon/gridrec/filters.cpp
+++ b/tomopy/algorithms/recon/gridrec/filters.cpp
@@ -25,7 +25,7 @@ float ramp(float x){	/* Ramp filter */
 	return abs(x);
 }
 
-struct {char* name; float (*fp)(float);} fltbl[]= {
+struct {const char* name; float (*fp)(float);} fltbl[]= {
         {"none",none},
 	{"shlo",shlo},		/* The default choice */
 	{"shepp",shlo},


### PR DESCRIPTION
Because these strings are declared during compileand only referenced (not written to), they should be `const char*`. 
