### PR TITLE
ncore now correctly defaults to cpu_count instead of 1.

### DIFF
--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -101,12 +101,12 @@ def distribute_jobs(
     if ncore is not None and nchunk is not None:
         logger.warning('ncore will be overwritten according to nchunk')
 
-    if ncore <= 0:
-        ncore = 1
-
     # Arrange number of processors.
     if ncore is None or ncore > mp.cpu_count():
         ncore = mp.cpu_count()
+    if ncore <= 0:
+        ncore = 1
+
     ndim = arr.shape[axis]
 
     # Maximum number of processors for the task.


### PR DESCRIPTION
When ncore defaults to None, ncore <= 0 evaluates to True.  This results in ncore being set to 1 by default.  I moved the <= 0 check to a point after None values being replaced with the number of cpus to fix it.