### PR TITLE
mock dxchange in RTD config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -321,7 +321,7 @@ MOCK_MODULES = [
     'matplotlib', 'matplotlib.pylab', 'tifffile', 'EdfFile', 'netCDF4',
     'spefile', 'scipy.ndimage', 'pywt', 'scikit-image', 'skimage',
     'skimage.io', 'skimage.filter', 'skimage.morphology', 'skimage.feature',
-    'DM3lib', 'pyfftw']
+    'DM3lib', 'pyfftw', 'dxchange']
 
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()


### PR DESCRIPTION
Docs failed to build API function links. This will fix it.