### PR TITLE
Add CI for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,8 +65,8 @@ install:
   - set PYTHONHOME=%MINICONDA%
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge 
-  - conda config --add channels intel 
   - if %PYTHON_MAJOR% == 2 conda install --yes futures nose six numpy h5py scipy scikit-image pywavelets mkl-devel mkl_fft python-coveralls dxchange numexpr python # force update to python >=2.7.14 to avoid  bug with load library introduced in 2.7.13
+  - if %PYTHON_MAJOR% == 3 conda config --add channels intel 
   - if %PYTHON_MAJOR% == 3 conda install --yes nose six numpy h5py scipy scikit-image pywavelets mkl-devel mkl_fft python-coveralls dxchange numexpr
   # - conda install --yes --file appveyor\\requirements.txt
   # - conda install --yes dxchnge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,13 +34,13 @@ environment:
       PYTHON_ARCH: "64"
       MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
 
-    - MINICONDA: "C:\\Miniconda-x64"
-      C_INCLUDE_PATH: "C:\\Miniconda-x64\\Library\\include"
-      LD_LIBRARY_PTH: "C:\\Miniconda-x64\\Library\\lib"
-      PYTHON_MAJOR: "2"
-      PYTHON_VERSION: "2.7.13"
-      PYTHON_ARCH: "64"
-      MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
+#    - MINICONDA: "C:\\Miniconda-x64"
+#      C_INCLUDE_PATH: "C:\\Miniconda-x64\\Library\\include"
+#      LD_LIBRARY_PTH: "C:\\Miniconda-x64\\Library\\lib"
+#      PYTHON_MAJOR: "2"
+#      PYTHON_VERSION: "2.7.13"
+#      PYTHON_ARCH: "64"
+#      MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
 
 # Because we only have a single worker, we don't want to waste precious
 # appveyor CI time and make other PRs wait for repeated failures in a failing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,115 @@
+# AppVeyor.com is a Continuous Integration service to build and run tests under
+# Windows
+# https://ci.appveyor.com/project/tomopy/tomopy
+
+environment:
+  # global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script interpreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    # CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build_tools\\appveyor\\run_with_env.cmd"
+
+
+  matrix:
+
+    - MINICONDA: "C:\\Miniconda36-x64"
+      C_INCLUDE_PATH: "C:\\Miniconda36-x64\\Library\\include"
+      LD_LIBRARY_PTH: "C:\\Miniconda36-x64\\Library\\lib"
+      PYTHON_MAJOR: "3"
+      PYTHON_ARCH: "64"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
+
+    - MINICONDA: "C:\\Miniconda35-x64"
+      C_INCLUDE_PATH: "C:\\Miniconda35-x64\\Library\\include"
+      LD_LIBRARY_PTH: "C:\\Miniconda35-x64\\Library\\lib"
+      PYTHON_MAJOR: "3"
+      PYTHON_ARCH: "64"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
+
+    - MINICONDA: "C:\\Miniconda3-x64"
+      C_INCLUDE_PATH: "C:\\Miniconda3-x64\\Library\\include"
+      LD_LIBRARY_PTH: "C:\\Miniconda3-x64\\Library\\lib"
+      PYTHON_MAJOR: "3"
+      PYTHON_VERSION: "3.4.3"
+      PYTHON_ARCH: "64"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
+
+    - MINICONDA: "C:\\Miniconda-x64"
+      C_INCLUDE_PATH: "C:\\Miniconda-x64\\Library\\include"
+      LD_LIBRARY_PTH: "C:\\Miniconda-x64\\Library\\lib"
+      PYTHON_MAJOR: "2"
+      PYTHON_VERSION: "2.7.13"
+      PYTHON_ARCH: "64"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64"
+
+# Because we only have a single worker, we don't want to waste precious
+# appveyor CI time and make other PRs wait for repeated failures in a failing
+# PR. The following option cancels pending jobs in a given PR after the first
+# job failure in that specific PR.
+matrix:
+    fast_finish: true
+
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds.
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+
+  - "set PATH=%MINGW_PATH%\\bin;%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - set PYTHONHOME=%MINICONDA%
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels conda-forge 
+  - conda config --add channels intel 
+  - if %PYTHON_MAJOR% == 2 conda install --yes futures nose six numpy h5py scipy scikit-image pywavelets mkl-devel mkl_fft python-coveralls dxchange numexpr python # force update to python >=2.7.14 to avoid  bug with load library introduced in 2.7.13
+  - if %PYTHON_MAJOR% == 3 conda install --yes nose six numpy h5py scipy scikit-image pywavelets mkl-devel mkl_fft python-coveralls dxchange numexpr
+  # - conda install --yes --file appveyor\\requirements.txt
+  # - conda install --yes dxchnge
+  # - conda install --no-update-dependencies --yes -c intel mkl-devel
+  # - pip install -r appveyor\\requirements.txt
+
+  # Check that we have the expected version and architecture for Python
+  - conda update -q conda
+  - conda info -a
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - "pip --version"
+  - "cd c:\\projects\\tomopy"
+
+  # Install the build and runtime dependencies of the project.
+  - "python setup.py build_ext --compiler=mingw32 install" 
+
+  # Install the generated wheel package to test it
+  #- "pip install --pre --no-index --find-links dist/ tomopy"
+
+# Not a .NET project, we build scikit-learn in the install step instead
+build: false
+
+test_script:
+  # rename tomopy  to make sure we run the tests on the
+  # installed library.
+  - rename tomopy tomopy2
+  - nosetests test --with-coverage
+  - rename tomopy2 tomopy
+
+artifacts:
+#   # Archive the generated wheel package in the ci.appveyor.com build report.
+  - path: build
+
+# on_success:
+  # Upload the generated wheel package to Rackspace
+  # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
+  # disable the ssl checks.
+  # - "python -m wheelhouse_uploader upload --no-ssl-check --local-folder=dist sklearn-windows-wheels"
+
+
+# cache:
+  # Use the appveyor cache to avoid re-downloading large archives such
+  # the MKL numpy and scipy wheels mirrored on a rackspace cloud
+  # container, speed up the appveyor jobs and reduce bandwidth
+  # usage on our rackspace account.

--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -1,0 +1,7 @@
+six
+numpy
+scipy
+scikit-image
+pywavelets
+dxchange
+numexpr

--- a/src/gridrec.c
+++ b/src/gridrec.c
@@ -551,9 +551,13 @@ legendre(int n, const float *coefs, float x)
 static inline void* 
 malloc_64bytes_aligned(size_t sz)
 {
+    #ifdef __MINGW32__
+    return  __mingw_aligned_malloc(sz, 64);  
+    #else
     void *r = NULL;
     int err = posix_memalign(&r, 64, sz);
     return (err) ? NULL : r;
+    #endif
 }
 
 inline float*
@@ -619,8 +623,13 @@ malloc_matrix_c(size_t nr, size_t nc)
 inline void
 free_matrix_c(float _Complex** m)
 {
+
     free_vector_c(m[0]);
-    free(m);
+    #ifdef __MINGW32__
+        __mingw_aligned_free (m);
+    #else
+        free(m);
+    #endif
 }
 
 // No filter


### PR DESCRIPTION
I made some fixes so that it would compile on Windows with MinGW.

Tests were passing on 3.6 and 3.4.
3.5 was not compiling because conda couldn't find mkl-devel for 3.5, but I had since added the intel channel.

It compiled fine on 2.7, however tests were failing because it couldn't import LIBTOMOPY for some reason.

Tests are now failing because scipy.msic.imresize had been marked deprecated is now removed.
So I can't really progress any more until that is resolved.