### PR TITLE
Windows build

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,21 +1,23 @@
 # -*- coding: utf-8 -*-
 import tomopy
 
-# Read HDF5 file.
-data, white, dark, theta = tomopy.xtomo_reader('demo/data.h5',
-                                               slices_start=0,
-                                               slices_end=16)
-
-# Xtomo object creation and pipeline of methods.
-d = tomopy.xtomo_dataset(log='debug')
-d.dataset(data, white, dark, theta)
-d.normalize()
-d.correct_drift()
-d.phase_retrieval()
-d.correct_drift()
-d.center = 661.5
-d.gridrec()
-
-
-# Write to stack of TIFFs.
-tomopy.xtomo_writer(d.data_recon, 'tmp/test_', axis=0)
+#main is needed on windows
+if __name__ == '__main__':
+    # Read HDF5 file.
+    data, white, dark, theta = tomopy.xtomo_reader('demo/data.h5',
+                                                   slices_start=0,
+                                                   slices_end=16)
+    
+    # Xtomo object creation and pipeline of methods.
+    d = tomopy.xtomo_dataset(log='debug')
+    d.dataset(data, white, dark, theta)
+    d.normalize()
+    d.correct_drift()
+    d.phase_retrieval()
+    d.correct_drift()
+    d.center = 661.5
+    d.gridrec()
+    
+    
+    # Write to stack of TIFFs.
+    tomopy.xtomo_writer(d.data_recon, 'tmp/test_', axis=0)

--- a/tomopy/algorithms/preprocess/apply_padding.c
+++ b/tomopy/algorithms/preprocess/apply_padding.c
@@ -1,8 +1,13 @@
 #include <stdio.h>
 #include <math.h>
 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
 
