### PR TITLE
Fix memory leak in remove_ring.c

### DIFF
--- a/src/remove_ring.c
+++ b/src/remove_ring.c
@@ -98,11 +98,15 @@ void remove_ring(
 				data[i+(j*dx)+s*dy*dx] = image[j][i];
 			}
 		}
+		
+		free(polar_image[0]);
+		free(polar_image);
+		
+		free(ring_image[0]);
+		free(ring_image);
 
 	}
 
-	free(ring_image);
-	free(polar_image);
 	free(image);
 
 	return;
@@ -123,6 +127,7 @@ int min_distance_to_edge(
 			min = dist[i];
 		}
 	}
+	free(dist);
 	return min;
 }
 


### PR DESCRIPTION
While trying some things I noticed that remove_ring was leaking memory. This PR fixes the leaks. I think it was not really a problem in practice, since the memory would be freed after each process of `multiprocessing` completed its work, but I guess it is better to remove the leaks.