### PR TITLE
Fix segfault in gridrec for odd starting slice in final chunk

### DIFF
--- a/src/gridrec.c
+++ b/src/gridrec.c
@@ -170,7 +170,7 @@ gridrec(
             while(j<dz)  
             {     
                 sino[j].r = data[j+s*dz+p*dy*dz];
-                if (!(dy == 1 || iend-istart == 1))
+                if (!(dy == 1 || iend-s == 1))
                 {
                     sino[j].i = data[j+(s+1)*dz+p*dy*dz];
                 } else {
@@ -306,7 +306,7 @@ gridrec(
                         corrn = corrn_u*winv[k+padx];
                         
                         recon[islc1+ngridy*(ngridx-1-k)+j] = corrn*H[iu][iv].r;
-                        if (!(dy == 1 || iend-istart == 1))
+                        if (!(dy == 1 || iend-s == 1))
                         {
                             recon[islc2+ngridy*(ngridx-1-k)+j] = corrn*H[iu][iv].i;
                         }


### PR DESCRIPTION
When the final chunk of a gridrec reconstruction starts with an odd slice number, `islc2` will point to an invalid memory address (one slice after the final one) in the last loop iteration. A previous check was already there to prevent these cases, but it only checked for when the starting slice was equal to the final slice. By changing this to check for the current slice that is reconstructed, I think the bug is fixed. 

I do not really know how the gridrec implementation is supposed to work, so please check whether I break something by this change!

PS. This is what caused the segfault and hang in #127 (since 100 slices over 8 cores will make the final chunk start at slice 91). After the fix, I don't get a segfault any more.