### PR TITLE
ENH: Performance improvements in gridrec.c

### DIFF
--- a/src/gridrec.c
+++ b/src/gridrec.c
@@ -74,14 +74,14 @@ pthread_mutex_t lock;
 #define __PRAGMA_SIMD _Pragma("simd assert")
 #define __PRAGMA_SIMD_VECREMAINDER _Pragma("simd assert, vecremainder")
 #define __PRAGMA_SIMD_VECREMAINDER_VECLEN8 _Pragma("simd assert, vecremainder, vectorlength(8)")
-#define __PRAGMA_OMP_SIMD_COLLAPSE(var) _Pragma("omp simd collapse(2) private(##var)")
+#define __PRAGMA_OMP_SIMD_COLLAPSE _Pragma("omp simd collapse(2)")
 #define __PRAGMA_IVDEP _Pragma("ivdep")
 #define __ASSSUME_64BYTES_ALIGNED(x) __assume_aligned((x), 64)
 #else
 #define __PRAGMA_SIMD
 #define __PRAGMA_SIMD_VECREMAINDER
 #define __PRAGMA_SIMD_VECREMAINDER_VECLEN8
-#define __PRAGMA_OMP_SIMD_COLLAPSE(var)
+#define __PRAGMA_OMP_SIMD_COLLAPSE
 #define __PRAGMA_IVDEP
 #define __ASSSUME_64BYTES_ALIGNED(x)
 #endif
@@ -213,7 +213,7 @@ gridrec(
         // an additional correction -- See Phase 3 below.
 
         float _Complex Cdata1, Cdata2;
-        float U, V, rtmp;
+        float U, V;
         const float L2 = (int)(C/M_PI);
         const float tblspcg = 2*ltbl/L;
 
@@ -287,9 +287,9 @@ gridrec(
                     work2[k] = wtbl[(int) roundf(fabsf(U-iu)*tblspcg)];
                 }
 
-                __PRAGMA_OMP_SIMD_COLLAPSE(rtmp)
+		__PRAGMA_OMP_SIMD_COLLAPSE
                 for (iu=iul, k2=0; iu <= iuh; iu++, k2++) {
-                    rtmp = work2[k2];
+                    const float rtmp = work2[k2];
                     for(iv=ivl, k=0; iv<=ivh; iv++, k++) {
                         const float convolv = rtmp*work[k];
                         H[iu][iv] += convolv*Cdata1;

--- a/src/gridrec.h
+++ b/src/gridrec.h
@@ -1,56 +1,56 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef _gridrec_h
 #define _gridrec_h
 
-#include <complex.h> 
+#include <complex.h>
 #include <stdlib.h>
 
 #ifdef WIN32
 #define DLL __declspec(dllexport)
 #else
-#define DLL 
+#define DLL
 #endif
 #define ANSI
 
@@ -66,13 +66,13 @@ gridrec(
     const char fname[16],
     const float *filter_par);
 
-float* 
+float*
 malloc_vector_f(size_t n);
 
 void
 free_vector_f(float* v);
 
-float _Complex* 
+float _Complex*
 malloc_vector_c(size_t n);
 
 void
@@ -84,28 +84,28 @@ malloc_matrix_c(size_t nr, size_t nc);
 void
 free_matrix_c(float _Complex** m);
 
-float 
+float
 (*get_filter(const char *name))(float, int, int, int, const float*);
 
-float 
+float
 filter_none(float, int, int, int, const float*);
 
-float 
+float
 filter_shepp(float, int, int, int, const float*);
 
-float 
+float
 filter_hann(float, int, int, int, const float*);
 
-float 
+float
 filter_hamming(float, int, int, int, const float*);
 
-float 
+float
 filter_ramlak(float, int, int, int, const float*);
 
-float 
+float
 filter_parzen(float, int, int, int, const float*);
 
-float 
+float
 filter_butterworth(float, int, int, int, const float*);
 
 float
@@ -117,24 +117,24 @@ filter_custom2d(float, int, int, int, const float*);
 unsigned char
 filter_is_2d(const char *name);
 
-void 
+void
 set_filter_tables(
-    int dt, int pd, 
-    float fac, 
+    int dt, int pd,
+    float fac,
     float(* const pf)(float, int, int, int, const float*), const float *filter_par,
     float _Complex *A, unsigned char is2d);
 
-void 
+void
 set_trig_tables(
-    int dt, const float *theta, 
+    int dt, const float *theta,
     float **SP, float **CP);
 
-void 
+void
 set_pswf_tables(
-    float C, int nt, float lmbda, const float *coefs, 
+    float C, int nt, float lmbda, const float *coefs,
     int ltbl, int linv, float* wtbl, float* winv);
 
-float 
+float
 legendre(int n, const float *coefs, float x);
 
 #endif


### PR DESCRIPTION

1. Use floating point functions, i.e.  `ceilf`, `sinf`, `cosf`, etc. instead
   of functions with doubles signature, i.e. `ceil`, `sin`, `cos`, etc..

   This helps compilers generate more efficient code by avoiding
   upcasting, evaluation of the function in double precision, and
   subsequent downcasting.

2. Replaced use of `lroundf(x)` with `(int) roundf(x)`.

   The latter one can be vectorized, while the former can not.

3. Icc-specific pragmas get applied to loops to assist vectorization
   if Intel C Compiler is used to compile the code.

4. The loop updating H was split in two to avoid genuine vector dependencies
   inhibiting vectorization by ICC.

5. Use 64-bytes aligned memory allocation from X/Open-7 posix standard
   instead of using fftw allocator.

@dgursoy 