### PR TITLE
bug fix. 

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -213,7 +213,8 @@ calc_dist(
     int csize, float *coorx, float *coory, 
     int *indi, float *dist)
 {
-    int n, x1, x2, i1, i2;
+    int n, i1, i2;
+    float x1, x2;
     float diffx, diffy, midx, midy;
     int indx, indy;
 


### PR DESCRIPTION
In old code, by nature the variables x1, x2 are integer, so the comparison with i1, i2 later on will not produce difference, and hence negative rounding to integer will have problem.

For all current test data set such situation would never occur, so nothing else is needed to fix.