### PR TITLE
Small fixes

### DIFF
--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -165,7 +165,7 @@ def distribute_jobs(arr,
 
     # if nchunk is zero, remove dimension from slice.
     map_args = []
-    for i in xrange(0, axis_size, nchunk or 1):
+    for i in range(0, axis_size, nchunk or 1):
         if nchunk:
             map_args.append((func, args, kwargs, np.s_[i:i+nchunk], axis))                
         else:
@@ -219,4 +219,4 @@ def _arg_parser(params):
 
 # apply slice to specific axis on ndarray
 def slice_axis(arr, slc, axis):
-    return arr[[slice(None) if i != axis else slc for i in xrange(arr.ndim)]]
+    return arr[[slice(None) if i != axis else slc for i in range(arr.ndim)]]

--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -187,7 +187,7 @@ def distribute_jobs(arr,
                 p.terminate()
                 raise
         else:
-            p.map(_arg_parser, map_args)
+            p.map_async(_arg_parser, map_args)
     try:
         p.join()
     except:


### PR DESCRIPTION
Small fixes for #162.

I don't know why `map_async` was changed to `map` in #162, so I reverted it in e075779. If there was a good reason to do this, I can remove that commit. The reason for the `if p._pool` check is because `_pool` is undocumented, so maybe it will not work with future versions of `multiprocessing`. In these cases, we would still want to run a `map_async`, just one without the polling of the pool state.