### PR TITLE
Do not call plt.style if not available

### DIFF
--- a/tomopy/algorithms/preprocess/to_gif.py
+++ b/tomopy/algorithms/preprocess/to_gif.py
@@ -2,7 +2,9 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import animation
-plt.style.use('ggplot')
+
+if hasattr(plt, 'style'):
+    plt.style.use('ggplot')
 
 # --------------------------------------------------------------------
 

--- a/tomopy/xftomo/xftomo_preprocess.py
+++ b/tomopy/xftomo/xftomo_preprocess.py
@@ -13,7 +13,9 @@ import scipy.ndimage as spn
 import os
 import matplotlib.pyplot as plt
 from matplotlib import animation
-plt.style.use('ggplot')
+
+if hasattr(plt, 'style'):
+    plt.style.use('ggplot')
 
 # Import main TomoPy object.
 from tomopy.xftomo.xftomo_dataset import XFTomoDataset


### PR DESCRIPTION
Ubuntu 14.04 is shipped with Matplotlib 1.3.1 which does not include this API. On the other hand it might also not be a very good idea to override the user's decision how things should look like.