### PR TITLE
enabled memmap in tiff reader to improve sino read performance

### DIFF
--- a/tomopy/io/exchange.py
+++ b/tomopy/io/exchange.py
@@ -245,8 +245,7 @@ def read_anka_tomotopo(fname, ind_tomo, ind_flat, ind_dark):
     dark = tio.read_tiff_stack(dark_name, ind=ind_dark, digit=5)
     return tomo, flat, dark
 
-
-def read_aps_1id(fname, ind_tomo=None):
+def read_aps_1id(fname, ind_tomo=None, proj=None, sino=None):
     """
     Read APS 1-ID standard data format.
 
@@ -297,9 +296,9 @@ def read_aps_1id(fname, ind_tomo=None):
         ind_tomo = range(prj_start, prj_start + nprj)
     ind_flat = range(flat_start, flat_start + nflat)
     ind_dark = range(dark_start, dark_start + ndark)
-    tomo = tio.read_tiff_stack(_fname, ind=ind_tomo, digit=6)
-    flat = tio.read_tiff_stack(_fname, ind=ind_flat, digit=6)
-    dark = tio.read_tiff_stack(_fname, ind=ind_dark, digit=6)
+    tomo = tio.read_tiff_stack(_fname, ind=ind_tomo, digit=6, slc=(proj, sino))
+    flat = tio.read_tiff_stack(_fname, ind=ind_flat, digit=6, slc=(None, sino))
+    dark = tio.read_tiff_stack(_fname, ind=ind_dark, digit=6, slc=(None, sino))
     return tomo, flat, dark
 
 

--- a/tomopy/io/reader.py
+++ b/tomopy/io/reader.py
@@ -117,7 +117,7 @@ def read_tiff(fname, slc=None):
     fname = _check_read(fname)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        arr = sio.imread(fname, plugin='tifffile')
+        arr = sio.imread(fname, plugin='tifffile', memmap=True)
     arr = _slice_array(arr, slc)
     return arr
 


### PR DESCRIPTION
memmap=True enables memory-mapped file. These files are used for accessing small segments of large files on disk, without reading the entire file into memory. More at http://docs.scipy.org/doc/numpy/reference/generated/numpy.memmap.html 

read test on APS 1-ID tiff files:
read of 1801 x (2kx2k): 15s (memmap=False) vs 9s (memmap=True)
read of 1801 x (100x2k): 11s  (memmap=False) vs 2s  (memmap=True)