### PR TITLE
Fix empty_shared_array for Python 3

### DIFF
--- a/tomopy/util/dtype.py
+++ b/tomopy/util/dtype.py
@@ -180,7 +180,7 @@ def empty_shared_array(shape, dtype=np.float32):
     size = 1
     for dim in shape:
         size *= dim
-    shared_obj = mp.RawArray(ctype, size)
+    shared_obj = mp.RawArray(ctype, int(size))
     # create numpy array from shared object
     arr = np.frombuffer(shared_obj, dtype)
     arr = arr.reshape(shape)    


### PR DESCRIPTION
On Python 3, for some reason the `size` variable turned into a `numpy.int64` instead of a python `int`. 

`mp.RawArray` doesn't like `numpy.int64` as the input argument (it probably checks for `isinstance(size, int)` or something). Simply casting `size` to a python `int` fixes the problem and makes travis builds pass.