### PR TITLE
Fix gridx/gridy producing out of bounds indices

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -134,7 +134,7 @@ trim_coords(
 
     *asize = 0;
     *bsize = 0;
-    for (n=0; n<=rz; n++) 
+    for (n=1; n<rz; n++) 
     {
         if (coordx[n] > gridx[0]) 
         {
@@ -146,7 +146,7 @@ trim_coords(
             }
         }
     }
-    for (n=0; n<=ry; n++) 
+    for (n=1; n<ry; n++) 
     {
         if (coordy[n] > gridy[0]) 
         {


### PR DESCRIPTION
This solves a segfault I was getting with `sirt`, but it may solve other segfaults for iterative methods as well (maybe the original #120 error).

After some debugging, I found out that in the `sirt` method, some pixel indices were becoming larger than their allowed values (which caused them to read/write outside of array bounds later).

It turns out that in the `trim_coords` method, `coordx`/`coordy` values outside of the reconstruction grid are checked for in the `if` statements,  but `gridx`/`gridy` values could still be outside (actually, on the exact edge) of the reconstruction grid, which causes the problems.

By changing the bounds of the `for` loop, the problem is fixed, since only `gridx[0]`, `gridx[ry]`, `gridy[0]`, and `gridy[rz]` cause problems.

As in #129, I don't know whether this change can cause any problems at other points in the code, since I am not really familiar with the code, so please check!