### PR TITLE
Do not build C library when running on RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -321,7 +321,7 @@ MOCK_MODULES = [
     'matplotlib', 'matplotlib.pylab', 'tifffile', 'EdfFile', 'netCDF4',
     'spefile', 'scipy.ndimage', 'pywt', 'scikit-image', 'skimage',
     'skimage.io', 'skimage.filter', 'skimage.morphology', 'skimage.feature',
-    'DM3lib', 'pyfftw', 'tomopy']
+    'DM3lib', 'pyfftw']
 
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,20 @@ tomoc = Extension(
         'src/stripe.c',
         'src/remove_ring.c'])
 
+
+ext_mods = [tomoc]
+
+# Remove external C code for RTD builds
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if on_rtd:
+    ext_mods = []
+
 setup(
     name='tomopy',
     packages=find_packages(exclude=['test*']),
     version=open('VERSION').read().strip(),
     include_package_data=True,
-    ext_modules=[tomoc],
+    ext_modules=ext_mods,
     zip_safe=False,
     author='Doga Gursoy',
     author_email='dgursoy@aps.anl.gov',


### PR DESCRIPTION
This PR should fix #169 by skipping compilation of TomoPy's C code when installing on RTD systems. The C code is not needed for parsing the Python docstrings, so the documentation should still be complete. An `import tomopy` call complains a bit about missing external libraries, but imports fine, so RTD is able to build the documentation.