### PR TITLE
Gridrec custom filter arrays

### DIFF
--- a/src/gridrec.h
+++ b/src/gridrec.h
@@ -85,34 +85,37 @@ void
 free_matrix_c(float _Complex** m);
 
 float 
-(*get_filter(const char *name))(float, float, float);
+(*get_filter(const char *name))(float, int, const float*);
 
 float 
-filter_none(float, float, float);
+filter_none(float, int, const float*);
 
 float 
-filter_shepp(float, float, float);
+filter_shepp(float, int, const float*);
 
 float 
-filter_hann(float, float, float);
+filter_hann(float, int, const float*);
 
 float 
-filter_hamming(float, float, float);
+filter_hamming(float, int, const float*);
 
 float 
-filter_ramlak(float, float, float);
+filter_ramlak(float, int, const float*);
 
 float 
-filter_parzen(float, float, float);
+filter_parzen(float, int, const float*);
 
 float 
-filter_butterworth(float, float, float);
+filter_butterworth(float, int, const float*);
+
+float
+filter_custom(float, int, const float*);
 
 void 
 set_filter_tables(
     int dt, int pd, 
     float fac, 
-    float(* const pf)(float, float, float), const float *filter_par,
+    float(* const pf)(float, int, const float*), const float *filter_par,
     float _Complex *A);
 
 void 

--- a/test/test_recon/test_algorithm.py
+++ b/test/test_recon/test_algorithm.py
@@ -52,6 +52,7 @@ from __future__ import (absolute_import, division, print_function,
 from test.util import read_file
 from tomopy.recon.algorithm import *
 from numpy.testing import assert_allclose
+import numpy as np
 
 
 __author__ = "Doga Gursoy"
@@ -79,6 +80,11 @@ class TestRecon(object):
         assert_allclose(
             recon(self.prj, self.ang, algorithm='fbp'),
             read_file('fbp.npy'), rtol=1e-2)
+
+    def test_gridrec_custom(self):
+        assert_allclose(
+            recon(self.prj, self.ang, algorithm='gridrec', filter_name='none'),
+            recon(self.prj, self.ang, algorithm='gridrec', filter_name='custom', filter_par=np.ones(self.prj.shape[-1],dtype=np.float32)))
 
     # def test_gridrec(self):
     #     assert_allclose(

--- a/tomopy/recon/algorithm.py
+++ b/tomopy/recon/algorithm.py
@@ -247,7 +247,7 @@ def recon(
                     (key, allowed_kwargs[algorithm]))
             else:
                 # Make sure they are numpy arrays.
-                if not isinstance(kwargs[key], (np.ndarray, np.generic)) and not isinstance(kwargs[key], str):
+                if not isinstance(kwargs[key], (np.ndarray, np.generic)) and not isinstance(kwargs[key], six.string_types):
                     kwargs[key] = np.array(value)
 
                 # Make sure reg_par is float32.

--- a/tomopy/recon/algorithm.py
+++ b/tomopy/recon/algorithm.py
@@ -247,7 +247,7 @@ def recon(
                     (key, allowed_kwargs[algorithm]))
             else:
                 # Make sure they are numpy arrays.
-                if not isinstance(kwargs, (np.ndarray, np.generic)):
+                if not isinstance(kwargs[key], (np.ndarray, np.generic)) and not isinstance(kwargs[key], str):
                     kwargs[key] = np.array(value)
 
                 # Make sure reg_par is float32.
@@ -363,7 +363,7 @@ def _get_algorithm_kwargs(shape):
     return {
         'num_gridx': dx,
         'num_gridy': dx,
-        'filter_name': np.array('shepp', dtype=(str, 16)),
+        'filter_name': 'shepp',
         'filter_par': np.array([0.5, 8], dtype='float32'),
         'num_iter': dtype.as_int32(1),
         'reg_par': np.ones(10, dtype='float32'),

--- a/tomopy/util/dtype.py
+++ b/tomopy/util/dtype.py
@@ -57,6 +57,7 @@ import ctypes
 import numpy as np
 import multiprocessing as mp
 import logging
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +130,7 @@ def as_c_float(arr):
 
 
 def as_c_char_p(arr):
-    return ctypes.c_char_p(str.encode(arr,"ascii"))
+    return ctypes.c_char_p(six.b(arr))
 
 
 def as_c_void_p():

--- a/tomopy/util/dtype.py
+++ b/tomopy/util/dtype.py
@@ -129,8 +129,7 @@ def as_c_float(arr):
 
 
 def as_c_char_p(arr):
-    c_char_p = ctypes.POINTER(ctypes.c_char)
-    return arr.ctypes.data_as(c_char_p)
+    return ctypes.c_char_p(str.encode(arr,"ascii"))
 
 
 def as_c_void_p():


### PR DESCRIPTION
This PR adds the option to specify a custom filter for gridrec, by using:

```python
recon(prj, ang, algorithm='gridrec', filter_name='custom', filter_par=custom_array)
```

This will be useful for computing advanced filter-based reconstruction methods with gridrec, which makes them suitable for fast computation on CPUs.

The length of the `filter_par` array is not checked at the moment, so it is assumed that it is long enough. I think if that if the array is not big enough, it will simply use 'random' values as the filter, and the reconstruction will be horrible. I don't see an easy way of adding a length check without rewriting too much, but maybe someone has a better idea how to handle this...

During work on this PR, I found that in Python 3 string options were not passed correctly through ctypes, so gridrec would always use the default `'shepp'` filter. I think the reason for this is that strings in Python 3 are unicode by default, which did not work in the ctypes conversion. I fixed this by changing the way passing filters to the algorithms works (i.e. using `ctypes.c_char_p` directly).

Todo:

- [ ] Allow for angle-dependent filters