### PR TITLE
Fixes for sino_360_to_180

### DIFF
--- a/test/test_misc/test_morph.py
+++ b/test/test_misc/test_morph.py
@@ -68,6 +68,14 @@ def test_downsample():
 def test_upsample():
     loop_dim(upsample, read_file('obj.npy'))
 
+def test_sino_360_to_180():
+    test_im = np.random.random((32, 32, 128)).astype(np.float32)
+    ltest = sino_360_to_180(test_im, 32, 'left')
+    rtest = sino_360_to_180(test_im, 32, 'right')
+    assert_array_almost_equal(ltest[:, :, -112:], test_im[:16, :, 16:])
+    assert_array_almost_equal(ltest[:, :, :112], test_im[16:, :, 16:][:, :, ::-1])
+    assert_array_almost_equal(rtest[:, :, :112], test_im[:16, :, :-16])
+    assert_array_almost_equal(rtest[:, :, -112:], test_im[16:, :, :-16][:, :, ::-1])
 
 if __name__ == '__main__':
     import nose

--- a/tomopy/misc/morph.py
+++ b/tomopy/misc/morph.py
@@ -264,6 +264,9 @@ def sino_360_to_180(data, overlap=0, rotation='left'):
     """
     Converts 0-360 degrees sinogram to a 0-180 sinogram.
 
+    If the number of projections in the input data is odd, the last projection
+    will be discarded.
+
     Parameters
     ----------
     data : ndarray

--- a/tomopy/misc/morph.py
+++ b/tomopy/misc/morph.py
@@ -283,6 +283,8 @@ def sino_360_to_180(data, overlap=0, rotation='left'):
     """
     dx, dy, dz = data.shape
 
+    overlap = int(np.round(overlap))
+
     lo = overlap//2
     ro = overlap - lo
     n = dx//2

--- a/tomopy/misc/morph.py
+++ b/tomopy/misc/morph.py
@@ -289,10 +289,10 @@ def sino_360_to_180(data, overlap=0, rotation='left'):
 
     out = np.zeros((n, dy, 2*dz-overlap), dtype=data.dtype)
 
-    if rotation is 'left':
+    if rotation == 'left':
         out[:, :, -(dz-lo):] = data[:n, :, lo:]
         out[:, :, :-(dz-lo)] = data[n:2*n, :, ro:][:, :, ::-1]
-    elif rotation is 'right':
+    elif rotation == 'right':
         out[:, :, :dz-lo] = data[:n, :, :-lo]
         out[:, :, dz-lo:] = data[n:2*n, :, :-ro][:, :, ::-1]
 


### PR DESCRIPTION
This PR includes some fixes for `sino_360_to_180`, specifically:

* Fix output for `rotation='right'`
* Use both arrays for filling the overlapping region instead of only one array. This avoids using values at the edges of the detector, which may have the most artifacts in practice.
* Simplified the code a bit, using only a single `if` statement
* Renamed `sino_360_t0_180` to `sino_360_to_180` (`sino_360_t0_180` is kept for backward compatibility)
* Changed `rotation is` to `rotation ==`, using an equality comparison instead of an identity comparison (which often gives the correct results due to string caching, but can fail)
* Added a small test for the method