### PR TITLE
fixes the API documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -341,7 +341,9 @@ MOCK_MODULES = [
     'matplotlib', 'matplotlib.pylab', 'tifffile', 'EdfFile', 'netCDF4',
     'spefile', 'scipy.ndimage', 'pywt', 'scikit-image', 'skimage',
     'skimage.io', 'skimage.filter', 'skimage.morphology', 'skimage.feature',
-    'DM3lib', 'pyfftw', 'dxchange', 'numexpr', 'concurrent', 'concurrent.futures']
+    'skimage.transform', 'DM3lib', 'pyfftw', 'dxchange', 'numexpr', 'concurrent', 
+    'concurrent.futures',
+    ]
 
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()


### PR DESCRIPTION
[now](https://tomopy.readthedocs.io/en/latest/api/tomopy.misc.morph.html) and [after](https://tomopy-fdc.readthedocs.io/en/latest/api/tomopy.misc.morph.html) accepting this pull request