### PR TITLE
add gcc-libs as a requirement to build and run on windows

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - mkl-devel
     - python
     - setuptools
+    - m2w64-gcc # [win]
 
   run:
     - python
@@ -28,6 +29,7 @@ requirements:
     - dxchange
     - numexpr
     - futures # [py2k]
+    - m2w64-gcc-libs # [win]
     
 test:
   # Python imports


### PR DESCRIPTION
As per #301, I tried adding the m2w64-gcc-libs and it's working.
I'm creating a pull request also to trigger travis to make sure that the changes to the meta.yml won't cause build issues on linux.

The only issue I encountered so far is that on the users's machine, I needed to edit the path environment variable to use tomopy properly.