### PR TITLE
Simplify package dependency installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.8.0
+scipy>=0.13.2
+h5py>=2.2.1
+pywavelets>=0.2.2
+scikit-image>=0.9

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ for requirement in install_requires:
         pkg_resources.require(requirement)
     except pkg_resources.DistributionNotFound:
         msg = 'Python package requirement not satisfied: ' + requirement
-        msg += '\nsuggest using this command:'
-        msg += '\n\tpip install -U ' + requirement.split('=')[0].rstrip('>')
+        msg += '\n\nInstall all required packages with\n\tpip install -r requirements.txt'
         raise pkg_resources.DistributionNotFound, msg
 
 # Get shared library locations (list of directories).


### PR DESCRIPTION
This is just a suggestion.

Packages could be installed simultaneously with
```python
pip install -r requirements.txt
```
So my pull request shows an implementation of this. I like it because it it more automated but the downside is that dependencies now live in two places: (i) setup.py install_requires and (ii) requirements.txt.

Anyway - just a thought!