### PR TITLE
Fix negative values in shepp3d phantom.

### DIFF
--- a/test/test_io/test_phantom.py
+++ b/test/test_io/test_phantom.py
@@ -95,6 +95,7 @@ def test_shepp2d():
 def test_shepp3d():
     assert_equals(shepp3d((6, 8, 10)).dtype, 'float32')
     assert_equals(shepp3d((6, 8, 10)).shape, (6, 8, 10))
+    assert_equals(shepp3d((6, 8, 10)).min(), 0)
 
 
 if __name__ == '__main__':

--- a/tomopy/io/phantom.py
+++ b/tomopy/io/phantom.py
@@ -242,7 +242,7 @@ def shepp3d(shape=(128, 128, 128), dtype='float32'):
         Output 3D test image.
     """
     shepp_params = _array_to_params(_get_shepp_array())
-    return phantom(shape, shepp_params, dtype)
+    return phantom(shape, shepp_params, dtype).clip(0, np.inf)
 
 
 def phantom(shape, params, dtype='float32'):


### PR DESCRIPTION
I expect the shepp3d phantom to be > 0, however small negative values are present:

```python

>>> tomopy.io.phantom.shepp3d((6, 8, 10)).min()
-1.4901161e-08

```

This hopefully fixes it.
    