### PR TITLE
Use correct python version in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,21 @@ os:
 sudo: false
 
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --add channels dgursoy
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
   - conda install anaconda-client
-  - conda info -a
 
 install:
-  - conda install nose six numpy h5py scipy scikit-image pywavelets fftw pyfftw spefile netcdf4 edffile tifffile python-coveralls
+  - conda install python=$TRAVIS_PYTHON_VERSION nose six numpy h5py scipy scikit-image pywavelets fftw pyfftw spefile netcdf4 edffile tifffile python-coveralls
+  - conda info -a
   - python setup.py build_ext --inplace
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"


### PR DESCRIPTION
When working on travis-ci integration for ASTRA (for which I learned a lot from TomoPy's integration, thanks!), I noticed that TomoPy's travis configuration always uses python 2.7, even when testing in Python 3 mode. The reason for this is that the current script always uses `Miniconda-latest`, which is Python 2.7, and does not specify `python=$TRAVIS_PYTHON_VERSION` to conda to change the python version.

This PR updates the travis configuration to use the specified python version in conda. I also had to remove Python 2.6 from the test matrix, since conda does not seem to work with that version anymore.