### PR TITLE
Output files - dtype uint16

### DIFF
--- a/tomopy/util/dtype.py
+++ b/tomopy/util/dtype.py
@@ -100,7 +100,7 @@ def as_int32(arr):
 
 def as_uint16(arr):
     arr = as_ndarray(arr, np.uint16)
-    return as_dtype(arr, np.int32)
+    return as_dtype(arr, np.uint16)
 
 
 def as_uint8(arr):


### PR DESCRIPTION
In `dtype.py` `as_uint16()` seems to return an int32 array.
https://github.com/tomopy/tomopy/blob/master/tomopy/util/dtype.py#L101-L103

Should `return as_dtype(arr, np.int32)` be `return as_dtype(arr, np.uint16)`?