### PR TITLE
Adding Binder links and demo notebook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Try Now
 =======
 
 You can try notebooks now using mybinder.org
+
 * GridRec: https://mybinder.org/v2/gh/kmader/tomopy/master?filepath=doc%2Fdemo%2Fgridrec.ipynb
 * Vector Heterostructure: https://mybinder.org/v2/gh/kmader/tomopy/master?filepath=doc%2Fdemo%2Fvector_heterostructure.ipynb
     

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ TomoPy
 .. image:: https://anaconda.org/dgursoy/tomopy/badges/downloads.svg
    :target: https://anaconda.org/dgursoy/tomopy
    :alt: Anaconda downloads
+   
+.. image:: https://mybinder.org/badge.svg 
+   :target: https://mybinder.org/v2/gh/kmader/tomopy/master
+   :alt: Use on Binder
 
 **TomoPy** is an open-source Python package for tomographic data 
 processing and image reconstruction.
@@ -38,6 +42,13 @@ Have `Conda <http://continuum.io/downloads>`_ installed first,
 then open a terminal or a command prompt window and run:
 
     conda install -c conda-forge tomopy
+    
+Try Now
+=======
+
+You can try notebooks now using mybinder.org
+* GridRec: https://mybinder.org/v2/gh/kmader/tomopy/master?filepath=doc%2Fdemo%2Fgridrec.ipynb
+* Vector Heterostructure: https://mybinder.org/v2/gh/kmader/tomopy/master?filepath=doc%2Fdemo%2Fvector_heterostructure.ipynb
     
 Contribute
 ==========

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,6 @@
+name: tomopy
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - tomopy

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,5 +2,7 @@ name: tomopy
 channels:
   - conda-forge
   - defaults
+  - astra-toolbox
 dependencies:
   - tomopy
+  - astra-toolbox


### PR DESCRIPTION
With binder you can make interactive demos of tomopy that run in the browser so people can try it without installing anything. I've added links for one or two notebooks, but more examples would be good.