### PR TITLE
Pass slice index to ASTRA reconstruction methods (needed for some methods)

### DIFF
--- a/tomopy/recon/wrappers.py
+++ b/tomopy/recon/wrappers.py
@@ -162,11 +162,14 @@ def astra(*args):
 
     if 'extra_options' in opts:
         cfg['option'] = opts['extra_options']
-
+    else:
+        cfg['option'] = {}
 
     # Perform reconstruction
     for i in xrange(istart, iend):
         sino[:] = tomo[:,i,:]
+
+        cfg['option']['z_id']=i
 
         # Fix center of rotation
         if use_cuda:


### PR DESCRIPTION
This PR adds code that passes the slice index to the ASTRA reconstruction method as an option. Some methods need this information, such as the NN-FBP method, and methods that don't need it can simply ignore it.