### PR TITLE
BUG: Fix overflow assert statements

### DIFF
--- a/src/morph.c
+++ b/src/morph.c
@@ -72,7 +72,7 @@ downsample(
 
     binsize = pow(2, level);
     // Ensure that largest array is small enough to be indexable
-    assert((unsigned long long)dx*dy*dz < ULLONG_MAX);
+    assert(ULLONG_MAX/dx/dy/dz > 0);
     // Ensure safe comparison between unsigned (ijk) and signed (xyz)
     assert(dx >= 0 && dy >= 0 && dz >= 0);
 
@@ -149,7 +149,7 @@ upsample(
     
     binsize = pow(2, level);
     // Ensure that largest array is small enough to be indexable
-    assert((unsigned long long)binsize*dy*dz*dx < ULLONG_MAX);
+    assert(ULLONG_MAX/binsize/dy/dz/dx > 0);
     // Ensure safe comparison between unsigned (ijk) and signed (xyz)
     assert(dx >= 0 && dy >= 0 && dz >= 0);
 


### PR DESCRIPTION
Assert statements didn't successfully check for overflow because
the expression in the assert statement would overflow. Doing
a series of divisions and checking whether they are larger than
zero will not overflow. #304