-void apply_padding(float* data, int num_projections, 
+DLL void apply_padding(float* data, int num_projections, 
                    int num_slices, int num_pixels, 
                    int num_pad, float* padded_data) {
     

--- a/tomopy/algorithms/preprocess/apply_padding.py
+++ b/tomopy/algorithms/preprocess/apply_padding.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/libprep.so')
-libprep = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/libprep.pyd'))
+    libprep = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/libprep.so'))
+    libprep = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/preprocess/correct_drift.c
+++ b/tomopy/algorithms/preprocess/correct_drift.c
@@ -1,7 +1,12 @@
 #include <stdio.h>
 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
 
-void correct_drift(float* data, int num_projections, 
+DLL void correct_drift(float* data, int num_projections, 
                    int num_slices, int num_pixels, int air_pixels) {
                        
     int n, m, i, j, iproj;

--- a/tomopy/algorithms/preprocess/correct_drift.py
+++ b/tomopy/algorithms/preprocess/correct_drift.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/libprep.so')
-libprep = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/libprep.pyd'))
+    libprep = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/libprep.so'))
+    libprep = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/preprocess/downsample.c
+++ b/tomopy/algorithms/preprocess/downsample.c
@@ -1,8 +1,18 @@
 #include <stdio.h>
 #include <math.h>
 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
 
-void downsample2d(float* data, int num_projections,
+//Needed for windows build
+void initlibprep()
+{
+}
+
+DLL void downsample2d(float* data, int num_projections,
                   int num_slices, int num_pixels,
                   int level, float* downsampled_data) {
 
@@ -30,7 +40,7 @@ void downsample2d(float* data, int num_projections,
     }
 }
 
-void downsample3d(float* data, int num_projections,
+DLL void downsample3d(float* data, int num_projections,
                   int num_slices, int num_pixels,
                   int level, float* downsampled_data) {
 

--- a/tomopy/algorithms/preprocess/downsample.py
+++ b/tomopy/algorithms/preprocess/downsample.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/libprep.so')
-libprep = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/libprep.pyd'))
+    libprep = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/libprep.so'))
+    libprep = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/recon/art.c
+++ b/tomopy/algorithms/recon/art.c
@@ -3,7 +3,13 @@
 #include <math.h>
 #include <stdbool.h>
 
-void art(float* data, float* theta, float center, 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
+
+DLL void art(float* data, float* theta, float center, 
          int num_projections, int num_slices, int num_pixels, 
          int num_grid, int iters, float* recon) {
               

--- a/tomopy/algorithms/recon/art.py
+++ b/tomopy/algorithms/recon/art.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/librecon.so')
-librecon = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.pyd'))
+    librecon = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__),'../..', 'lib/librecon.so'))
+    librecon = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/recon/gridrec.py
+++ b/tomopy/algorithms/recon/gridrec.py
@@ -11,9 +11,12 @@ import multiprocessing as mp
 # --------------------------------------------------------------------
 
 # Get the shared library for gridrec.
-libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), 
-                          '../..', 'lib/librecon.so'))
-librecon = ctypes.CDLL(libpath)
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.pyd'))
+    librecon = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.so'))
+    librecon = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/recon/gridrec/tomoReconPy.cpp
+++ b/tomopy/algorithms/recon/gridrec/tomoReconPy.cpp
@@ -5,13 +5,25 @@
 #include <functional>
 #include <iostream>
 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
+
 static tomoRecon *pTomoRecon = NULL;
 static tomoParams_t tomoParams;
 static float *angles = NULL;
 
 extern "C" {
 
-void reconCreate(tomoParams_t *pTomoParams, float *pAngles)
+//Needed for windows build
+void initlibrecon()
+{
+
+}
+
+DLL void reconCreate(tomoParams_t *pTomoParams, float *pAngles)
 {
     if (angles) free(angles);
     angles = NULL;
@@ -23,7 +35,7 @@ void reconCreate(tomoParams_t *pTomoParams, float *pAngles)
     pTomoRecon = new tomoRecon(&tomoParams, angles);
 }
 
-void reconDelete()
+DLL void reconDelete()
 {
     if (pTomoRecon) delete pTomoRecon;
     pTomoRecon = NULL;
@@ -31,7 +43,7 @@ void reconDelete()
     angles = NULL;
 }
 
-void reconRun(int *numSlices,
+DLL void reconRun(int *numSlices,
              float *pCenter,
              float *pIn,
              float *pOut)
@@ -40,7 +52,7 @@ void reconRun(int *numSlices,
     pTomoRecon -> reconstruct(*numSlices, pCenter, pIn, pOut);
 }
 
-void reconPoll(int *pReconComplete,
+DLL void reconPoll(int *pReconComplete,
                int *pSlicesRemaining)
 {
     if (pTomoRecon == NULL) return;

--- a/tomopy/algorithms/recon/mlem.c
+++ b/tomopy/algorithms/recon/mlem.c
@@ -3,7 +3,19 @@
 #include <math.h>
 #include <stdbool.h>
 
-void mlem(float* data, float* theta, float center, 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
+
+//for windows build
+void initlibtest()
+{
+
+}
+
+DLL void mlem(float* data, float* theta, float center, 
           int num_projections, int num_slices, int num_pixels, 
           int num_grid, int iters, float* recon) {
               

--- a/tomopy/algorithms/recon/mlem.py
+++ b/tomopy/algorithms/recon/mlem.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/librecon.so')
-librecon = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.pyd'))
+    librecon = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.so'))
+    librecon = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/recon/pml.c
+++ b/tomopy/algorithms/recon/pml.c
@@ -3,7 +3,13 @@
 #include <math.h>
 #include <stdbool.h>
 
-void pml(float* data, float* theta, float center, 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
+
+DLL void pml(float* data, float* theta, float center, 
          int num_projections, int num_slices, int num_pixels, 
          int num_grid, int iters, float beta, float* recon) {
               

--- a/tomopy/algorithms/recon/pml.py
+++ b/tomopy/algorithms/recon/pml.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/librecon.so')
-librecon = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.pyd'))
+    librecon = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__),'../..', 'lib/librecon.so'))
+    librecon = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/recon/sirt.c
+++ b/tomopy/algorithms/recon/sirt.c
@@ -3,7 +3,13 @@
 #include <math.h>
 #include <stdbool.h>
 
-void sirt(float* data, float* theta, float center, 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
+
+DLL void sirt(float* data, float* theta, float center, 
          int num_projections, int num_slices, int num_pixels, 
          int num_grid, int iters, float* recon) {
               

--- a/tomopy/algorithms/recon/sirt.py
+++ b/tomopy/algorithms/recon/sirt.py
@@ -6,8 +6,12 @@ import ctypes
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/librecon.so')
-librecon = ctypes.CDLL(os.path.abspath(libpath))
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.pyd'))
+    librecon = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__),'../..', 'lib/librecon.so'))
+    librecon = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/algorithms/recon/upsample.c
+++ b/tomopy/algorithms/recon/upsample.c
@@ -1,8 +1,13 @@
 #include <stdio.h>
 #include <math.h>
 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
 
-void upsample2d(float* data, int num_slices, int num_pixels,
+DLL void upsample2d(float* data, int num_slices, int num_pixels,
                 int level, float* upsampled_data) {
 
     long m, n, k, i, p, q, iproj, ind;
@@ -31,7 +36,7 @@ void upsample2d(float* data, int num_slices, int num_pixels,
 }
 
 
-void upsample3d(float* data, int num_slices, int num_pixels,
+DLL void upsample3d(float* data, int num_slices, int num_pixels,
                 int level, float* upsampled_data) {
 
     int m, n, k, i, p, q, j, iproj, ind;

--- a/tomopy/algorithms/recon/upsample.py
+++ b/tomopy/algorithms/recon/upsample.py
@@ -8,8 +8,13 @@ import tomopy.tools.multiprocess_shared as mp
 # --------------------------------------------------------------------
 
 # Get the shared library.
-libpath = os.path.join(os.path.dirname(__file__), '../../lib/librecon.so')
-librecon = ctypes.CDLL(os.path.abspath(libpath))
+# Get the shared library.
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.pyd'))
+    librecon = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'lib/librecon.so'))
+    librecon = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 

--- a/tomopy/tools/fftw.cpp
+++ b/tomopy/tools/fftw.cpp
@@ -2,6 +2,12 @@
 #include <string.h>
 #include <fftw3.h>
 
+#ifdef WIN32
+#define DLL __declspec(dllexport)
+#else
+#define DLL 
+#endif
+
 extern "C" {
     
     void test ()
@@ -9,7 +15,12 @@ extern "C" {
         std::cout << "Hey!" << std::endl;
     }
     
-    void fftw_1d (float *argv1, int *argv2, int *argv3)
+	void initlibfftw()
+	{
+	
+	}
+	
+    DLL void fftw_1d (float *argv1, int *argv2, int *argv3)
     {
         
         float *data = (float *)argv1;
@@ -36,7 +47,7 @@ extern "C" {
         memcpy(data, in, n*sizeof(fftwf_complex));
     }
     
-    void fftw_2d (float *argv1, int *argv2, int *argv3,  int *argv4)
+    DLL void fftw_2d (float *argv1, int *argv2, int *argv3,  int *argv4)
     {
         
         float *data = (float *)argv1;

--- a/tomopy/tools/fftw.py
+++ b/tomopy/tools/fftw.py
@@ -8,8 +8,12 @@ import os
 
 # --------------------------------------------------------------------
 
-libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib/libfftw.so'))
-libfftw = ctypes.CDLL(libpath)
+if os.name == 'nt':
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib/libfftw.pyd'))
+    libfftw = ctypes.CDLL(libpath)
+else:
+    libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib/libfftw.so'))
+    libfftw = ctypes.CDLL(libpath)
 
 # --------------------------------------------------------------------
 


### PR DESCRIPTION
These are the changes I had to make for the windows build to work.
Python builds shared libraries on Windows with the .pyd extension. All the files that used ctypes to call shared object functions had to be updated with a check. They call .so for linux and .pyd for Windows.

On the c/c++ side we had to add defines for Windows. This define exposes the functions so that python can call them. The define is left blank for linux.

If new C functions are added in the future, they will need to add the define DLL before the function definition in order for it to work on Windows.

I used Anaconda 64 bit python which comes with MinGW GCC. I used this to compile the needed boost libraries and create an .a library definition for fftw.