### PR TITLE
API: Test whether keyword is needed instead of just adding it

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - python={{ python }}
     - pywavelets
     - numpy
-    - "scikit-image>=0.14"
+    - scikit-image
     - scipy
     - six
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 h5py
 scipy
 six
-"scikit-image>=0.14"
+scikit-image
 pywavelets
 mkl
 mkl_fft

--- a/tomopy/misc/phantom.py
+++ b/tomopy/misc/phantom.py
@@ -55,6 +55,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 import skimage
+import skimage.transform
 import tifffile
 import os.path
 import logging
@@ -79,6 +80,13 @@ __all__ = ['baboon',
 DATA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', 'data'))
 
+try:
+    resize_kwargs = {'anti_aliasing': False}
+    ignore = skimage.transform.resize(np.zeros(5), 2, **resize_kwargs)
+except TypeError:
+    logger.debug("Determined that the anti_aliasing keyword is not needed.")
+    resize_kwargs = dict()
+
 
 def baboon(size=512, dtype='float32'):
     """
@@ -101,7 +109,7 @@ def baboon(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     im = im.astype(dtype)
     return im
@@ -128,7 +136,7 @@ def barbara(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     return im.astype(dtype)
 
@@ -154,7 +162,7 @@ def cameraman(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     return im.astype(dtype)
 
@@ -180,7 +188,7 @@ def checkerboard(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     return im.astype(dtype)
 
@@ -206,7 +214,7 @@ def lena(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     return im.astype(dtype)
 
@@ -232,7 +240,7 @@ def peppers(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     return im.astype(dtype)
 
@@ -258,7 +266,7 @@ def shepp2d(size=512, dtype='float32'):
     im = tifffile.imread(fname)
     im = skimage.transform.resize(im, size, order=3,
                                   preserve_range=True, mode='constant',
-                                  anti_aliasing=False)
+                                  **resize_kwargs)
     im = np.expand_dims(im, 0)
     return im.astype(dtype)
 


### PR DESCRIPTION
I was testing some changes to `tomopy` on another branch last night, and I was getting `TypeError` because of the anti_aliasing keyword was unexpected, which was strange because I was using `scikit-image >= 0.14` According to the [scikit-image docs](http://scikit-image.org/docs/0.14.x/api/skimage.transform.html#resize) I shouldn't be having this problem, so I don't know what is going on. I recently added this keyword because of the warning that they were adding the keyword and the keyword is needed to keep the current behaviour.

This patch does what I should have done in the first place, which is explicitly check whether the keyword is needed. This way the version of `scikit-image` is unrestricted.