### PR TITLE
Additions for debugging

### DIFF
--- a/tomopy/__init__.py
+++ b/tomopy/__init__.py
@@ -65,6 +65,7 @@ from tomopy.recon.rotation import *
 from tomopy.recon.acceleration import *
 from tomopy.sim.project import *
 from tomopy.sim.propagate import *
+from tomopy.util.mproc import set_debug
 
 import logging
 logging.basicConfig()

--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -202,8 +202,10 @@ def distribute_jobs(arr,
                     p.terminate()
                     raise
             else:
-                p.map_async(_arg_parser, map_args)
+                res = p.map_async(_arg_parser, map_args)
         try:
+            p.close()
+            res.get()
             p.join()
         except:
             p.terminate()

--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -73,7 +73,11 @@ SHARED_ARRAYS = None
 SHARED_OUT = None
 SHARED_QUEUE = None
 ON_HOST = False
+DEBUG = False
 
+def set_debug(val=True):
+    global DEBUG
+    DEBUG=val
 
 def distribute_jobs(arr,
                     func,
@@ -180,7 +184,7 @@ def distribute_jobs(arr,
 
     init_shared(shared_arrays, shared_out, queue, on_host=True)
 
-    if ncore > 1:
+    if ncore > 1 and DEBUG==False:
         with closing(mp.Pool(processes=ncore,
                              initializer=init_shared,
                              initargs=(shared_arrays, shared_out, queue))) as p:

--- a/tomopy/util/mproc.py
+++ b/tomopy/util/mproc.py
@@ -76,6 +76,14 @@ ON_HOST = False
 DEBUG = False
 
 def set_debug(val=True):
+    """
+    Set the global DEBUG variable.
+
+    If DEBUG is True, all computations will be run on the host process instead
+    of distributing work over different processes. This can help to debug
+    functions that give errors or cause segmentation faults. If DEBUG is False
+    (the default value), work is distributed over different processes.
+    """
     global DEBUG
     DEBUG=val
 


### PR DESCRIPTION
This PR adds two things to help debug problems:

* TomoPy will now reraise exceptions that are thrown by child processes, which will help debug problems like #195. Before, exceptions in child processes would simply result in a zero array being returned without any error message. Now it will show an error message, which might help a user to find out what went wrong (on Python 2 the message is quite short, but on Python 3 it will show a full traceback).
* A debug mode is added (turn on by calling `tomopy.set_debug()`), which will make everything run without any `multiprocessing`, but will still use the same chunk size and everything. This can help to find problems causing segfaults, since they will now cause the whole python instance to close instead of only stopping a single child process without a useful error message. Since it is implemented in `mproc`, it will work with any code that uses `mproc`. Obviously using debug mode will be much slower, since it will only use a single core.

Before first point (will return empty array):
```python
rec = tomopy.recon(d, ang,  algorithm=tomopy.astra, options={'method':'FBP', 'proj_type':'WRONG'})
```
After first point:
```python
rec = tomopy.recon(d, ang, ^J    algorithm=tomopy.astra, options={'method':'FBP', 'proj_type':'WRONG'})
---------------------------------------------------------------------------
RemoteTraceback                           Traceback (most recent call last)
RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/tomopy/util/mproc.py", line 252, in _arg_parser
    result = func(*func_args, **kwargs)
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/tomopy/recon/wrappers.py", line 122, in astra
    astra_run(*args, **kwargs)
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/tomopy/recon/wrappers.py", line 170, in astra_run
    pi = astra_mod.create_projector(opts['proj_type'], proj_geom, vol_geom)
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/astra/creators.py", line 558, in create_projector
    return projector.create(cfg)
  File "/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/astra/projector.py", line 36, in create
    return p.create(config)
  File "astra/projector_c.pyx", line 63, in astra.projector_c.create (astra/projector_c.cpp:930)
Exception: Error creating projector.
"""

The above exception was the direct cause of the following exception:

Exception                                 Traceback (most recent call last)
<ipython-input-9-b9bf8d62bd17> in <module>()
      1 rec = tomopy.recon(d, ang, 
----> 2     algorithm=tomopy.astra, options={'method':'FBP', 'proj_type':'WRONG'})

/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/tomopy/recon/algorithm.py in recon(tomo, theta, center, sinogram_order, algorithm, init_recon, ncore, nchunk, **kwargs)
    282     recon = _init_recon(recon_shape, init_recon)
    283     return _dist_recon(
--> 284         tomo, center_arr, recon, _get_func(algorithm), args, kwargs, ncore, nchunk)
    285 
    286 

/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/tomopy/recon/algorithm.py in _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk)
    351         axis=0,
    352         ncore=ncore,
--> 353         nchunk=nchunk)
    354 
    355 

/export/scratch2/pelt/condas/c3/lib/python3.5/site-packages/tomopy/util/mproc.py in distribute_jobs(arr, func, axis, args, kwargs, ncore, nchunk, out)
    205         try:
    206             p.close()
--> 207             res.get()
    208             p.join()
    209         except:

/export/scratch2/pelt/condas/c3/lib/python3.5/multiprocessing/pool.py in get(self, timeout)
    606             return self._value
    607         else:
--> 608             raise self._value
    609 
    610     def _set(self, i, obj):

Exception: Error creating projector.
```