### PR TITLE
Allow threads to specify code to run on the main thread

### DIFF
--- a/tomopy/recon/wrappers.py
+++ b/tomopy/recon/wrappers.py
@@ -76,7 +76,6 @@ needed_options = {
     'astra': ['method']
 }
 
-
 def astra(*args):
     """
     Reconstruct object using the ASTRA toolbox
@@ -113,6 +112,12 @@ def astra(*args):
     >>> pylab.imshow(rec[64], cmap='gray')
     >>> pylab.show()
     """
+    if args[5]['options']['proj_type']=='cuda':
+        mproc.SHARED_QUEUE.put([astra_run]+list(args))
+    else:
+        astra_run(*args)
+
+def astra_run(*args):
     # Lazy import ASTRA
     import astra as astra_mod
 

--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -152,17 +152,17 @@ def _prepare_args(func, args, kwargs, istart, iend):
 
 def _start_proc(arr, args):
     shared_arr = get_shared(arr)
-    if len(args)==1:
-        init_shared(shared_arr)
-        _arg_parser(args[0])
-    else:
-        with closing(
-            mp.Pool(processes=len(args),
-                    initializer=init_shared,
-                    initargs=(shared_arr,))) as p:
-            p.map_async(_arg_parser, args)
-        p.join()
-        p.close()
+    init_shared(shared_arr)
+    man = mp.Manager()
+    queue = man.Queue()
+    with closing(
+        mp.Pool(processes=len(args),
+                initializer=init_shared,
+                initargs=(shared_arr,queue))) as p:
+        p.map_async(_arg_parser, args)
+    p.join()
+    p.close()
+    clear_queue(queue)
     return shared_arr
 
 
@@ -183,9 +183,11 @@ def _to_numpy_array(mp_arr, dshape):
     return np.reshape(a, dshape)
 
 
-def init_shared(shared_arr):
+def init_shared(shared_arr, queue=None):
     global SHARED_ARRAY
     SHARED_ARRAY = shared_arr
+    global SHARED_QUEUE
+    SHARED_QUEUE = queue
 
 
 def init_tomo(arr):
@@ -196,3 +198,9 @@ def init_tomo(arr):
 def init_obj(arr):
     global SHARED_OBJ
     SHARED_OBJ = get_shared(arr)
+
+def clear_queue(queue):
+    while not queue.empty():
+        args = queue.get(False)
+        func = args[0]
+        func(*args[1::])


### PR DESCRIPTION
In some cases, we want to run code on the main thread
instead of in the multiprocessing thread. For example, when
using CUDA functions in ASTRA, all cuda code has to be run
on the main thread. Currently, this has to be specified by the
user by setting ncore=1. If you forget to specify this, cuda
errors occur, and worse, the user has to kill the python process
(ctrl+c and such do not work). This happens to me a lot, for example
when switching from CPU to GPU ASTRA methods, and forgetting to specify
ncore=1.

This commit adds a shared Queue to the multiprocessing code, where
threads can put things in that have to be run by the main thread. After
all threads join, the main thread clears the queue by running all code
in it. The commit also updates the ASTRA wrapper to use the queue when
using CUDA functions of ASTRA. Therefore, ASTRA CUDA code always runs
on the main thread, even when running on multiple cores, and no errors
occur when forgetting to specify ncore=1.