### PR TITLE
Fix travis builds by specifying conda path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --add channels dgursoy
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
@@ -28,7 +29,6 @@ before_install:
 install:
   - conda install python=$TRAVIS_PYTHON_VERSION nose six numpy h5py scipy scikit-image pywavelets fftw pyfftw spefile netcdf4 edffile tifffile python-coveralls
   - conda info -a
-  - conda install python=$TRAVIS_PYTHON_VERSION coverage
   - python setup.py build_ext --inplace
 
 script: 


### PR DESCRIPTION
The old travis files did not specify the conda bin path in `PATH`, so the system `nosetests` command was used instead of the installed conda `nosetests` command. This PR fixes that.

There is still an error in Python 3.x versions, but that does not seem to be caused by the travis configuration.