### PR TITLE
ENH: Perf. improvements to retieve_phase

### DIFF
--- a/src/gridrec.c
+++ b/src/gridrec.c
@@ -146,10 +146,12 @@ gridrec(
     DFTI_DESCRIPTOR_HANDLE reverse_1d;
     MKL_LONG length_1d = (MKL_LONG) pdim;
     DftiCreateDescriptor(&reverse_1d, DFTI_SINGLE, DFTI_COMPLEX, 1, length_1d);
+    DftiSetValue(reverse_1d, DFTI_THREAD_LIMIT, 1); /* FFT should run sequentially to avoid oversubscription */
     DftiCommitDescriptor(reverse_1d);
     DFTI_DESCRIPTOR_HANDLE forward_2d;
     MKL_LONG length_2d[2] = {(MKL_LONG) pdim, (MKL_LONG) pdim};
     DftiCreateDescriptor(&forward_2d, DFTI_SINGLE, DFTI_COMPLEX, 2, length_2d);
+    DftiSetValue(forward_2d, DFTI_THREAD_LIMIT, 1); /* FFT should run sequentially to avoid oversubscription */
     DftiCommitDescriptor(forward_2d);
 #else
     // Set up fftw plans

--- a/tomopy/prep/phase.py
+++ b/tomopy/prep/phase.py
@@ -54,7 +54,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-import pyfftw
+from tomopy.util.misc import (fft2, ifft2)
+
+
 import tomopy.util.mproc as mproc
 import logging
 
@@ -120,7 +122,7 @@ def retrieve_phase(
     phase_filter = np.fft.fftshift(
         _paganin_filter_factor(energy, dist, alpha, w2))
 
-    prj = val * np.ones((dy + 2 * py, dz + 2 * pz), dtype='float32')
+    prj = np.full((dy + 2 * py, dz + 2 * pz), val, dtype='float32')
     arr = mproc.distribute_jobs(
         tomo,
         func=_retrieve_phase,
@@ -134,28 +136,20 @@ def retrieve_phase(
 def _retrieve_phase(tomo, phase_filter, px, py, prj, pad):
     dx, dy, dz = tomo.shape
     num_jobs = tomo.shape[0]
+    normalized_phase_filter = phase_filter / phase_filter.max()
     for m in range(num_jobs):
         prj[px:dy + px, py:dz + py] = tomo[m]
         prj[:px] = prj[px]
         prj[-px:] = prj[-px-1]
         prj[:, :py] = prj[:, py][:, np.newaxis]
         prj[:, -py:] = prj[:, -py-1][:, np.newaxis]
-        fproj = pyfftw.interfaces.numpy_fft.fft2(
-                prj, planner_effort=_plan_effort(num_jobs))
-        filtproj = np.multiply(phase_filter, fproj)
-        proj = np.real(pyfftw.interfaces.numpy_fft.ifft2(
-            filtproj, planner_effort=_plan_effort(num_jobs))
-            ) / phase_filter.max()
+        fproj = fft2(prj, extra_info=num_jobs)
+        fproj *= normalized_phase_filter
+        proj = np.real(ifft2(fproj, extra_info=num_jobs, overwrite_input=True))
         if pad:
             proj = proj[px:dy + px, py:dz + py]
         tomo[m] = proj
 
-
-def _plan_effort(num_jobs):
-    if num_jobs > 10:
-        return 'FFTW_MEASURE'
-    else:
-        return 'FFTW_ESTIMATE'
 
 
 def _calc_pad(tomo, pixel_size, dist, energy, pad):
@@ -226,8 +220,9 @@ def _reciprocal_grid(pixel_size, nx, ny):
     # Sampling in reciprocal space.
     indx = _reciprocal_coord(pixel_size, nx)
     indy = _reciprocal_coord(pixel_size, ny)
-    du, dv = np.meshgrid(indy, indx)
-    return np.square(du) + np.square(dv)
+    np.square(indx, out=indx)
+    np.square(indy, out=indy)
+    return np.add.outer(indx, indy)
 
 
 def _reciprocal_coord(pixel_size, num_grid):
@@ -247,5 +242,7 @@ def _reciprocal_coord(pixel_size, num_grid):
     ndarray
         Grid coordinates.
     """
-    return (1 / ((num_grid - 1) * pixel_size)) * \
-        np.arange(-(num_grid - 1) * 0.5, num_grid * 0.5)
+    n = num_grid - 1
+    rc = np.arange(-n, num_grid, 2, dtype = np.float32)
+    rc *= 0.5 / (n * pixel_size)
+    return  rc

--- a/tomopy/util/misc.py
+++ b/tomopy/util/misc.py
@@ -56,13 +56,15 @@ from __future__ import (absolute_import, division, print_function,
 import logging
 import warnings
 
+
+
 logger = logging.getLogger(__name__)
 
 
 __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2016, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
-__all__ = ['deprecated']
+__all__ = ['deprecated', 'fft2', 'ifft2', 'fft', 'ifft']
 
 
 def deprecated(func, msg=None):
@@ -81,3 +83,83 @@ def deprecated(func, msg=None):
     new_func.__doc__ = func.__doc__
     new_func.__dict__.update(func.__dict__)
     return new_func
+
+
+try:
+    import mkl_fft
+    fft_impl = 'mkl_fft'
+    logger.debug('FFT implementation is mkl_fft')
+except ImportError:
+    try:
+        import pyfftw
+        fft_impl = 'pyfftw'
+        logger.debug('FFT implementation is pyfftw')
+    except ImportError:
+        import np.fft
+        fft_impl = 'numpy.fft'
+        logger.debug('FFT implementation is numpy.fft')
+
+
+if fft_impl == 'mkl_fft':
+    def fft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
+        return mkl_fft.fft(x, n=n, axis=axis, overwrite_x=overwrite_input)
+
+
+    def ifft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
+        return mkl_fft.ifft(x, n=n, axis=axis, overwrite_x=overwrite_input)
+
+
+    def fft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
+        return mkl_fft.fft2(x, shape=s, axes=axes, overwrite_x=overwrite_input)
+
+
+    def ifft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
+        return mkl_fft.ifft2(x, shape=s, axes=axes, overwrite_x=overwrite_input)
+
+elif fft_impl == 'pyfftw':
+    def _plan_effort(num_jobs):
+        if not num_jobs:
+            return 'FFTW_MEASURE'
+        if num_jobs > 10:
+            return 'FFTW_MEASURE'
+        else:
+            return 'FFTW_ESTIMATE'
+
+    def fft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
+        return pyfftw.interfaces.numpy_fft.fft(x, n=n, axis=axis,
+                                               overwrite_input=overwrite_input,
+                                               planner_effort=_plan_effort(extra_info))
+    
+
+    def ifft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
+        return pyfftw.interfaces.numpy_fft.ifft(x, n=n, axis=axis,
+                                                overwrite_input=overwrite_input,
+                                                planner_effort=_plan_effort(extra_info))
+
+
+    def fft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
+        return pyfftw.interfaces.numpy_fft.fft2(x, s=s, axes=axes,
+                                                overwrite_input=overwrite_input,
+                                                planner_effort=_plan_effort(extra_info))
+    
+
+    def ifft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
+        return pyfftw.interfaces.numpy_fft.ifft2(x, s=s, axes=axes,
+                                                 overwrite_input=overwrite_input,
+                                                 planner_effort=_plan_effort(extra_info))
+
+else:
+    def fft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
+        return np.fft.fft(x, n=n, axis=axis)
+
+
+    def ifft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
+        return np.fft.ifft(x, n=n, axis=axis)
+
+
+    def fft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
+        return np.fft.fft2(x, s=s, axes=axes)
+
+
+    def ifft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
+        return np.fft.ifft2(x, s=s, axes=axes)


### PR DESCRIPTION
1. Wrote more efficient code for `_reciprocal_grid` and `_reciprocal_coord`.
2. Encapsulated uses of `fft`, `ifft` and `fft2`, `ifft2` by replacing direct calls to `pyfftw.interfaces.numpy` functions with calls to wrapper functions defined in `tomopy.util.misc`. 
3. Wrote definitions of these functions in terms of `mkl_fft` functions, in terms of `pyfftw` functions and in terms of `numpy.fft` functions as fall-back. Supported in-place operations with `overwrite_input=True`.
4. in `_retrieve_phase` `ifft2` is now done in place for efficiency.

Using 

```
import tomopy
obj = tomopy.lena(1024)
ang = tomopy.angles(200)
prj = tomopy.project(obj, ang)
import timeit
t0 = timeit.default_timer()
prj = tomopy. retrieve_phase(prj)
t1 = timeit.default_timer()
print(t1-t0)
```

The timings are `5.4` seconds in master to `0.52` seconds in this branch with the use of `pyfftw` as a back-end.

Switching to `mkl_fft` back-end, the timing goes up to `4.57` due to oversubscription, Using `MKL_THREADING_LAYER=sequential python test_phase.py` the timing is `0.42` seconds.

Using `TBB` module from Intel Distribution for Python to combat oversubscription with `python -m tbb test_phase.py` the timing is `0.435` seconds.


Also, in `gridrec.c`, set MKL's FFT to be single threaded, to avoid oversubscription.

@dgursoy 