### PR TITLE
Use NullHandler instead of basicConfig

### DIFF
--- a/tomopy/__init__.py
+++ b/tomopy/__init__.py
@@ -61,6 +61,9 @@ else:
     import pyfftw
     sys.setdlopenflags(curFlags)
 
+import logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 from tomopy.io import *
 from tomopy.io.exchange import * # deprecated
 from tomopy.io.reader import *   # deprecated
@@ -78,9 +81,6 @@ from tomopy.recon.acceleration import *
 from tomopy.sim.project import *
 from tomopy.sim.propagate import *
 from tomopy.util.mproc import set_debug
-
-import logging
-logging.basicConfig()
 
 try:
     import pkg_resources

--- a/tomopy/io/writer.py
+++ b/tomopy/io/writer.py
@@ -60,7 +60,6 @@ import os
 import six
 import h5py
 import logging
-import warnings
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
`logging.basicConfig()` was propably added to avoid the dreaded "no log handler found for ..." messages however this is the wrong approach because it interferes with the log handling in applications using the library, instead libraries should never set up log handlers and leave it to client application. To avoid the message, libraries can register the `NullHandler` though, see for example:

  http://docs.python-guide.org/en/latest/writing/logging/#logging-in-a-library