### PR TITLE
Make several io.reader imports optional

### DIFF
--- a/tomopy/io/reader.py
+++ b/tomopy/io/reader.py
@@ -58,13 +58,20 @@ import warnings
 import numpy as np
 import os
 import h5py
-import spefile
-import netCDF4
-import EdfFile
 import logging
 
 logger = logging.getLogger(__name__)
 
+def _check_import(modname):
+    try:
+        return __import__(modname)
+    except ImportError:
+        logger.warn(modname + ' module not found')
+        return None
+
+spefile = _check_import('spefile')
+netCDF4 = _check_import('netCDF4')
+EdfFile = _check_import('EdfFile')
 
 __author__ = "Doga Gursoy"
 __credits__ = "Francesco De Carlo"


### PR DESCRIPTION
This PR makes some of the less well-known imports within `io.reader` optional. For users that are not using spe files, netcdf files, or EDF files, this reduces the number of dependencies. For users that have installed the dependencies, everything works as before. 

This allows me to install tomopy using `python setup.py install`, which makes changing things and recompiling a bit easier for me. 

Currently, it shows a warning if an import is not found (at import time), and will throw an exception when trying to use a `read` method for which the import was not found. I think the exception and the warning give enough information for users, but I can add a specific warning message at the `read` method calls as well if you like!