### PR TITLE
Add 1D outlier removal and make current outlier removal support N dimensions

### DIFF
--- a/tomopy/misc/corr.py
+++ b/tomopy/misc/corr.py
@@ -346,8 +346,9 @@ def remove_neg(arr, val=0., ncore=None):
 
 def remove_outlier(arr, dif, size=3, axis=0, ncore=None, out=None):
     """
-    Remove high intensity bright spots from a 3D array along specified
-    dimension.
+    Remove high intensity bright spots from a N-dimensional array by chunking 
+    along the specified dimension, and performing (N-1)-dimensional median 
+    filtering along the other dimensions.
 
     Parameters
     ----------
@@ -359,7 +360,7 @@ def remove_outlier(arr, dif, size=3, axis=0, ncore=None, out=None):
     size : int
         Size of the median filter.
     axis : int, optional
-        Axis along which median filtering is performed.
+        Axis along which to chunk.
     ncore : int, optional
         Number of cores that will be assigned to jobs.
     out : ndarray, optional
@@ -376,14 +377,16 @@ def remove_outlier(arr, dif, size=3, axis=0, ncore=None, out=None):
 
     tmp = np.empty_like(arr)
 
-    if ncore is None:
-        ncore = mproc.mp.cpu_count()
+    ncore, chnk_slices = mproc.get_ncore_slices(arr.shape[axis], ncore=ncore)
+    
+    filt_size = [size]*arr.ndim
+    filt_size[axis] = 1
 
     with cf.ThreadPoolExecutor(ncore) as e:
         slc = [slice(None)]*arr.ndim
-        for i in range(arr.shape[axis]):
-            slc[axis] = i
-            e.submit(filters.median_filter, arr[slc], size=(size, size),
+        for i in range(ncore):
+            slc[axis] = chnk_slices[i]
+            e.submit(filters.median_filter, arr[slc], size=filt_size,
                      output=tmp[slc])
 
     with mproc.set_numexpr_threads(ncore):


### PR DESCRIPTION
This PR adds a new function, `remove_outlier1d`, that is similar to the existing `remove_outlier`, but performs median filtering only along a single axis. In addition, it makes a small change to the existing `remove_outlier` code such that is supports N-dimensional arrays (instead of only 3-D), and updates its documentation to clarify what is does.

We found the 1D outlier removal to be useful when only processing a small number of slices (for example just one). In these cases, the existing 2D outlier removal would use only a small filter size (since part of the filter is 'cropped' by the limited number of slices). Since there is usually some cross-talk between neighboring pixels, the small median filter would not remove many of the existing outliers. Using a larger filter size will work in these cases, but then the required filter size depends on the number of slices the user is processing.

Using the added `remove_outlier1d` function, it is possible to filter along the angle dimension in 1D (which is the default case). Since there is no cross-talk between projections, a small filter size correctly filters out most outliers, even when only processing a small number of slices. In fact, each slice is filtered independently from the others in this case, so the output of the procedure is identical when processing few slices compared to processing many slices.

While working on this PR, I noticed that `remove_outlier` only supported 3-D arrays: I have changed the code so that it supports generic N-D arrays. Furthermore, the documentation of `remove_outlier` was a bit confusing to me: it suggested that the filtering was performed along the `axis` axis, but the filtering is actually performed along all axes other than `axis`. I have tried to clarify this in the documentation.