### PR TITLE
Add support for reconstruction with UFO

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -122,3 +122,17 @@ Does ASTRA support all GPUs?
 
 The GPU algorithms are all implemented used nVidia CUDA. As a result, 
 only nVidia CUDA­ enabled video cards can be used to run them.
+
+
+What is UFO
+===========
+
+UFO is a general purpose image processing framework, optimized for heterogeneous
+compute systems and streams of data. Arbitrary data processing tasks are plugged
+together to form larger processing pipelines. These pipelines are then mapped to
+the hardware resources available at run-time, i.e. both multiple GPUs and CPUs.
+
+One specific use case that has been integrated into the TomoPy is fast
+reconstruction using the filtered backprojection and direct Fourier inversion
+methods although others for pre- and post-processing might be added in the
+future.

--- a/doc/source/ipynb/ufo.rst
+++ b/doc/source/ipynb/ufo.rst
@@ -14,13 +14,8 @@ reconstruction algorithms.
 Install
 `TomoPy <http://tomopy.readthedocs.io/en/latest/install.html>`__,
 `ufo-core <http://ufo-core.readthedocs.io/en/latest/>`__ and
-`ufo-filters <http://ufo-filters.readthedocs.io/en/master/>`__ and
-import TomoPy and the TomoPy wrapper for UFO:
-
-.. code:: python
-
-    import tomopy
-    import ufo.tomopy
+`ufo-filters <http://ufo-filters.readthedocs.io/en/master/>`__. Make sure to
+install the Python Numpy interfaces in the ``python`` subdirectory of ufo-core.
 
 `DXchange <http://dxchange.readthedocs.io>`__ is installed with tomopy
 to provide support for tomographic data loading. Various data format
@@ -108,7 +103,7 @@ than 1 will crash the reconstruction.
 
 .. code:: python
 
-    recon = tomopy.recon(proj, theta, center=center, algorithm=ufo.tomopy.fbp, ncore=1)
+    recon = tomopy.recon(proj, theta, center=center, algorithm=ufo_fbp, ncore=1)
 
 Mask each reconstructed slice with a circle.
 
@@ -120,7 +115,6 @@ Mask each reconstructed slice with a circle.
 
     plt.imshow(recon[0, :,:], cmap='Greys_r')
     plt.show()
-
 
 
 .. image:: ufo_files/ufo_26_0.png

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if C_INCLUDE_PATH is None:
 else:
     C_INCLUDE_PATH = C_INCLUDE_PATH.split(':')
 
-use_mkl = True
+use_mkl = os.environ.get('DISABLE_MKL') is None
 
 extra_comp_args = ['-std=c99']
 extra_link_args = ['-lm']

--- a/tomopy/recon/wrappers.py
+++ b/tomopy/recon/wrappers.py
@@ -58,6 +58,7 @@ from tomopy.util import mproc
 
 import numpy as np
 import copy
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ logger = logging.getLogger(__name__)
 __author__ = "Daniel M. Pelt"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
-__all__ = ['astra']
+__all__ = ['astra', 'ufo_fbp', 'ufo_dfi']
 
 default_options = {
     'astra': {
@@ -231,3 +232,115 @@ def astra_rec_cpu(tomo, center, recon, theta, vol_geom, niter, proj_type, opts):
         astra_mod.data2d.delete(vid)
     astra_mod.data2d.delete(sid)
     astra_mod.projector.delete(pid)
+
+
+def _process_data(input_task, output_task, sinograms, slices):
+    import ufo.numpy as unp
+    num_sinograms, num_projections, width = sinograms.shape
+
+    for i in range(num_sinograms):
+        if i == 0:
+            data = unp.empty_like(sinograms[i,:,:])
+        else:
+            data = input_task.get_input_buffer()
+
+        # Set host array pointer and use that as first input
+        data.set_host_array(sinograms[i,:,:].__array_interface__['data'][0], False)
+        input_task.release_input_buffer(data)
+
+        # Get last output and copy result back into NumPy buffer
+        data = output_task.get_output_buffer()
+        array = unp.asarray(data)
+        frm = int(array.shape[0] / 2 - width / 2)
+        to = int(array.shape[0] / 2 + width / 2)
+        slices[i,:,:] = array[frm:to, frm:to]
+        output_task.release_output_buffer(data)
+
+    input_task.stop()
+
+
+def ufo_fbp(tomo, center, recon, theta, **kwargs):
+    """
+    Reconstruct object using UFO's FBP pipeline
+    """
+    import gi
+    gi.require_version('Ufo', '0.0')
+    from gi.repository import Ufo
+
+    width = tomo.shape[2]
+    theta = theta[1] - theta[0]
+    center = center[0]
+
+    g = Ufo.TaskGraph()
+    pm = Ufo.PluginManager()
+    sched = Ufo.Scheduler()
+
+    input_task = Ufo.InputTask()
+    output_task = Ufo.OutputTask()
+    fft = pm.get_task('fft')
+    ifft = pm.get_task('ifft')
+    fltr = pm.get_task('filter')
+    backproject = pm.get_task('backproject')
+
+    ifft.set_properties(crop_width=width)
+    backproject.set_properties(axis_pos=center, angle_step=theta, angle_offset=np.pi)
+
+    g.connect_nodes(input_task, fft)
+    g.connect_nodes(fft, fltr)
+    g.connect_nodes(fltr, ifft)
+    g.connect_nodes(ifft, backproject)
+    g.connect_nodes(backproject, output_task)
+
+    args = (input_task, output_task, tomo, recon)
+    thread = threading.Thread(target=_process_data, args=args)
+    thread.start()
+    sched.run(g)
+    thread.join()
+
+    logger.info("UFO+FBP run time: {}s".format(sched.props.time))
+
+
+def ufo_dfi(tomo, center, recon, theta, **kwargs):
+    """
+    Reconstruct object using UFO's Direct Fourier pipeline
+    """
+    import gi
+    gi.require_version('Ufo', '0.0')
+    from gi.repository import Ufo
+
+    theta = theta[1] - theta[0]
+    center = center[0]
+
+    g = Ufo.TaskGraph()
+    pm = Ufo.PluginManager()
+    sched = Ufo.Scheduler()
+
+    input_task = Ufo.InputTask()
+    output_task = Ufo.OutputTask()
+    pad = pm.get_task('zeropad')
+    fft = pm.get_task('fft')
+    ifft = pm.get_task('ifft')
+    dfi = pm.get_task('dfi-sinc')
+    swap_forward = pm.get_task('swap-quadrants')
+    swap_backward = pm.get_task('swap-quadrants')
+
+    pad.set_properties(oversampling=1, center_of_rotation=center)
+    fft.set_properties(dimensions=1, auto_zeropadding=False)
+    ifft.set_properties(dimensions=2)
+    dfi.set_properties(angle_step=theta)
+
+    g.connect_nodes(input_task, pad)
+    g.connect_nodes(pad, fft)
+    g.connect_nodes(fft, dfi)
+    g.connect_nodes(dfi, swap_forward)
+    g.connect_nodes(swap_forward, ifft)
+    g.connect_nodes(ifft, swap_backward)
+    g.connect_nodes(swap_backward, output_task)
+
+    args = (input_task, output_task, tomo, recon)
+    thread = threading.Thread(target=_process_data, args=args)
+    thread.start()
+    sched.run(g)
+    thread.join()
+
+    logger.info("UFO+DFI run time: {}s".format(sched.props.time))


### PR DESCRIPTION
This change adds the wrapper which we currently distribute with UFO itself (and would remove if this gets merged). This allows reconstruction with the FBP and DFI algorithms, the iterative methods require a more intricate installation procedure, so for now this is kept outside. The wrapper has no build time dependency but of course requires a functioning UFO installation at run-time.

At the moment there is one caveat which is also documented: the user *must* call TomoPy's reconstruction routine with `ncore=1` otherwise our own scheduler gets confused. Ideally, the reconstruction plugins could either override this decision or at least give this information to the calling function.