### PR TITLE
Warnings fixes + optimizations + floating-point consistency + clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,60 @@
+---
+# requires clang-tidy version 6.0+
+BasedOnStyle: Mozilla
+Language: Cpp
+AlignOperands: true
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignTrailingComments: true
+AlignAfterOpenBracket: Align
+AlignEscapedNewlinesLeft: false
+AllowShortFunctionsOnASingleLine: All
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: TopLevel
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeInheritanceComma: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:       true
+  AfterEnum:        true
+  AfterFunction:    true
+  AfterStruct:      true
+  AfterUnion:       true
+  AfterExternBlock: true
+  BeforeCatch:      false
+  BeforeElse:       false
+  IndentBraces:     false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+ColumnLimit: 80
+ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+PointerAlignment: Left
+SpaceAfterTemplateKeyword: true
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: false
+SpacesInAngles: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SortIncludes: true
+SortUsingDeclarations: true
+SpacesInContainerLiterals: true
+Standard: Cpp11
+TabWidth: 4
+IndentWidth: 4
+UseTab: Never
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+BreakBeforeBraces: Allman
+...

--- a/benchmarking/pyctest_tomopy_phantom.py
+++ b/benchmarking/pyctest_tomopy_phantom.py
@@ -152,7 +152,7 @@ def main(args):
         imgs = run(args.phantom, args.algorithm, args)
 
     # timing report to stdout
-    print('{}'.format(manager))
+    print('{}\n'.format(manager))
 
     timemory.options.output_dir = "{}/{}/{}".format(
         args.output_dir, args.phantom, algorithm)

--- a/benchmarking/pyctest_tomopy_rec.py
+++ b/benchmarking/pyctest_tomopy_rec.py
@@ -125,8 +125,8 @@ def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
         _kwargs["num_iter"] = nitr
 
     # Reconstruct object.
-    with timemory.util.auto_timer("[tomopy.recon(algorithm='{}')]".format(
-                                  algorithm)):
+    with timemory.util.auto_timer(
+        "[tomopy.recon(algorithm='{}')]".format(algorithm)):
         rec = tomopy.recon(proj, theta, **_kwargs)
 
     # Mask each reconstructed slice with a circle.
@@ -217,6 +217,43 @@ def rec_slice(h5fname, nsino, rot_center, args, blocked_views):
     return imgs
 
 
+def output_analysis(manager, args):
+    # timing report to stdout
+    print('{}\n'.format(manager))
+
+    fpath = args.output_dir
+    timemory.options.output_dir = fpath
+    timemory.options.set_report("run_tomopy.out")
+    timemory.options.set_serial("run_tomopy.json")
+    manager.report()
+    # provide timing plots
+    try:
+        print("\nPlotting TiMemory results...\n")
+        timemory.plotting.plot(files=[timemory.options.serial_filename],
+                               echo_dart=True,
+                               output_dir=timemory.options.output_dir)
+    except Exception as e:
+        print("Exception [timemory.plotting] - {}".format(e))
+    # provide results to dashboard
+    try:
+        print("\nEchoing dart tags...\n")
+        for i in range(0, len(imgs)):
+            img_type = args.format
+            img_name = os.path.basename(imgs[i]).replace(
+                ".{}".format(args.format), "")
+            img_path = imgs[i]
+            timemory.plotting.echo_dart_tag(img_name, img_path, img_type)
+    except Exception as e:
+        print("Exception [echo_dart_tag] - {}".format(e))
+    # provide ASCII results
+    try:
+        print("\nWriting notes...\n")
+        notes = manager.write_ctest_notes(directory=fpath)
+        print('"{}" wrote CTest notes file : {}'.format(__file__, notes))
+    except Exception as e:
+        print("Exception [write_ctest_notes] - {}".format(e))
+
+
 def main(arg):
 
     import multiprocessing as mp
@@ -297,48 +334,9 @@ def main(arg):
                             args.grainsize)
 
     else:
-        print("File Name does not exist: ", fname)
+        print("File name does not exist: ", fname)
 
-    # timing report to stdout
-    print('{}'.format(manager))
-
-    fpath = args.output_dir
-    timemory.options.output_dir = fpath
-    timemory.options.set_report("run_tomopy.out")
-    timemory.options.set_serial("run_tomopy.json")
-    manager.report()
-    # provide timing plots
-    try:
-        print("\nPlotting TiMemory results...\n")
-        timemory.plotting.plot(files=[timemory.options.serial_filename],
-                               echo_dart=True,
-                               output_dir=timemory.options.output_dir)
-    except Exception as e:
-        print("Exception [timemory.plotting] - {}".format(e))
-    # provide results to dashboard
-    try:
-        print("\nEchoing dart tags...\n")
-        for i in range(0, len(imgs)):
-            print("imgs[{}] = {}".format(i, imgs[i]))
-            img_type = args.format
-            print("Image name: {}".format(img_type))
-            img_name = os.path.basename(imgs[i]).replace(
-                ".{}".format(args.format), "")
-            print("Image name: {}".format(img_name))
-            img_path = imgs[i]
-            print("name: {}, type: {}, path: {}".format(img_name, img_type,
-                                                        img_path))
-            timemory.plotting.echo_dart_tag(img_name, img_path, img_type)
-    except Exception as e:
-        print("Exception [echo_dart_tag] - {}".format(e))
-    # provide ASCII results
-    try:
-        print("\nWriting notes...\n")
-        notes = manager.write_ctest_notes(directory=fpath)
-        print('"{}" wrote CTest notes file : {}'.format(__file__, notes))
-    except Exception as e:
-        print("Exception [write_ctest_notes] - {}".format(e))
-
+    output_analysis(manager, args)
 
 if __name__ == "__main__":
     ret = 0

--- a/build.py
+++ b/build.py
@@ -53,14 +53,17 @@ def build_libtomopy():
     with open('Mk.config', 'w') as fout:
         fout.write(conf)
     cmd = ['make', '-j4', '-f', get_makefile()]
-    if INSTALL_PREFIX is not None:
+    _PREFIX_PATH = os.path.abspath(INSTALL_PREFIX)
+    _BINARY_PATH = os.path.abspath(os.path.join(os.getcwd(), ".."))
+    if INSTALL_PREFIX is not None and _PREFIX_PATH != _BINARY_PATH:
         cmd.append('install')
     subprocess.check_call(tuple(cmd))
 
 
 def clean_libtomopy():
     """Clean libtomopy shared library for the current system."""
-    subprocess.check_call(('make', 'clean', '-f', get_makefile()))
+    if os.path.exists(os.path.join(os.getcwd(), "config", "Mk.config")):
+        subprocess.check_call(('make', 'clean', '-f', get_makefile()))
 
 
 class Config:
@@ -79,6 +82,11 @@ class Config:
                 self.conda_compat = '-B %s' % compat
         if 'GCC' in os.environ:
             self.compilerdir = os.environ["GCC"]
+        # CC environment variable is standard, not GCC
+        if 'CC' in os.environ:
+            self.compilerdir = os.environ["CC"]
+            print("### Compiler set via CC environment variable: '{}'".format(
+                self.compilerdir))
         # includes
         top_include = pjoin(PREFIX, 'include')
         includes = [top_include]

--- a/include/gridrec.h
+++ b/include/gridrec.h
@@ -48,23 +48,16 @@
 #include <stdlib.h>
 
 #ifdef WIN32
-#define DLL __declspec(dllexport)
+#    define DLL __declspec(dllexport)
 #else
-#define DLL
+#    define DLL
 #endif
 #define ANSI
 
-
 void DLL
-gridrec(
-    const float *data,
-    int dy, int dt, int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx, int ngridy,
-    const char fname[16],
-    const float *filter_par);
+     gridrec(const float* data, int dy, int dt, int dx, const float* center,
+             const float* theta, float* recon, int ngridx, int ngridy,
+             const char fname[16], const float* filter_par);
 
 float*
 malloc_vector_f(size_t n);
@@ -84,8 +77,7 @@ malloc_matrix_c(size_t nr, size_t nc);
 void
 free_matrix_c(float _Complex** m);
 
-float
-(*get_filter(const char *name))(float, int, int, int, const float*);
+float (*get_filter(const char* name))(float, int, int, int, const float*);
 
 float
 filter_none(float, int, int, int, const float*);
@@ -115,26 +107,22 @@ float
 filter_custom2d(float, int, int, int, const float*);
 
 unsigned char
-filter_is_2d(const char *name);
+filter_is_2d(const char* name);
 
 void
-set_filter_tables(
-    int dt, int pd,
-    float fac,
-    float(* const pf)(float, int, int, int, const float*), const float *filter_par,
-    float _Complex *A, unsigned char is2d);
+set_filter_tables(int dt, int pd, float fac,
+                  float (*const pf)(float, int, int, int, const float*),
+                  const float* filter_par, float _Complex* A,
+                  unsigned char is2d);
 
 void
-set_trig_tables(
-    int dt, const float *theta,
-    float **SP, float **CP);
+set_trig_tables(int dt, const float* theta, float** SP, float** CP);
 
 void
-set_pswf_tables(
-    float C, int nt, float lmbda, const float *coefs,
-    int ltbl, int linv, float* wtbl, float* winv);
+set_pswf_tables(float C, int nt, float lmbda, const float* coefs, int ltbl,
+                int linv, float* wtbl, float* winv);
 
 float
-legendre(int n, const float *coefs, float x);
+legendre(int n, const float* coefs, float x);
 
 #endif

--- a/include/morph.h
+++ b/include/morph.h
@@ -1,44 +1,44 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 // Module for data morphing.
@@ -46,34 +46,25 @@
 #ifndef _morph_h
 #define _morph_h
 
-#include <stdio.h>
 #include <math.h>
-
+#include <stdio.h>
 
 #ifdef WIN32
-#define DLL __declspec(dllexport)
+#    define DLL __declspec(dllexport)
 #else
-#define DLL 
+#    define DLL
 #endif
 
+DLL void
+sample(int mode, const float* data, int dx, int dy, int dz, int axis, int npad,
+       float* out);
 
-DLL void 
-sample(
-    int mode, 
-    const float* data,
-    int dx, int dy, int dz, 
-    int axis, int npad, float* out);
+DLL void
+downsample(const float* data, int dx, int dy, int dz, int level, int axis,
+           float* out);
 
-DLL void 
-downsample(
-    const float* data,
-    int dx, int dy, int dz,
-    int level, int axis, float* out);
-
-DLL void 
-upsample(
-    const float* data,
-    int dx, int dy, int dz,
-    int level, int axis, float* out);
+DLL void
+upsample(const float* data, int dx, int dy, int dz, int level, int axis,
+         float* out);
 
 #endif

--- a/include/prep.h
+++ b/include/prep.h
@@ -1,44 +1,44 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 // Module for data value corrections.
@@ -48,18 +48,13 @@
 
 #include <stdio.h>
 
-
 #ifdef WIN32
-#define DLL __declspec(dllexport)
+#    define DLL __declspec(dllexport)
 #else
-#define DLL 
+#    define DLL
 #endif
 
-
-DLL void 
-normalize_bg(
-    float* data, 
-    int dx, int dy, int dz,
-    int nair);
+DLL void
+normalize_bg(float* data, int dx, int dy, int dz, int nair);
 
 #endif

--- a/include/remove_ring.h
+++ b/include/remove_ring.h
@@ -1,4 +1,4 @@
- // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
+// Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
 // Copyright 2015. UChicago Argonne, LLC. This software was produced
 // under U.S. Government contract DE-AC02-06CH11357 for Argonne National
@@ -41,104 +41,83 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-//Module for ring removal in reconstructed domain
+// Module for ring removal in reconstructed domain
 
 #ifndef _remove_ring_h
 #define _remove_ring_h
 
 #include <math.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef WIN32
-#define DLL __declspec(dllexport)
+#    define DLL __declspec(dllexport)
 #else
-#define DLL
+#    define DLL
 #endif
 
 #define PI 3.14159265359
 
 void DLL
-remove_ring(
-	    float* data,
-	    float center_x,
-        float center_y,
-	    int dx,
-	    int dy,
-	    int dz,
-        float thresh_max,
-	    float thresh_min,
-	    float threshold,
-	    int angular_min,
-	    int ring_width,
-			int int_mode,
-	    int istart,
-	    int iend);
+     remove_ring(float* data, float center_x, float center_y, int dx, int dy, int dz,
+                 float thresh_max, float thresh_min, float threshold,
+                 int angular_min, int ring_width, int int_mode, int istart,
+                 int iend);
 
 int
-min_distance_to_edge(
-	float center_x, float center_y,
-	int width, int height);
+min_distance_to_edge(float center_x, float center_y, int width, int height);
 
 int
 iroundf(float x);
 
 float**
-polar_transform(
-	float** image, float center_x, float center_y,
-	int width, int height, int* p_pol_width,
-	int* p_pol_height, float thresh_max, float thresh_min,
-	int r_scale, int ang_scale, int overhang);
+polar_transform(float** image, float center_x, float center_y, int width,
+                int height, int* p_pol_width, int* p_pol_height,
+                float thresh_max, float thresh_min, int r_scale, int ang_scale,
+                int overhang);
 
 float**
-inverse_polar_transform(
-	float** polar_image, float center_x, float center_y, int pol_width,
-	int  pol_height, int width, int height, int r_scale, int over_hang);
+inverse_polar_transform(float** polar_image, float center_x, float center_y,
+                        int pol_width, int pol_height, int width, int height,
+                        int r_scale, int over_hang);
 
 void
-swap_float(
-	float* arr, int index1, int index2);
+swap_float(float* arr, int index1, int index2);
 
 void
-swap_integer(
-	int* arr, int index1, int index2);
+swap_integer(int* arr, int index1, int index2);
 
 int
-partition(
-	float* median_array, int left, int right, int pivot_index);
+partition(float* median_array, int left, int right, int pivot_index);
 
 int
-partition_2_arrays(
-	float* median_array, int* position_array, int left, int right,
-	int pivot_index);
+partition_2_arrays(float* median_array, int* position_array, int left,
+                   int right, int pivot_index);
 
 void
-quick_sort(
-	float* median_array, int left, int right);
+quick_sort(float* median_array, int left, int right);
 
 void
-quick_sort_2_arrays(
-	float* median_array, int* position_array, int left, int right);
+quick_sort_2_arrays(float* median_array, int* position_array, int left,
+                    int right);
 
 void
-bubble_2_arrays(
-	float* median_array, int* position_array, int index, int length);
+bubble_2_arrays(float* median_array, int* position_array, int index,
+                int length);
 
 void
-median_filter_fast_1D(
-	float *** filtered_image, float*** image, int start_row,
-	int start_col, int end_row, int end_col, char axis,
-	int kernel_rad,	int filter_width, int width, int height);
+median_filter_fast_1D(float*** filtered_image, float*** image, int start_row,
+                      int start_col, int end_row, int end_col, char axis,
+                      int kernel_rad, int filter_width, int width, int height);
 
 void
-mean_filter_fast_1D(
-	float*** filtered_image, float*** image,
- 	int start_row, int start_col, int end_row, int end_col,
-	int int_mode, int kernel_rad, int width, int height);
+mean_filter_fast_1D(float*** filtered_image, float*** image, int start_row,
+                    int start_col, int end_row, int end_col, int int_mode,
+                    int kernel_rad, int width, int height);
 
 void
-ring_filter(
-	float*** polar_image, int pol_height, int pol_width,
-	float threshold, int m_rad, int m_azi, int ring_width, int int_mode);
+ring_filter(float*** polar_image, int pol_height, int pol_width,
+            float threshold, int m_rad, int m_azi, int ring_width,
+            int int_mode);
 
 #endif

--- a/include/stripe.h
+++ b/include/stripe.h
@@ -1,44 +1,44 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 // Module for stripe removal.
@@ -49,20 +49,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 #ifdef WIN32
-#define DLL __declspec(dllexport)
+#    define DLL __declspec(dllexport)
 #else
-#define DLL 
+#    define DLL
 #endif
 
-
-DLL void 
-remove_stripe_sf(
-    float* data, 
-    int dx, int dy, int dz,
-    int size,
-    int istart,
-    int iend);
+DLL void
+remove_stripe_sf(float* data, int dx, int dy, int dz, int size, int istart,
+                 int iend);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,427 +1,210 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef _utils_h
 #define _utils_h
 
-#include <stdio.h>
-#include <stdlib.h>
+#include "string.h"
+#include <assert.h>
 #include <math.h>
 #include <stdbool.h>
-#include <assert.h>
-#include "string.h"
-
+#include <stdio.h>
+#include <stdlib.h>
 
 #define _USE_MATH_DEFINES
 #ifndef M_PI
-#define M_PI 3.14159265358979323846264338327
+#    define M_PI 3.14159265358979323846264338327
 #endif
 
 #ifdef WIN32
-#define DLL __declspec(dllexport)
+#    define DLL __declspec(dllexport)
 #else
-#define DLL 
+#    define DLL
 #endif
 
 // Data simulation
 
 void DLL
-project(
-    const float *obj,
-    int oy,
-    int ox, 
-    int oz,
-    float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta);
+     project(const float* obj, int oy, int ox, int oz, float* data, int dy, int dt,
+             int dx, const float* center, const float* theta);
 
 void DLL
-project2(
-    const float *objx,
-    const float *objy,
-    int oy,
-    int ox, 
-    int oz,
-    float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta);
+     project2(const float* objx, const float* objy, int oy, int ox, int oz,
+              float* data, int dy, int dt, int dx, const float* center,
+              const float* theta);
 
 void DLL
-project3(
-    const float *objx,
-    const float *objy,
-    const float *objz,
-    int oy,
-    int ox, 
-    int oz,
-    float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    int axis);
-
+     project3(const float* objx, const float* objy, const float* objz, int oy,
+              int ox, int oz, float* data, int dy, int dt, int dx,
+              const float* center, const float* theta, int axis);
 
 // Reconstruction algorithms
 
 void DLL
-art(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter);
+     art(const float* data, int dy, int dt, int dx, const float* center,
+         const float* theta, float* recon, int ngridx, int ngridy, int num_iter);
 
 void DLL
-bart(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    int num_block,
-    const float *ind_block); //TODO: I think this should be int *
+     bart(const float* data, int dy, int dt, int dx, const float* center,
+          const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+          int          num_block,
+          const float* ind_block);  // TODO: I think this should be int *
 
 void DLL
-fbp(
-    const float *data,
-    int dy,
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    const char name[16],
-    const float *filter_par);
+     fbp(const float* data, int dy, int dt, int dx, const float* center,
+         const float* theta, float* recon, int ngridx, int ngridy,
+         const char name[16], const float* filter_par);
 
 void DLL
-grad(
-    const float *data,
-    int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy,
-    int num_iter,
-    const float *reg_pars);
+     grad(const float* data, int dy, int dt, int dx, const float* center,
+          const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+          const float* reg_pars);
 
 void DLL
-mlem(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter);
+     mlem(const float* data, int dy, int dt, int dx, const float* center,
+          const float* theta, float* recon, int ngridx, int ngridy, int num_iter);
 
 void DLL
-osem(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    int num_block,
-    const float *ind_block);
+     osem(const float* data, int dy, int dt, int dx, const float* center,
+          const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+          int num_block, const float* ind_block);
 
 void DLL
-ospml_hybrid(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    const float *reg_pars,
-    int num_block,
-    const float *ind_block);
+     ospml_hybrid(const float* data, int dy, int dt, int dx, const float* center,
+                  const float* theta, float* recon, int ngridx, int ngridy,
+                  int num_iter, const float* reg_pars, int num_block,
+                  const float* ind_block);
 
 void DLL
-ospml_quad(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    const float *reg_pars,
-    int num_block,
-    const float *ind_block);
+     ospml_quad(const float* data, int dy, int dt, int dx, const float* center,
+                const float* theta, float* recon, int ngridx, int ngridy,
+                int num_iter, const float* reg_pars, int num_block,
+                const float* ind_block);
 
 void DLL
-pml_hybrid(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    const float *reg_pars);
+     pml_hybrid(const float* data, int dy, int dt, int dx, const float* center,
+                const float* theta, float* recon, int ngridx, int ngridy,
+                int num_iter, const float* reg_pars);
 
 void DLL
-pml_quad(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    const float *reg_pars);
+     pml_quad(const float* data, int dy, int dt, int dx, const float* center,
+              const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+              const float* reg_pars);
 
 void DLL
-sirt(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon,
-    int ngridx,
-    int ngridy,
-    int num_iter);
+     sirt(const float* data, int dy, int dt, int dx, const float* center,
+          const float* theta, float* recon, int ngridx, int ngridy, int num_iter);
 
 void DLL
-tv(
-    const float *data,
-    int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy,
-    int num_iter, const float *reg_pars);
+     tv(const float* data, int dy, int dt, int dx, const float* center,
+        const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+        const float* reg_pars);
 
 void DLL
-vector(
-    const float *data,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center,
-    const float *theta,
-    float *recon1,
-    float *recon2,
-    int ngridx,
-    int ngridy,
-    int num_iter);
+     vector(const float* data, int dy, int dt, int dx, const float* center,
+            const float* theta, float* recon1, float* recon2, int ngridx, int ngridy,
+            int num_iter);
 
 void DLL
-vector2(
-    const float *data1,
-    const float *data2,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center1,
-    const float *center2,
-    const float *theta1,
-    const float *theta2,
-    float *recon1,
-    float *recon2,
-    float *recon3,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    int axis1,
-    int axis2);
+     vector2(const float* data1, const float* data2, int dy, int dt, int dx,
+             const float* center1, const float* center2, const float* theta1,
+             const float* theta2, float* recon1, float* recon2, float* recon3,
+             int ngridx, int ngridy, int num_iter, int axis1, int axis2);
 
 void DLL
-vector3(
-    const float *data1,
-    const float *data2,
-    const float *data3,
-    int dy, 
-    int dt,
-    int dx,
-    const float *center1,
-    const float *center2,
-    const float *center3,
-    const float *theta1,
-    const float *theta2,
-    const float *theta3,
-    float *recon1,
-    float *recon2,
-    float *recon3,
-    int ngridx,
-    int ngridy,
-    int num_iter,
-    int axis1,
-    int axis2,
-    int axis3);
-
+     vector3(const float* data1, const float* data2, const float* data3, int dy,
+             int dt, int dx, const float* center1, const float* center2,
+             const float* center3, const float* theta1, const float* theta2,
+             const float* theta3, float* recon1, float* recon2, float* recon3,
+             int ngridx, int ngridy, int num_iter, int axis1, int axis2, int axis3);
 
 // Utility functions for data simultation
 
 void DLL
-preprocessing(
-    int ngridx, int ngridy, 
-    int dz, 
-    float center, float *mov, 
-    float *gridx, float *gridy);
+     preprocessing(int ngridx, int ngridy, int dz, float center, float* mov,
+                   float* gridx, float* gridy);
 
 int DLL
-calc_quadrant(
-    float theta_p); 
+    calc_quadrant(float theta_p);
 
 void DLL
-calc_coords(
-    int ngridx, int ngridy,
-    float xi, float yi,
-    float sin_p, float cos_p,
-    const float *gridx, const float *gridy,
-    float *coordx, float *coordy);
+     calc_coords(int ngridx, int ngridy, float xi, float yi, float sin_p,
+                 float cos_p, const float* gridx, const float* gridy, float* coordx,
+                 float* coordy);
 
 void DLL
-trim_coords(
-    int ngridx, int ngridy,
-    const float *coordx, const float *coordy,
-    const float *gridx, const float *gridy,
-    int *asize, float *ax, float *ay, 
-    int *bsize, float *bx, float *by);
+     trim_coords(int ngridx, int ngridy, const float* coordx, const float* coordy,
+                 const float* gridx, const float* gridy, int* asize, float* ax,
+                 float* ay, int* bsize, float* bx, float* by);
 
 void DLL
-sort_intersections(
-    int ind_condition, 
-    int asize, const float *ax, const float *ay,
-    int bsize, const float *bx, const float *by,
-    int *csize, 
-    float *coorx, float *coory);
+     sort_intersections(int ind_condition, int asize, const float* ax,
+                        const float* ay, int bsize, const float* bx, const float* by,
+                        int* csize, float* coorx, float* coory);
 
 void DLL
-calc_dist(
-    int ngridx, int ngridy, 
-    int csize, 
-    const float *coorx, const float *coory,
-    int *indi, 
-    float *dist);
+     calc_dist(int ngridx, int ngridy, int csize, const float* coorx,
+               const float* coory, int* indi, float* dist);
 
 void DLL
-calc_dist2(
-    int ngridx, int ngridy, 
-    int csize, 
-    const float *coorx, const float *coory,
-    int *indx, int *indy,
-    float *dist);
+     calc_dist2(int ngridx, int ngridy, int csize, const float* coorx,
+                const float* coory, int* indx, int* indy, float* dist);
 
 void DLL
-calc_simdata(
-    int s, int p, int d,
-    int ngridx, int ngridy, 
-    int dt, int dx,
-    int csize, 
-    const int *indi,
-    const float *dist,
-    const float *model,
-    float *simdata);
+     calc_simdata(int s, int p, int d, int ngridx, int ngridy, int dt, int dx,
+                  int csize, const int* indi, const float* dist, const float* model,
+                  float* simdata);
 
 void DLL
-calc_simdata2(
-    int s, int p, int d,
-    int ngridx, int ngridy, 
-    int dt, int dx,
-    int csize, 
-    const int *indx,
-    const int *indy,
-    const float *dist,
-    float vx, float vy,
-    const float *modelx,
-    const float *modely,
-    float *simdata);
+     calc_simdata2(int s, int p, int d, int ngridx, int ngridy, int dt, int dx,
+                   int csize, const int* indx, const int* indy, const float* dist,
+                   float vx, float vy, const float* modelx, const float* modely,
+                   float* simdata);
 
 void DLL
-calc_simdata3(
-    int s, int p, int d,
-    int ngridx, int ngridy, 
-    int dt, int dx,
-    int csize, 
-    const int *indx,
-    const int *indy,
-    const float *dist,
-    float vx, float vy,
-    const float *modelx,
-    const float *modely,
-    const float *modelz,
-    int axis,
-    float *simdata);
+     calc_simdata3(int s, int p, int d, int ngridx, int ngridy, int dt, int dx,
+                   int csize, const int* indx, const int* indy, const float* dist,
+                   float vx, float vy, const float* modelx, const float* modely,
+                   const float* modelz, int axis, float* simdata);
 
 #endif

--- a/meta.yaml
+++ b/meta.yaml
@@ -9,7 +9,6 @@ source:
 build:
   number: 1
   script:
-    - "{{ PYTHON }} build.py"
     - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:

--- a/pyctest_tomopy.py
+++ b/pyctest_tomopy.py
@@ -22,8 +22,7 @@ import pyctest.helpers as helpers
 
 def cleanup(path=None, exclude=[]):
     files = [ "coverage.xml", "pyctest_tomopy_rec.py",
-               "pyctest_tomopy_phantom.py", "pyctest_tomopy_utils.py",
-               "config/Mk.config" ]
+              "pyctest_tomopy_phantom.py", "pyctest_tomopy_utils.py"]
 
     sp.call((sys.executable, os.path.join(os.getcwd(), "setup.py"), "clean"))
     helpers.Cleanup(path, extra=files, exclude=exclude)

--- a/src/art.c
+++ b/src/art.c
@@ -1,157 +1,146 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-art(
-    const float *data, int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter)
+void
+art(const float* data, int dy, int dt, int dx, const float* center,
+    const float* theta, float* recon, int ngridx, int ngridy, int num_iter)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
-    float* simdata = (float *)malloc((dy*dt*dx)*sizeof(float));
+    float* gridx   = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy   = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax      = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay      = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx      = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by      = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi    = (int*) malloc((ngridx + ngridy) * sizeof(int));
+    float* simdata = (float*) malloc((dy * dt * dx) * sizeof(float));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-        indi != NULL && simdata != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL && simdata != NULL);
 
-    int s, p, d, i, n;
-    int quadrant;
+    int   s, p, d, i, n;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float mov, xi, yi;
-    int asize, bsize, csize;
+    int   asize, bsize, csize;
     float upd;
-    int ind_data, ind_recon;
+    int   ind_data, ind_recon;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
         // initialize simdata to zero
-        memset(simdata, 0, dy*dt*dx*sizeof(float));
+        memset(simdata, 0, dy * dt * dx * sizeof(float));
 
-        preprocessing(ngridx, ngridy, dx, center[0], 
-            &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+        preprocessing(ngridx, ngridy, dx, center[0], &mov, gridx,
+                      gridy);  // Outputs: mov, gridx, gridy
 
-        // For each projection angle 
-        for (p=0; p<dt; p++) 
+        // For each projection angle
+        for(p = 0; p < dt; p++)
         {
-            // Calculate the sin and cos values 
+            // Calculate the sin and cos values
             // of the projection angle and find
             // at which quadrant on the cartesian grid.
-            theta_p = fmod(theta[p], 2*M_PI);
+            theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
             quadrant = calc_quadrant(theta_p);
-            sin_p = sinf(theta_p);
-            cos_p = cosf(theta_p);
+            sin_p    = sinf(theta_p);
+            cos_p    = cosf(theta_p);
 
-            // For each detector pixel 
-            for (d=0; d<dx; d++) 
+            // For each detector pixel
+            for(d = 0; d < dx; d++)
             {
                 // Calculate coordinates
-                xi = -ngridx-ngridy;
-                yi = (1-dx)/2.0+d+mov;
-                calc_coords(
-                    ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                    coordx, coordy);
+                xi = -ngridx - ngridy;
+                yi = 0.5f * (1 - dx) + d + mov;
+                calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
+                            coordx, coordy);
 
                 // Merge the (coordx, gridy) and (gridx, coordy)
-                trim_coords(
-                    ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                    &asize, ax, ay, &bsize, bx, by);
+                trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                            &asize, ax, ay, &bsize, bx, by);
 
                 // Sort the array of intersection points (ax, ay) and
-                // (bx, by). The new sorted intersection points are 
-                // stored in (coorx, coory). Total number of points 
+                // (bx, by). The new sorted intersection points are
+                // stored in (coorx, coory). Total number of points
                 // are csize.
-                sort_intersections(
-                    quadrant, asize, ax, ay, bsize, bx, by, 
-                    &csize, coorx, coory);
+                sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                   &csize, coorx, coory);
 
-                // Calculate the distances (dist) between the 
-                // intersection points (coorx, coory). Find the 
+                // Calculate the distances (dist) between the
+                // intersection points (coorx, coory). Find the
                 // indices of the pixels on the reconstruction grid.
-                calc_dist(
-                    ngridx, ngridy, csize, coorx, coory, 
-                    indi, dist);
-
+                calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
                 // Calculate dist*dist
-                float sum_dist2 = 0.0;
-                for (n=0; n<csize-1; n++) 
+                float sum_dist2 = 0.0f;
+                for(n = 0; n < csize - 1; n++)
                 {
-                    sum_dist2 += dist[n]*dist[n];
+                    sum_dist2 += dist[n] * dist[n];
                 }
 
-                if (sum_dist2 != 0.0)
+                if(sum_dist2 != 0.0f)
                 {
                     // For each slice
-                    for (s=0; s<dy; s++)
+                    for(s = 0; s < dy; s++)
                     {
-
                         // Calculate simdata
-                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
+                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize,
+                                     indi, dist, recon,
+                                     simdata);  // Output: simdata
 
                         // Update
-                        ind_data = d+p*dx+s*dt*dx;
-                        ind_recon = s*ngridx*ngridy;
-                        upd = (data[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data  = d + p * dx + s * dt * dx;
+                        ind_recon = s * ngridx * ngridy;
+                        upd = (data[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                        	recon[indi[n]+ind_recon] += upd*dist[n];
+                            recon[indi[n] + ind_recon] += upd * dist[n];
                         }
                     }
                 }

--- a/src/bart.c
+++ b/src/bart.c
@@ -1,188 +1,183 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-bart(
-    const float *data, int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter, 
-    int num_block, const float *ind_block) //TODO: I think ind_block should be int*
+void
+bart(const float* data, int dy, int dt, int dx, const float* center,
+     const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+     int          num_block,
+     const float* ind_block)  // TODO: I think ind_block should be int*
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
-    float *simdata = (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *sum_dist = (float *)malloc((ngridx*ngridy)*sizeof(float));
-    float *update = (float *)malloc((ngridx*ngridy)*sizeof(float));
+    float* gridx    = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy    = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx   = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy   = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi     = (int*) malloc((ngridx + ngridy) * sizeof(int));
+    float* simdata  = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* sum_dist = (float*) malloc((ngridx * ngridy) * sizeof(float));
+    float* update   = (float*) malloc((ngridx * ngridy) * sizeof(float));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-        indi != NULL && simdata != NULL && sum_dist != NULL &&
-        update != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL && simdata != NULL &&
+           sum_dist != NULL && update != NULL);
 
-    int s, q, p, d, i, n, os;
-    int quadrant;
+    int   s, q, p, d, i, n, os;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float mov, xi, yi;
-    int asize, bsize, csize;
+    int   asize, bsize, csize;
     float upd;
-    int ind_data, ind_recon;
+    int   ind_data, ind_recon;
     float sum_dist2;
-    int subset_ind1, subset_ind2;
+    int   subset_ind1, subset_ind2;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
         // initialize simdata to zero
-        memset(simdata, 0, dy*dt*dx*sizeof(float));
+        memset(simdata, 0, dy * dt * dx * sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            subset_ind1 = dt/num_block;
+            subset_ind1 = dt / num_block;
             subset_ind2 = subset_ind1;
 
             // For each ordered-subset num_subset
-            for (os=0; os<num_block+1; os++) 
+            for(os = 0; os < num_block + 1; os++)
             {
-                if (os == num_block) 
+                if(os == num_block)
                 {
-                    subset_ind2 = dt%num_block;
+                    subset_ind2 = dt % num_block;
                 }
 
                 // initialize sum_dist and update to zero
-                memset(sum_dist, 0, (ngridx*ngridy)*sizeof(float));
-                memset(update, 0, (ngridx*ngridy)*sizeof(float));
-                
-                // For each projection angle 
-                for (q=0; q<subset_ind2; q++) 
-                {
-                    p = ind_block[q+os*subset_ind1];
+                memset(sum_dist, 0, (ngridx * ngridy) * sizeof(float));
+                memset(update, 0, (ngridx * ngridy) * sizeof(float));
 
-                    // Calculate the sin and cos values 
+                // For each projection angle
+                for(q = 0; q < subset_ind2; q++)
+                {
+                    p = ind_block[q + os * subset_ind1];
+
+                    // Calculate the sin and cos values
                     // of the projection angle and find
                     // at which quadrant on the cartesian grid.
-                    theta_p = fmod(theta[p], 2*M_PI);
+                    theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                     quadrant = calc_quadrant(theta_p);
-                    sin_p = sinf(theta_p);
-                    cos_p = cosf(theta_p);
+                    sin_p    = sinf(theta_p);
+                    cos_p    = cosf(theta_p);
 
-                    // For each detector pixel 
-                    for (d=0; d<dx; d++)
+                    // For each detector pixel
+                    for(d = 0; d < dx; d++)
                     {
                         // Calculate coordinates
-                        xi = -ngridx-ngridy;
-                        yi = (1-dx)/2.0+d+mov;
-                        calc_coords(
-                            ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                            coordx, coordy);
+                        xi = -ngridx - ngridy;
+                        yi = 0.5f * (1 - dx) + d + mov;
+                        calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                    gridy, coordx, coordy);
 
                         // Merge the (coordx, gridy) and (gridx, coordy)
-                        trim_coords(
-                            ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                            &asize, ax, ay, &bsize, bx, by);
+                        trim_coords(ngridx, ngridy, coordx, coordy, gridx,
+                                    gridy, &asize, ax, ay, &bsize, bx, by);
 
                         // Sort the array of intersection points (ax, ay) and
-                        // (bx, by). The new sorted intersection points are 
-                        // stored in (coorx, coory). Total number of points 
+                        // (bx, by). The new sorted intersection points are
+                        // stored in (coorx, coory). Total number of points
                         // are csize.
-                        sort_intersections(
-                            quadrant, asize, ax, ay, bsize, bx, by, 
-                            &csize, coorx, coory);
+                        sort_intersections(quadrant, asize, ax, ay, bsize, bx,
+                                           by, &csize, coorx, coory);
 
-                        // Calculate the distances (dist) between the 
-                        // intersection points (coorx, coory). Find the 
+                        // Calculate the distances (dist) between the
+                        // intersection points (coorx, coory). Find the
                         // indices of the pixels on the reconstruction grid.
-                        calc_dist(
-                            ngridx, ngridy, csize, coorx, coory, 
-                            indi, dist);
+                        calc_dist(ngridx, ngridy, csize, coorx, coory, indi,
+                                  dist);
 
-                        // Calculate simdata 
-                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
-
+                        // Calculate simdata
+                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize,
+                                     indi, dist, recon,
+                                     simdata);  // Output: simdata
 
                         // Calculate dist*dist
-                        sum_dist2 = 0.0;
-                        for (n=0; n<csize-1; n++) 
+                        sum_dist2 = 0.0f;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            sum_dist2 += dist[n]*dist[n];
+                            sum_dist2 += dist[n] * dist[n];
                             sum_dist[indi[n]] += dist[n];
                         }
 
                         // Update
-                        if (sum_dist2 != 0.0) 
+                        if(sum_dist2 != 0.0f)
                         {
-                            ind_data = d+p*dx+s*dt*dx;
-                            upd = (data[ind_data]-simdata[ind_data])/sum_dist2;
-                            for (n=0; n<csize-1; n++) 
+                            ind_data = d + p * dx + s * dt * dx;
+                            upd      = (data[ind_data] - simdata[ind_data]) /
+                                  sum_dist2;
+                            for(n = 0; n < csize - 1; n++)
                             {
-                                update[indi[n]] += upd*dist[n];
+                                update[indi[n]] += upd * dist[n];
                             }
                         }
                     }
                 }
 
-                for (n = 0; n < ngridx*ngridy; n++) {
-                    if (sum_dist[n] != 0.0) {
-                        ind_recon = s*ngridx*ngridy;
-                        recon[n+ind_recon] += update[n]/sum_dist[n];
+                for(n = 0; n < ngridx * ngridy; n++)
+                {
+                    if(sum_dist[n] != 0.0)
+                    {
+                        ind_recon = s * ngridx * ngridy;
+                        recon[n + ind_recon] += update[n] / sum_dist[n];
                     }
                 }
             }

--- a/src/fbp.c
+++ b/src/fbp.c
@@ -1,132 +1,125 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-fbp(
-    const float *data, int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, const char *fname, const float *filter_par)
+void
+fbp(const float* data, int dy, int dt, int dx, const float* center,
+    const float* theta, float* recon, int ngridx, int ngridy, const char* fname,
+    const float* filter_par)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi   = (int*) malloc((ngridx + ngridy) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d, n;
-    int quadrant;
+    int   s, p, d, n;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float mov, xi, yi;
-    int asize, bsize, csize;
-    int ind_data, ind_recon;
+    int   asize, bsize, csize;
+    int   ind_data, ind_recon;
 
     // For each slice
-    for (s=0; s<dy; s++)
+    for(s = 0; s < dy; s++)
     {
-        preprocessing(ngridx, ngridy, dx, center[s], 
-            &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
-        // For each projection angle 
-        for (p=0; p<dt; p++) 
+        preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                      gridy);  // Outputs: mov, gridx, gridy
+
+        // For each projection angle
+        for(p = 0; p < dt; p++)
         {
-            // Calculate the sin and cos values 
+            // Calculate the sin and cos values
             // of the projection angle and find
             // at which quadrant on the cartesian grid.
-            theta_p = fmod(theta[p], 2*M_PI);
+            theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
             quadrant = calc_quadrant(theta_p);
-            sin_p = sinf(theta_p);
-            cos_p = cosf(theta_p);
+            sin_p    = sinf(theta_p);
+            cos_p    = cosf(theta_p);
 
-            // For each detector pixel 
-            for (d=0; d<dx; d++) 
+            // For each detector pixel
+            for(d = 0; d < dx; d++)
             {
                 // Calculate coordinates
-                xi = -ngridx-ngridy;
-                yi = (1-dx)/2.0+d+mov;
-                calc_coords(
-                    ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                    coordx, coordy);
+                xi = -ngridx - ngridy;
+                yi = 0.5f * (1 - dx) + d + mov;
+                calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
+                            coordx, coordy);
 
                 // Merge the (coordx, gridy) and (gridx, coordy)
-                trim_coords(
-                    ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                    &asize, ax, ay, &bsize, bx, by);
+                trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                            &asize, ax, ay, &bsize, bx, by);
 
                 // Sort the array of intersection points (ax, ay) and
-                // (bx, by). The new sorted intersection points are 
-                // stored in (coorx, coory). Total number of points 
+                // (bx, by). The new sorted intersection points are
+                // stored in (coorx, coory). Total number of points
                 // are csize.
-                sort_intersections(
-                    quadrant, asize, ax, ay, bsize, bx, by, 
-                    &csize, coorx, coory);
+                sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                   &csize, coorx, coory);
 
-                // Calculate the distances (dist) between the 
-                // intersection points (coorx, coory). Find the 
+                // Calculate the distances (dist) between the
+                // intersection points (coorx, coory). Find the
                 // indices of the pixels on the reconstruction grid.
-                calc_dist(
-                    ngridx, ngridy, csize, coorx, coory, 
-                    indi, dist);
+                calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
                 // Update
-                ind_recon = s*ngridx*ngridy;
-                ind_data = d+p*dx+s*dt*dx;
-                for (n=0; n<csize-1; n++)
+                ind_recon = s * ngridx * ngridy;
+                ind_data  = d + p * dx + s * dt * dx;
+                for(n = 0; n < csize - 1; n++)
                 {
-                	recon[indi[n]+ind_recon] += data[ind_data]*dist[n];
+                    recon[indi[n] + ind_recon] += data[ind_data] * dist[n];
                 }
             }
         }

--- a/src/grad.c
+++ b/src/grad.c
@@ -1,239 +1,240 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratongridx (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratongridx (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binangridx forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binangridx forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binangridx form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binangridx form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratongridx, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratongridx, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLAngridx, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEOngridx OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLAngridx, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEOngridx OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-    void 
-grad(
-        const float *data, int dy, int dt, int dx,
-        const float *center, const float *theta,
-        float *recon, int ngridx, int ngridy, int num_iter, const float *reg_pars)
+void
+grad(const float* data, int dy, int dt, int dx, const float* center,
+     const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+     const float* reg_pars)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
-    float *simdata = (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *sum_dist = (float *)malloc((ngridx*ngridy)*sizeof(float));
+    float* gridx    = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy    = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx   = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy   = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi     = (int*) malloc((ngridx + ngridy) * sizeof(int));
+    float* simdata  = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* sum_dist = (float*) malloc((ngridx * ngridy) * sizeof(float));
 
-    float *prox1= (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *grad= (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
-    float *grad0= (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
-    float *recon0= (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
-    float *lambda= (float *)malloc((dy)*sizeof(float));
+    float* prox1  = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* grad   = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
+    float* grad0  = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
+    float* recon0 = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
+    float* lambda = (float*) malloc((dy) * sizeof(float));
 
-    assert(coordx != NULL && coordy != NULL &&
-            ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-            coorx != NULL && coory != NULL && dist != NULL &&
-            indi != NULL && simdata != NULL && sum_dist != NULL &&
-            grad != NULL && grad0 != NULL && recon0 !=NULL && lambda!=NULL
-            );
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL && simdata != NULL &&
+           sum_dist != NULL && grad != NULL && grad0 != NULL &&
+           recon0 != NULL && lambda != NULL);
 
-    int s, p, d, i, n;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;    
+    int    s, p, d, i, n;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
     double upd;
-    int ind_data, ind_recon;
-    float sum_dist2;
-    int ix,iy;
+    int    ind_data, ind_recon;
+    float  sum_dist2;
+    int    ix, iy;
 
-    //scaling constant r such that r*R(r*R^*(data)) ~ data
+    // scaling constant r such that r*R(r*R^*(data)) ~ data
     float r;
 
-    r = 1/sqrt(dx*dt/2.0);
+    r = 1 / sqrt(dx * dt / 2.0);
 
-    //scale initial guess
-    for (s=0; s<dy; s++)
+    // scale initial guess
+    for(s = 0; s < dy; s++)
     {
-        ind_recon = s*ngridx*ngridy;
-        for (iy=0; iy<ngridy; iy++) 
-            for (ix=0; ix<ngridx; ix++) 
-                recon[ind_recon+iy*ngridx+ix] /= r;
+        ind_recon = s * ngridx * ngridy;
+        for(iy = 0; iy < ngridy; iy++)
+            for(ix = 0; ix < ngridx; ix++)
+                recon[ind_recon + iy * ngridx + ix] /= r;
     }
 
-    memset(grad0, 0, dy*ngridx*ngridy*sizeof(float));
-    memset(prox1, 0, dy*dt*dx*sizeof(float));
-    memcpy(recon0, recon, dy*ngridx*ngridy*sizeof(float));
+    memset(grad0, 0, dy * ngridx * ngridy * sizeof(float));
+    memset(prox1, 0, dy * dt * dx * sizeof(float));
+    memcpy(recon0, recon, dy * ngridx * ngridy * sizeof(float));
 
-    //Iterations    
-    for (i=0; i<num_iter; i++) 
+    // Iterations
+    for(i = 0; i < num_iter; i++)
     {
         // initialize simdata and grad to 0
-        memset(simdata, 0, dy*dt*dx*sizeof(float));
-        memset(grad, 0, dy*ngridx*ngridy*sizeof(float));
+        memset(simdata, 0, dy * dt * dx * sizeof(float));
+        memset(grad, 0, dy * ngridx * ngridy * sizeof(float));
 
         // compute gradient, grad = 2*R^*(R(recon)-data)
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            ind_recon = s*ngridx*ngridy;
-            //compute proximal of the projections
-            preprocessing(ngridx, ngridy, dx, center[s],
-                    &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            ind_recon = s * ngridx * ngridy;
+            // compute proximal of the projections
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
             // initialize sum_dist and update to zero
-            memset(sum_dist, 0, (ngridx*ngridy)*sizeof(float));
+            memset(sum_dist, 0, (ngridx * ngridy) * sizeof(float));
 
-            // For each projection angle 
-            for (p=0; p<dt; p++)
+            // For each projection angle
+            for(p = 0; p < dt; p++)
             {
-                // Calculate the sin and cos values 
+                // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
-                // For each detector pixel 
-                for (d=0; d<dx; d++)
+                // For each detector pixel
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
-                    calc_coords(
-                            ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                            coordx, coordy);
+                    xi = -ngridx - ngridy;
+                    yi = 0.5f * (1 - dx) + d + mov;
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                            ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                            &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
-                    // (bx, by). The new sorted intersection points are 
-                    // stored in (coorx, coory). Total number of points 
+                    // (bx, by). The new sorted intersection points are
+                    // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                            quadrant, asize, ax, ay, bsize, bx, by, 
-                            &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
-                    // Calculate the distances (dist) between the 
-                    // intersection points (coorx, coory). Find the 
+                    // Calculate the distances (dist) between the
+                    // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist(
-                            ngridx, ngridy, csize, coorx, coory, 
-                            indi, dist);
+                    calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
-                    // Calculate simdata 
-                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
+                    // Calculate simdata
+                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize, indi,
+                                 dist, recon,
+                                 simdata);  // Output: simdata
 
-                    ind_data = d+p*dx+s*dt*dx;
-                    prox1[ind_data] = simdata[ind_data]*r - data[ind_data];
+                    ind_data        = d + p * dx + s * dt * dx;
+                    prox1[ind_data] = simdata[ind_data] * r - data[ind_data];
 
                     // Calculate dist*dist
-                    sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++) 
+                    sum_dist2 = 0.0f;
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
+                        sum_dist2 += dist[n] * dist[n];
                         sum_dist[indi[n]] += dist[n];
                     }
 
-                    if (sum_dist2 != 0.0) 
-                        for (n=0; n<csize-1; n++) 
-                            grad[ind_recon+indi[n]] += 2*r*prox1[ind_data]*dist[n];
+                    if(sum_dist2 != 0.0f)
+                        for(n = 0; n < csize - 1; n++)
+                            grad[ind_recon + indi[n]] +=
+                                2 * r * prox1[ind_data] * dist[n];
                 }
             }
         }
 
-        //compute the gradient step
-        for (s=0; s<dy; s++)
+        // compute the gradient step
+        for(s = 0; s < dy; s++)
         {
-            if (reg_pars[0] < 0)
-            {    
-                 if (i==0) 
-                    //first gradient step (small)
+            if(reg_pars[0] < 0)
+            {
+                if(i == 0)
+                    // first gradient step (small)
                     lambda[s] = 1e-3;
                 else
-                {    
-                    upd = 0;
-                    lambda[s] = 0;            
-                    ind_recon = s*ngridx*ngridy;
-                    for (iy=0; iy<ngridy; iy++) 
-                        for (ix=0; ix<ngridx; ix++) 
+                {
+                    upd       = 0;
+                    lambda[s] = 0;
+                    ind_recon = s * ngridx * ngridy;
+                    for(iy = 0; iy < ngridy; iy++)
+                        for(ix = 0; ix < ngridx; ix++)
                         {
-                            lambda[s] += (recon[ind_recon+iy*ngridx+ix]-recon0[ind_recon+iy*ngridx+ix])*(grad[ind_recon+iy*ngridx+ix]-grad0[ind_recon+iy*ngridx+ix]);
-                            upd += (grad[ind_recon+iy*ngridx+ix]-grad0[ind_recon+iy*ngridx+ix])*(grad[ind_recon+iy*ngridx+ix]-grad0[ind_recon+iy*ngridx+ix]);
-                        }                
-                    lambda[s]/=upd;
-                }            
+                            lambda[s] +=
+                                (recon[ind_recon + iy * ngridx + ix] -
+                                 recon0[ind_recon + iy * ngridx + ix]) *
+                                (grad[ind_recon + iy * ngridx + ix] -
+                                 grad0[ind_recon + iy * ngridx + ix]);
+                            upd += (grad[ind_recon + iy * ngridx + ix] -
+                                    grad0[ind_recon + iy * ngridx + ix]) *
+                                   (grad[ind_recon + iy * ngridx + ix] -
+                                    grad0[ind_recon + iy * ngridx + ix]);
+                        }
+                    lambda[s] /= upd;
+                }
             }
             else
                 lambda[s] = reg_pars[0];
         }
-        //save previous iterations
-        memcpy(grad0,grad,dy*ngridx*ngridy*sizeof(float));
-        memcpy(recon0,recon,dy*ngridx*ngridy*sizeof(float));    
-        //update, recon = recon - lambda*grad
-        for (s=0; s<dy; s++)
+        // save previous iterations
+        memcpy(grad0, grad, dy * ngridx * ngridy * sizeof(float));
+        memcpy(recon0, recon, dy * ngridx * ngridy * sizeof(float));
+        // update, recon = recon - lambda*grad
+        for(s = 0; s < dy; s++)
         {
-            ind_recon = s*ngridx*ngridy;
-            for (iy=0; iy<ngridy; iy++) 
-                for (ix=0; ix<ngridx; ix++) 
-                    recon[ind_recon+iy*ngridx+ix] -= lambda[s]*grad[ind_recon+iy*ngridx+ix];                
+            ind_recon = s * ngridx * ngridy;
+            for(iy = 0; iy < ngridy; iy++)
+                for(ix = 0; ix < ngridx; ix++)
+                    recon[ind_recon + iy * ngridx + ix] -=
+                        lambda[s] * grad[ind_recon + iy * ngridx + ix];
         }
     }
-    
-    //scale result
-    for (s=0; s<dy; s++)
+
+    // scale result
+    for(s = 0; s < dy; s++)
     {
-        ind_recon = s*ngridx*ngridy;
-        for (iy=0; iy<ngridy; iy++) 
-            for (ix=0; ix<ngridx; ix++) 
-                recon[ind_recon+iy*ngridx+ix] *= r;
+        ind_recon = s * ngridx * ngridy;
+        for(iy = 0; iy < ngridy; iy++)
+            for(ix = 0; ix < ngridx; ix++)
+                recon[ind_recon + iy * ngridx + ix] *= r;
     }
     free(gridx);
     free(gridy);

--- a/src/gridrec.c
+++ b/src/gridrec.c
@@ -54,47 +54,47 @@
 
 #include "gridrec.h"
 #ifdef USE_MKL
-    #include "mkl.h"
+#    include "mkl.h"
 #else
-    #include <fftw3.h>
+#    include <fftw3.h>
 #endif
 #include <math.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 #ifndef USE_MKL
-#include <pthread.h>
+#    include <pthread.h>
 pthread_mutex_t lock;
 #endif
 
 #ifndef M_PI
-    #define M_PI 3.14159265359
+#    define M_PI 3.14159265359
 #endif
 
 #define __LIKELY(x) __builtin_expect(!!(x), 1)
 #ifdef __INTEL_COMPILER
-#define __PRAGMA_SIMD _Pragma("simd assert")
-#define __PRAGMA_SIMD_VECREMAINDER _Pragma("simd assert, vecremainder")
-#define __PRAGMA_SIMD_VECREMAINDER_VECLEN8 _Pragma("simd assert, vecremainder, vectorlength(8)")
-#define __PRAGMA_OMP_SIMD_COLLAPSE _Pragma("omp simd collapse(2)")
-#define __PRAGMA_IVDEP _Pragma("ivdep")
-#define __ASSSUME_64BYTES_ALIGNED(x) __assume_aligned((x), 64)
+#    define __PRAGMA_SIMD _Pragma("simd assert")
+#    define __PRAGMA_SIMD_VECREMAINDER _Pragma("simd assert, vecremainder")
+#    define __PRAGMA_SIMD_VECREMAINDER_VECLEN8                                 \
+        _Pragma("simd assert, vecremainder, vectorlength(8)")
+#    define __PRAGMA_OMP_SIMD_COLLAPSE _Pragma("omp simd collapse(2)")
+#    define __PRAGMA_IVDEP _Pragma("ivdep")
+#    define __ASSSUME_64BYTES_ALIGNED(x) __assume_aligned((x), 64)
 #else
-#define __PRAGMA_SIMD
-#define __PRAGMA_SIMD_VECREMAINDER
-#define __PRAGMA_SIMD_VECREMAINDER_VECLEN8
-#define __PRAGMA_OMP_SIMD_COLLAPSE
-#define __PRAGMA_IVDEP
-#define __ASSSUME_64BYTES_ALIGNED(x)
+#    define __PRAGMA_SIMD
+#    define __PRAGMA_SIMD_VECREMAINDER
+#    define __PRAGMA_SIMD_VECREMAINDER_VECLEN8
+#    define __PRAGMA_OMP_SIMD_COLLAPSE
+#    define __PRAGMA_IVDEP
+#    define __ASSSUME_64BYTES_ALIGNED(x)
 #endif
 
 void
-gridrec(
-    const float *data, int dy, int dt, int dx, const float *center,
-    const float *theta, float *recon, int ngridx, int ngridy, const char *fname,
-	const float *filter_par)
+gridrec(const float* data, int dy, int dt, int dx, const float* center,
+        const float* theta, float* recon, int ngridx, int ngridy,
+        const char* fname, const float* filter_par)
 {
-    int s, p, iu, iv;
-    int j;
+    int    s, p, iu, iv;
+    int    j;
     float *sine, *cose, *wtbl, *winv;
 
 #ifdef USE_MKL
@@ -103,32 +103,33 @@ gridrec(
     float _Complex **work, **work2;
 #endif
 
-    float (* const filter)(float, int, int, int, const float*) = get_filter(fname);
-    const float C = 7.0;
-    const float nt = 20.0;
-    const float lambda = 0.99998546;
-    const unsigned int L = (int)(2*C/M_PI);
-    const int ltbl = 512;
-    int pdim;
-    float _Complex *sino, *filphase, *filphase_iter, **H;
-    float _Complex **U_d, **V_d;
-    float *J_z,*P_z;
+    float (*const filter)(float, int, int, int, const float*) =
+        get_filter(fname);
+    const float        C      = 7.0;
+    const float        nt     = 20.0;
+    const float        lambda = 0.99998546;
+    const unsigned int L      = (int) (2 * C / M_PI);
+    const int          ltbl   = 512;
+    int                pdim;
+    float _Complex *   sino, *filphase, *filphase_iter, **H;
+    float _Complex **  U_d, **V_d;
+    float *            J_z, *P_z;
 #ifndef USE_MKL
-    pthread_mutex_lock(&lock); // acquire global lock for set-up
+    pthread_mutex_lock(&lock);  // acquire global lock for set-up
 #endif
 
-    const float coefs[11] = {
-         0.5767616E+02, -0.8931343E+02,  0.4167596E+02,
-        -0.1053599E+02,  0.1662374E+01, -0.1780527E-00,
-         0.1372983E-01, -0.7963169E-03,  0.3593372E-04,
-        -0.1295941E-05,  0.3817796E-07};
+    const float coefs[11] = { 0.5767616E+02,  -0.8931343E+02, 0.4167596E+02,
+                              -0.1053599E+02, 0.1662374E+01,  -0.1780527E-00,
+                              0.1372983E-01,  -0.7963169E-03, 0.3593372E-04,
+                              -0.1295941E-05, 0.3817796E-07 };
 
     // Compute pdim = next power of 2 >= dx
-    for(pdim = 16; pdim < dx; pdim *= 2);
+    for(pdim = 16; pdim < dx; pdim *= 2)
+        ;
 
     const int pdim2 = pdim >> 1;
-    const int M02 = pdim2 - 1;
-    const int M2 = pdim2;
+    const int M02   = pdim2 - 1;
+    const int M2    = pdim2;
 
     unsigned char filter2d = filter_is_2d(fname);
 
@@ -136,73 +137,94 @@ gridrec(
 #ifdef USE_MKL
     sino = malloc_vector_c(pdim);
 #else
-    sino = malloc_vector_c(pdim*dt);
+    sino = malloc_vector_c(pdim * dt);
 #endif
-    if(!filter2d){
-        filphase = malloc_vector_c(pdim2);
+    if(!filter2d)
+    {
+        filphase      = malloc_vector_c(pdim2);
         filphase_iter = filphase;
-    }else{
-        filphase = malloc_vector_c(dt*(pdim2));
+    }
+    else
+    {
+        filphase = malloc_vector_c(dt * (pdim2));
     }
     __ASSSUME_64BYTES_ALIGNED(filphase);
-    H = malloc_matrix_c(pdim, pdim); __ASSSUME_64BYTES_ALIGNED(H);
-    wtbl = malloc_vector_f(ltbl+1);  __ASSSUME_64BYTES_ALIGNED(wtbl);
-    winv = malloc_vector_f(pdim-1);  __ASSSUME_64BYTES_ALIGNED(winv);
-    J_z = malloc_vector_f(pdim2*dt); __ASSSUME_64BYTES_ALIGNED(J_z);
-    P_z = malloc_vector_f(pdim2*dt); __ASSSUME_64BYTES_ALIGNED(P_z);
-    U_d = malloc_matrix_c(dt, pdim); __ASSSUME_64BYTES_ALIGNED(U_d);
-    V_d = malloc_matrix_c(dt, pdim); __ASSSUME_64BYTES_ALIGNED(V_d);
+    H = malloc_matrix_c(pdim, pdim);
+    __ASSSUME_64BYTES_ALIGNED(H);
+    wtbl = malloc_vector_f(ltbl + 1);
+    __ASSSUME_64BYTES_ALIGNED(wtbl);
+    winv = malloc_vector_f(pdim - 1);
+    __ASSSUME_64BYTES_ALIGNED(winv);
+    J_z = malloc_vector_f(pdim2 * dt);
+    __ASSSUME_64BYTES_ALIGNED(J_z);
+    P_z = malloc_vector_f(pdim2 * dt);
+    __ASSSUME_64BYTES_ALIGNED(P_z);
+    U_d = malloc_matrix_c(dt, pdim);
+    __ASSSUME_64BYTES_ALIGNED(U_d);
+    V_d = malloc_matrix_c(dt, pdim);
+    __ASSSUME_64BYTES_ALIGNED(V_d);
 #ifdef USE_MKL
-    work = malloc_vector_f(L+1);     __ASSSUME_64BYTES_ALIGNED(work);
-    work2 = malloc_vector_f(L+1);    __ASSSUME_64BYTES_ALIGNED(work2)
+    work = malloc_vector_f(L + 1);
+    __ASSSUME_64BYTES_ALIGNED(work);
+    work2 = malloc_vector_f(L + 1);
+    __ASSSUME_64BYTES_ALIGNED(work2);
 #else
-	work = malloc_matrix_c(pdim2*dt, L+1);  __ASSSUME_64BYTES_ALIGNED(work);
-    work2 = malloc_matrix_c(pdim2*dt, L+1); __ASSSUME_64BYTES_ALIGNED(work2);
+    work = malloc_matrix_c(pdim2 * dt, L + 1);
+    __ASSSUME_64BYTES_ALIGNED(work);
+    work2 = malloc_matrix_c(pdim2 * dt, L + 1);
+    __ASSSUME_64BYTES_ALIGNED(work2);
 #endif
 
     // Set up table of sines and cosines.
-    set_trig_tables(dt, theta, &sine, &cose); __ASSSUME_64BYTES_ALIGNED(sine); __ASSSUME_64BYTES_ALIGNED(cose);
+    set_trig_tables(dt, theta, &sine, &cose);
+    __ASSSUME_64BYTES_ALIGNED(sine);
+    __ASSSUME_64BYTES_ALIGNED(cose);
 
     // Set up PSWF lookup tables.
     set_pswf_tables(C, nt, lambda, coefs, ltbl, M02, wtbl, winv);
 
 #ifdef USE_MKL
     DFTI_DESCRIPTOR_HANDLE reverse_1d;
-    MKL_LONG length_1d = (MKL_LONG) pdim;
+    MKL_LONG               length_1d = (MKL_LONG) pdim;
     DftiCreateDescriptor(&reverse_1d, DFTI_SINGLE, DFTI_COMPLEX, 1, length_1d);
-    DftiSetValue(reverse_1d, DFTI_THREAD_LIMIT, 1); /* FFT should run sequentially to avoid oversubscription */
+    DftiSetValue(reverse_1d, DFTI_THREAD_LIMIT,
+                 1); /* FFT should run sequentially to avoid oversubscription */
     DftiCommitDescriptor(reverse_1d);
     DFTI_DESCRIPTOR_HANDLE forward_2d;
-    MKL_LONG length_2d[2] = {(MKL_LONG) pdim, (MKL_LONG) pdim};
+    MKL_LONG               length_2d[2] = { (MKL_LONG) pdim, (MKL_LONG) pdim };
     DftiCreateDescriptor(&forward_2d, DFTI_SINGLE, DFTI_COMPLEX, 2, length_2d);
-    DftiSetValue(forward_2d, DFTI_THREAD_LIMIT, 1); /* FFT should run sequentially to avoid oversubscription */
+    DftiSetValue(forward_2d, DFTI_THREAD_LIMIT,
+                 1); /* FFT should run sequentially to avoid oversubscription */
     DftiCommitDescriptor(forward_2d);
 #else
-    int n[1] = {pdim};
+    int n[1] = { pdim };
     // Set up fftw plans
     fftwf_plan reverse_1d;
     fftwf_plan reverse_1d_many;
     fftwf_plan forward_2d;
-    reverse_1d = fftwf_plan_dft_1d(pdim, sino, sino, FFTW_BACKWARD, FFTW_MEASURE);
-    reverse_1d_many = fftwf_plan_many_dft(1, n, dt, sino, n, 1, pdim, sino, n, 1, pdim, FFTW_BACKWARD, FFTW_MEASURE);
-    forward_2d = fftwf_plan_dft_2d(pdim, pdim, H[0], H[0], FFTW_FORWARD, FFTW_MEASURE);
-    pthread_mutex_unlock(&lock); // release global lock
+    reverse_1d =
+        fftwf_plan_dft_1d(pdim, sino, sino, FFTW_BACKWARD, FFTW_MEASURE);
+    reverse_1d_many = fftwf_plan_many_dft(1, n, dt, sino, n, 1, pdim, sino, n,
+                                          1, pdim, FFTW_BACKWARD, FFTW_MEASURE);
+    forward_2d =
+        fftwf_plan_dft_2d(pdim, pdim, H[0], H[0], FFTW_FORWARD, FFTW_MEASURE);
+    pthread_mutex_unlock(&lock);  // release global lock
 #endif
 
-    for(p=0; p<dt; p++)
+    for(p = 0; p < dt; p++)
     {
-        for(j=1; j<pdim2; j++)
+        for(j = 1; j < pdim2; j++)
         {
             U_d[p][j] = j * cose[p] + M2;
             V_d[p][j] = j * sine[p] + M2;
         }
     }
 
-    float U, V;
-    const float L2 = (int)(C/M_PI);
-    const float tblspcg = 2*ltbl/L;
-    int iul, iuh, ivl, ivh;
-    int k, k2;
+    float       U, V;
+    const float L2      = (int) (C / M_PI);
+    const float tblspcg = 2 * ltbl / L;
+    int         iul, iuh, ivl, ivh;
+    int         k, k2;
 
 #ifndef USE_MKL
     int jmin, jmax;
@@ -210,18 +232,18 @@ gridrec(
     // Tune block size depending on architecture
     const int bh = 64;
     const int nb = pdim / bh;
-    float wl, wh;
-    int z = 0;
+    float     wl, wh;
+    int       z = 0;
     // Calculations below same for all slices so move outside of slice loop
     // Set up cache blocking to reduce irregular access
-    for(b=0; b<nb; b++)
+    for(b = 0; b < nb; b++)
     {
         wl = bh * b;
         wh = bh * (b + 1);
         // Limit j to loop over jmin,jmax and reduce if condition overhead
-        for (p = 0; p < dt; p++)
+        for(p = 0; p < dt; p++)
         {
-            if (cose[p] > 0)
+            if(cose[p] > 0)
             {
                 jmin = ((wl - M2) / cose[p]);
                 jmax = ceil(((wh - M2) / cose[p]));
@@ -231,47 +253,49 @@ gridrec(
                 jmin = ((wh - M2) / cose[p]);
                 jmax = ceil(((wl - M2) / cose[p]));
             }
-            if (jmin < 1)
+            if(jmin < 1)
             {
                 jmin = 1;
             }
-            if (jmax > pdim2)
+            if(jmax > pdim2)
             {
                 jmax = pdim2;
             }
-            for (j = jmin; j < jmax; j++)
+            for(j = jmin; j < jmax; j++)
             {
                 U = U_d[p][j];
-                if (U >= wl && U < wh)
+                if(U >= wl && U < wh)
                 {
                     J_z[z] = j;
                     P_z[z] = p;
-                    V = V_d[p][j];
+                    V      = V_d[p][j];
 
                     iul = ceil(U - L2);
                     iuh = floor(U + L2);
                     ivl = ceil(V - L2);
                     ivh = floor(V + L2);
-                    if (iul < 1)
+                    if(iul < 1)
                         iul = 1;
-                    if (iuh >= pdim)
+                    if(iuh >= pdim)
                         iuh = pdim - 1;
-                    if (ivl < 1)
+                    if(ivl < 1)
                         ivl = 1;
-                    if (ivh >= pdim)
+                    if(ivh >= pdim)
                         ivh = pdim - 1;
 
                     // Pre-compute work and work2
                     // Note aliasing value (at index=0) is forced to zero.
                     __PRAGMA_SIMD_VECREMAINDER_VECLEN8
-                    for (iv = ivl, k = 0; iv <= ivh; iv++, k++)
+                    for(iv = ivl, k = 0; iv <= ivh; iv++, k++)
                     {
-                        work[z][k] = wtbl[(int)roundf(fabsf(V - iv) * tblspcg)];
+                        work[z][k] =
+                            wtbl[(int) roundf(fabsf(V - iv) * tblspcg)];
                     }
                     __PRAGMA_SIMD_VECREMAINDER_VECLEN8
-                    for (iu = iul, k2 = 0; iu <= iuh; iu++, k2++)
+                    for(iu = iul, k2 = 0; iu <= iuh; iu++, k2++)
                     {
-                        work2[z][k2] = wtbl[(int)roundf(fabsf(U - iu) * tblspcg)];
+                        work2[z][k2] =
+                            wtbl[(int) roundf(fabsf(U - iu) * tblspcg)];
                     }
 
                     z++;
@@ -281,10 +305,11 @@ gridrec(
     }
 #endif
     // For each slice.
-    for (s=0; s<dy; s+=2)
+    for(s = 0; s < dy; s += 2)
     {
         // Set up table of combined filter-phase factors.
-        set_filter_tables(dt, pdim, center[s], filter, filter_par, filphase, filter2d);
+        set_filter_tables(dt, pdim, center[s], filter, filter_par, filphase,
+                          filter2d);
 
         // First clear the array H
         memset(H[0], 0, pdim * pdim * sizeof(H[0][0]));
@@ -304,10 +329,10 @@ gridrec(
 
         //     3. Multiply each element of the 1-D transform by a complex,
         //      frequency dependent factor, filphase[].  These factors were
-        //      precomputed as part of recofour1((float*)sino-1,pdim,1);n_init() and combine the
-        //      tomographic filtering with a phase factor which shifts the
-        //      origin in configuration space to the projection of the
-        //      rotation axis as defined by the parameter, "center".  If a
+        //      precomputed as part of recofour1((float*)sino-1,pdim,1);n_init()
+        //      and combine the tomographic filtering with a phase factor which
+        //      shifts the origin in configuration space to the projection of
+        //      the rotation axis as defined by the parameter, "center".  If a
         //      region of interest (ROI) centered on a different origin has
         //      been specified [(X0,Y0)!=(0,0)], multiplication by an
         //      additional phase factor, dependent on angle as well as
@@ -336,73 +361,82 @@ gridrec(
 
 #ifdef USE_MKL
         // For each projection
-        for(p=0; p<dt; p++)
+        for(p = 0; p < dt; p++)
         {
-            float sine_p = sine[p], cose_p = cose[p];
-            const unsigned int j0 = dx*(p + s*dt), delta_index = dx*dt;
+            float              sine_p = sine[p], cose_p = cose[p];
+            const unsigned int j0 = dx * (p + s * dt), delta_index = dx * dt;
 
             __PRAGMA_SIMD_VECREMAINDER
-            for(j=0; j<dx; j++)
+            for(j = 0; j < dx; j++)
             {
                 // Add data from both slices
-                float second_sino = 0.0;
-                const unsigned int index = j + j0;
-                if (__LIKELY((s + 1) < dy))
+                float              second_sino = 0.0;
+                const unsigned int index       = j + j0;
+                if(__LIKELY((s + 1) < dy))
                 {
                     second_sino = data[index + delta_index];
                 }
-                sino[j] = data[index] + I*second_sino;
-
+                sino[j] = data[index] + I * second_sino;
             }
 
             __PRAGMA_SIMD_VECREMAINDER
-            for(j=dx; j<pdim; j++) {
-                    // Zero fill the rest of the array
-                    sino[j] = 0.0;
+            for(j = dx; j < pdim; j++)
+            {
+                // Zero fill the rest of the array
+                sino[j] = 0.0;
             }
 
             DftiComputeBackward(reverse_1d, sino);
 
-            if(filter2d) filphase_iter = filphase + pdim2*p;
+            if(filter2d)
+                filphase_iter = filphase + pdim2 * p;
 
             // For each FFT(projection)
-            for(j=1; j<pdim2; j++)
+            for(j = 1; j < pdim2; j++)
             {
                 Cdata1 = filphase_iter[j] * sino[j];
-                Cdata2 = conjf(filphase_iter[j]) * sino[pdim-j];
+                Cdata2 = conjf(filphase_iter[j]) * sino[pdim - j];
 
                 U = j * cose_p + M2;
                 V = j * sine_p + M2;
 
                 // Note freq space origin is at (M2,M2), but we
                 // offset the indices U, V, etc. to range from 0 to M-1.
-                iul = ceilf(U-L2);
-                iuh = floorf(U+L2);
-                ivl = ceilf(V-L2);
-                ivh = floorf(V+L2);
-                if(iul<1) iul = 1;
-                if(iuh>=pdim) iuh = pdim-1;
-                if(ivl<1) ivl = 1;
-                if(ivh>=pdim) ivh = pdim-1;
+                iul = ceilf(U - L2);
+                iuh = floorf(U + L2);
+                ivl = ceilf(V - L2);
+                ivh = floorf(V + L2);
+                if(iul < 1)
+                    iul = 1;
+                if(iuh >= pdim)
+                    iuh = pdim - 1;
+                if(ivl < 1)
+                    ivl = 1;
+                if(ivh >= pdim)
+                    ivh = pdim - 1;
 
                 // Note aliasing value (at index=0) is forced to zero.
                 __PRAGMA_SIMD_VECREMAINDER_VECLEN8
-                for(iv=ivl, k=0; iv<=ivh; iv++, k++) {
-                    work[k] = wtbl[(int) roundf(fabsf(V-iv)*tblspcg)];
+                for(iv = ivl, k = 0; iv <= ivh; iv++, k++)
+                {
+                    work[k] = wtbl[(int) roundf(fabsf(V - iv) * tblspcg)];
                 }
 
                 __PRAGMA_SIMD_VECREMAINDER_VECLEN8
-                for(iu=iul, k=0; iu<=iuh; iu++, k++) {
-                    work2[k] = wtbl[(int) roundf(fabsf(U-iu)*tblspcg)];
+                for(iu = iul, k = 0; iu <= iuh; iu++, k++)
+                {
+                    work2[k] = wtbl[(int) roundf(fabsf(U - iu) * tblspcg)];
                 }
 
-        __PRAGMA_OMP_SIMD_COLLAPSE
-                for (iu=iul, k2=0; iu <= iuh; iu++, k2++) {
-                    for(iv=ivl, k=0; iv<=ivh; iv++, k++) {
-                    	const float rtmp = work2[k2];
-                        const float convolv = rtmp*work[k];
-                        H[iu][iv] += convolv*Cdata1;
-                        H[pdim-iu][pdim-iv] += convolv*Cdata2;
+                __PRAGMA_OMP_SIMD_COLLAPSE
+                for(iu = iul, k2 = 0; iu <= iuh; iu++, k2++)
+                {
+                    for(iv = ivl, k = 0; iv <= ivh; iv++, k++)
+                    {
+                        const float rtmp    = work2[k2];
+                        const float convolv = rtmp * work[k];
+                        H[iu][iv] += convolv * Cdata1;
+                        H[pdim - iu][pdim - iv] += convolv * Cdata2;
                     }
                 }
             }
@@ -411,83 +445,90 @@ gridrec(
 #else
         int zlimit = z;
         // For each projection
-        for(p=0; p<dt; p++)
+        for(p = 0; p < dt; p++)
         {
-            const unsigned int j0 = dx*(p + s*dt), delta_index = dx*dt;
+            const unsigned int j0 = dx * (p + s * dt), delta_index = dx * dt;
 
             __PRAGMA_SIMD_VECREMAINDER
-            for(j=0; j<dx; j++)
+            for(j = 0; j < dx; j++)
             {
                 // Add data from both slices
-                float second_sino = 0.0;
-                const unsigned int index = j + j0;
-                if (__LIKELY((s + 1) < dy))
+                float              second_sino = 0.0;
+                const unsigned int index       = j + j0;
+                if(__LIKELY((s + 1) < dy))
                 {
                     second_sino = data[index + delta_index];
                 }
-                //sino[j] = data[index] + I*second_sino;
-                sino[j+(p*pdim)] = data[index] + I*second_sino;
+                // sino[j] = data[index] + I*second_sino;
+                sino[j + (p * pdim)] = data[index] + I * second_sino;
             }
 
             __PRAGMA_SIMD_VECREMAINDER
-            for(j=dx; j<pdim; j++) {
-                    // Zero fill the rest of the array
-                    //sino[j] = 0.0;
-                    sino[j+(p*pdim)] = 0.0;
+            for(j = dx; j < pdim; j++)
+            {
+                // Zero fill the rest of the array
+                // sino[j] = 0.0;
+                sino[j + (p * pdim)] = 0.0;
             }
         }
-            // Take FFT of the projection array
-            //fftwf_execute(reverse_1d);
-            fftwf_execute(reverse_1d_many);
+        // Take FFT of the projection array
+        // fftwf_execute(reverse_1d);
+        fftwf_execute(reverse_1d_many);
 
+        // Use re-ordered p,j,U,V from cache-blocking calculations
+        // For each FFT(projection)
+        for(z = 0; z < zlimit; z++)
+        {
+            p = P_z[z];
+            j = J_z[z];
+            U = U_d[p][j];
+            V = V_d[p][j];
 
-            // Use re-ordered p,j,U,V from cache-blocking calculations
-            // For each FFT(projection)
-        	for(z=0; z<zlimit ;z++)
+            if(filter2d)
+                filphase_iter = filphase + pdim2 * p;
+
+            Cdata1 = filphase_iter[j] * sino[j + (p * pdim)];
+            Cdata2 = conjf(filphase_iter[j]) * sino[pdim - j + (p * pdim)];
+
+            // Note freq space origin is at (M2,M2), but we
+            // offset the indices U, V, etc. to range from 0 to M-1.
+            iul = ceilf(U - L2);
+            iuh = floorf(U + L2);
+            ivl = ceilf(V - L2);
+            ivh = floorf(V + L2);
+            if(iul < 1)
+                iul = 1;
+            if(iuh >= pdim)
+                iuh = pdim - 1;
+            if(ivl < 1)
+                ivl = 1;
+            if(ivh >= pdim)
+                ivh = pdim - 1;
+
+            __PRAGMA_OMP_SIMD_COLLAPSE
+            for(iu = iul, k2 = 0; iu <= iuh; iu++, k2++)
             {
-                p = P_z[z];
-                j = J_z[z];
-                U = U_d[p][j];
-                V = V_d[p][j];
-
-                if(filter2d) filphase_iter = filphase + pdim2*p;
-
-                Cdata1 = filphase_iter[j] * sino[j+(p*pdim)];
-                Cdata2 = conjf(filphase_iter[j]) * sino[pdim-j+(p*pdim)];
-
-                // Note freq space origin is at (M2,M2), but we
-                // offset the indices U, V, etc. to range from 0 to M-1.
-                iul = ceilf(U-L2);
-                iuh = floorf(U+L2);
-                ivl = ceilf(V-L2);
-                ivh = floorf(V+L2);
-                if(iul<1) iul = 1;
-                if(iuh>=pdim) iuh = pdim-1;
-                if(ivl<1) ivl = 1;
-                if(ivh>=pdim) ivh = pdim-1;
-
-		__PRAGMA_OMP_SIMD_COLLAPSE
-                for (iu=iul, k2=0; iu <= iuh; iu++, k2++) {
-                    for(iv=ivl, k=0; iv<=ivh; iv++, k++) {
-                        const float convolv = work2[z][k2]*work[z][k];
-                        H[iu][iv] += convolv*Cdata1;
-                        H[pdim-iu][pdim-iv] += convolv*Cdata2;
-                    }
+                for(iv = ivl, k = 0; iv <= ivh; iv++, k++)
+                {
+                    const float convolv = work2[z][k2] * work[z][k];
+                    H[iu][iv] += convolv * Cdata1;
+                    H[pdim - iu][pdim - iv] += convolv * Cdata2;
                 }
             }
+        }
 #endif
         // Carry out a 2D inverse FFT on the array H.
 
         // At the conclusion of this phase, the configuration
         // space data is arranged in wrap-around order with the origin
         // (center of reconstructed images) situated at the start of the
-        // array.  The first (resp. second) half of the array contains the lower,
-        // Y<0 (resp, upper Y>0) part of the image, and within each row of the
-        // array, the first (resp. second) half contains data for the right [X>0]
-        // (resp. left [X<0]) half of the image.
+        // array.  The first (resp. second) half of the array contains the
+        // lower, Y<0 (resp, upper Y>0) part of the image, and within each row
+        // of the array, the first (resp. second) half contains data for the
+        // right [X>0] (resp. left [X<0]) half of the image.
 
 #ifdef USE_MKL
-	DftiComputeForward(forward_2d, H[0]);
+        DftiComputeForward(forward_2d, H[0]);
 #else
         fftwf_execute(forward_2d);
 #endif
@@ -496,7 +537,8 @@ gridrec(
         // into the output buffers for the two reconstructed real images,
         // simultaneously carrying out a final multiplicative correction.
         // The correction factors are taken from the array, winv[], previously
-        // computed in set_pswf_tables(), and consist logically of three parts, namely:
+        // computed in set_pswf_tables(), and consist logically of three parts,
+        // namely:
 
         //  1. A positive real factor, corresponding to the reciprocal
         //     of the inverse Fourier transform, of the convolving
@@ -515,58 +557,61 @@ gridrec(
         //     its start.
 
         // Only the elements in the square M0xM0 subarray of H[][], centered
-        // about the origin, are utilized.  The other elements are not part of the
-        // actual region being reconstructed and are discarded.  Because of the
-        // wrap-around ordering, the subarray must actually be taken from the four
-        // corners" of the 2D array, H[][] -- See Phase 2 description, above.
+        // about the origin, are utilized.  The other elements are not part of
+        // the actual region being reconstructed and are discarded.  Because of
+        // the wrap-around ordering, the subarray must actually be taken from
+        // the four corners" of the 2D array, H[][] -- See Phase 2 description,
+        // above.
 
         // The final data corresponds physically to the linear X-ray absorption
         // coefficient expressed in units of the inverse detector spacing -- to
         // convert to inverse cm (say), one must divide the data by the detector
         // spacing in cm.
 
-        int ustart, vstart, ufin, vfin;
-        const int padx = (pdim-ngridx)/2;
-        const int pady = (pdim-ngridy)/2;
-        const int offsetx = M02+1-padx;
-        const int offsety = M02+1-pady;
-        const int islc1 = s*ngridx*ngridy; // index slice 1
-        const int islc2 = (s+1)*ngridx*ngridy; // index slice 2
+        int       ustart, vstart, ufin, vfin;
+        const int padx    = (pdim - ngridx) / 2;
+        const int pady    = (pdim - ngridy) / 2;
+        const int offsetx = M02 + 1 - padx;
+        const int offsety = M02 + 1 - pady;
+        const int islc1   = s * ngridx * ngridy;        // index slice 1
+        const int islc2   = (s + 1) * ngridx * ngridy;  // index slice 2
 
-        ustart = pdim-offsety;
-        ufin = pdim;
-        j = 0;
-        while(j<ngridy)
+        ustart = pdim - offsety;
+        ufin   = pdim;
+        j      = 0;
+        while(j < ngridy)
         {
-            for(iu=ustart; iu<ufin; j++, iu++)
+            for(iu = ustart; iu < ufin; j++, iu++)
             {
-                const float corrn_u = winv[j+pady];
-                vstart = pdim-offsetx;
-                vfin = pdim;
-                k = 0;
-                while(k<ngridx)
+                const float corrn_u = winv[j + pady];
+                vstart              = pdim - offsetx;
+                vfin                = pdim;
+                k                   = 0;
+                while(k < ngridx)
                 {
                     __PRAGMA_SIMD
-                    for(iv=vstart; iv<vfin; k++, iv++)
+                    for(iv = vstart; iv < vfin; k++, iv++)
                     {
-                        const float corrn = corrn_u*winv[k+padx];
-                        recon[islc1+ngridy*(ngridx-1-k)+j] = corrn*crealf(H[iu][iv]);
-                        if(__LIKELY((s+1) < dy))
+                        const float corrn = corrn_u * winv[k + padx];
+                        recon[islc1 + ngridy * (ngridx - 1 - k) + j] =
+                            corrn * crealf(H[iu][iv]);
+                        if(__LIKELY((s + 1) < dy))
                         {
-                            recon[islc2+ngridy*(ngridx-1-k)+j] = corrn*cimagf(H[iu][iv]);
+                            recon[islc2 + ngridy * (ngridx - 1 - k) + j] =
+                                corrn * cimagf(H[iu][iv]);
                         }
                     }
-                    if(k<ngridx)
+                    if(k < ngridx)
                     {
                         vstart = 0;
-                        vfin = ngridx-offsetx;
+                        vfin   = ngridx - offsetx;
                     }
                 }
             }
-            if(j<ngridy)
+            if(j < ngridy)
             {
                 ustart = 0;
-                ufin = ngridy-offsety;
+                ufin   = ngridy - offsety;
             }
         }
     }
@@ -599,136 +644,137 @@ gridrec(
     return;
 }
 
-
 void
-set_filter_tables(
-    int dt, int pd, float center,
-    float(* const pf)(float, int, int, int, const float *), const float *filter_par, float _Complex *A, unsigned char filter2d)
+set_filter_tables(int dt, int pd, float center,
+                  float (*const pf)(float, int, int, int, const float*),
+                  const float* filter_par, float _Complex* A,
+                  unsigned char filter2d)
 {
     // Set up the complex array, filphase[], each element of which
     // consists of a real filter factor [obtained from the function,
     // (*pf)()], multiplying a complex phase factor (derived from the
     // parameter, center}.  See Phase 1 comments.
 
-    const float norm = M_PI/pd/dt;
-    const float rtmp1 = 2*M_PI*center/pd;
-    int j,i;
-    int pd2 = pd/2;
-    float x;
+    const float norm  = M_PI / pd / dt;
+    const float rtmp1 = 2 * M_PI * center / pd;
+    int         j, i;
+    int         pd2 = pd / 2;
+    float       x;
 
-    if(!filter2d){
-        for(j=0; j<pd2; j++)
+    if(!filter2d)
+    {
+        for(j = 0; j < pd2; j++)
         {
-            A[j] = (*pf)((float)j/pd, j, 0, pd2, filter_par);
+            A[j] = (*pf)((float) j / pd, j, 0, pd2, filter_par);
         }
 
         __PRAGMA_SIMD
-        for(j=0; j<pd2; j++)
+        for(j = 0; j < pd2; j++)
         {
-            x = j*rtmp1;
-            A[j] *= (cosf(x) - I*sinf(x))*norm;
+            x = j * rtmp1;
+            A[j] *= (cosf(x) - I * sinf(x)) * norm;
         }
-    }else{
-        for(i=0;i<dt;i++)
+    }
+    else
+    {
+        for(i = 0; i < dt; i++)
         {
             int j0 = i * pd2;
 
-            for(j=0; j<pd2; j++)
+            for(j = 0; j < pd2; j++)
             {
-                A[j0 + j] = (*pf)((float)j/pd, j, i, pd2, filter_par);
+                A[j0 + j] = (*pf)((float) j / pd, j, i, pd2, filter_par);
             }
 
             __PRAGMA_SIMD
-            for(j=0; j<pd2; j++)
+            for(j = 0; j < pd2; j++)
             {
-                x = j*rtmp1;
-                A[j0 + j] *= (cosf(x) - I*sinf(x))*norm;
+                x = j * rtmp1;
+                A[j0 + j] *= (cosf(x) - I * sinf(x)) * norm;
             }
         }
     }
 }
 
-
 void
-set_pswf_tables(
-    float C, int nt, float lambda, const float *coefs,
-    int ltbl, int linv, float* wtbl, float* winv)
+set_pswf_tables(float C, int nt, float lambda, const float* coefs, int ltbl,
+                int linv, float* wtbl, float* winv)
 {
     // Set up lookup tables for convolvent (used in Phase 1 of
     // do_recon()), and for the final correction factor (used in
     // Phase 3).
 
-    int i;
-    float norm;
-    const float fac = (float)ltbl / (linv+0.5);
+    int         i;
+    float       norm;
+    const float fac   = (float) ltbl / (linv + 0.5);
     const float polyz = legendre(nt, coefs, 0.);
 
     wtbl[0] = 1.0;
-    for(i=1; i<=ltbl; i++)
+    for(i = 1; i <= ltbl; i++)
     {
-        wtbl[i] = legendre(nt, coefs, (float)i/ltbl) / polyz;
+        wtbl[i] = legendre(nt, coefs, (float) i / ltbl) / polyz;
     }
 
     // Note the final result at end of Phase 3 contains the factor,
     // norm^2.  This incorporates the normalization of the 2D
     // inverse FFT in Phase 2 as well as scale factors involved
     // in the inverse Fourier transform of the convolvent.
-    norm = sqrt(M_PI/2/C/lambda) / 1.2;
+    norm = sqrt(M_PI / 2 / C / lambda) / 1.2;
 
     winv[linv] = norm / wtbl[0];
     __PRAGMA_IVDEP
-    for(i=1; i<=linv; i++)
+    for(i = 1; i <= linv; i++)
     {
         // Minus sign for alternate entries
         // corrects for "natural" data layout
         // in array H at end of Phase 1.
-        norm = -norm;
-        winv[linv+i] = winv[linv-i] = norm / wtbl[(int) roundf(i*fac)];
+        norm           = -norm;
+        winv[linv + i] = winv[linv - i] = norm / wtbl[(int) roundf(i * fac)];
     }
 }
 
-
 void
-set_trig_tables(int dt, const float *theta, float **sine, float **cose)
+set_trig_tables(int dt, const float* theta, float** sine, float** cose)
 {
     // Set up tables of sines and cosines.
     float *s, *c;
 
-    *sine = s = malloc_vector_f(dt); __ASSSUME_64BYTES_ALIGNED(s);
-    *cose = c = malloc_vector_f(dt); __ASSSUME_64BYTES_ALIGNED(c);
+    *sine = s = malloc_vector_f(dt);
+    __ASSSUME_64BYTES_ALIGNED(s);
+    *cose = c = malloc_vector_f(dt);
+    __ASSSUME_64BYTES_ALIGNED(c);
 
     __PRAGMA_SIMD
-    for(int j=0; j<dt; j++)
+    for(int j = 0; j < dt; j++)
     {
         s[j] = sinf(theta[j]);
         c[j] = cosf(theta[j]);
     }
 }
 
-
 float
-legendre(int n, const float *coefs, float x)
+legendre(int n, const float* coefs, float x)
 {
     // Compute SUM(coefs(k)*P(2*k,x), for k=0,n/2)
     // where P(j,x) is the jth Legendre polynomial.
     // x must be between -1 and 1.
     float penult, last, cur, y, mxlast;
 
-    y = coefs[0];
+    y      = coefs[0];
     penult = 1.0;
-    last = x;
-    for(int j=2; j<=n; j++)
+    last   = x;
+    for(int j = 2; j <= n; j++)
     {
-	mxlast = -(x*last);
-	cur = -(2*mxlast + penult) + (penult + mxlast)/j;
+        mxlast = -(x * last);
+        cur    = -(2 * mxlast + penult) + (penult + mxlast) / j;
         // cur = (x*(2*j-1)*last-(j-1)*penult)/j;
-        if(!(j&1)) // if j is even
+        if(!(j & 1))  // if j is even
         {
-            y += cur*coefs[j >> 1];
+            y += cur * coefs[j >> 1];
         }
 
         penult = last;
-        last = cur;
+        last   = cur;
     }
     return y;
 }
@@ -736,20 +782,20 @@ legendre(int n, const float *coefs, float x)
 static inline void*
 malloc_64bytes_aligned(size_t sz)
 {
-    #ifdef __MINGW32__
-    return  __mingw_aligned_malloc(sz, 64);
-    #else
-    void *r = NULL;
-    int err = posix_memalign(&r, 64, sz);
+#ifdef __MINGW32__
+    return __mingw_aligned_malloc(sz, 64);
+#else
+    void* r   = NULL;
+    int   err = posix_memalign(&r, 64, sz);
     return (err) ? NULL : r;
-    #endif
+#endif
 }
 
 inline float*
 malloc_vector_f(size_t n)
 {
 #ifdef USE_MKL
-    return (float *)malloc(n*sizeof(float));
+    return (float*) malloc(n * sizeof(float));
 #else
     return fftwf_alloc_real(n);
 #endif
@@ -769,7 +815,7 @@ inline float _Complex*
 malloc_vector_c(size_t n)
 {
 #ifdef USE_MKL
-    return (float _Complex*)malloc(n*sizeof(float _Complex));
+    return (float _Complex*) malloc(n * sizeof(float _Complex));
 #else
     return fftwf_alloc_complex(n);
 #endif
@@ -785,22 +831,21 @@ free_vector_c(float _Complex* v)
 #endif
 }
 
-
 float _Complex**
 malloc_matrix_c(size_t nr, size_t nc)
 {
-    float _Complex **m = NULL;
-    size_t i;
+    float _Complex** m = NULL;
+    size_t           i;
 
     // Allocate pointers to rows,
-    m = (float _Complex **) malloc_64bytes_aligned(nr * sizeof(float _Complex *));
+    m = (float _Complex**) malloc_64bytes_aligned(nr * sizeof(float _Complex*));
 
     /* Allocate rows and set the pointers to them */
     m[0] = malloc_vector_c(nr * nc);
 
-    for (i = 1; i < nr; i++)
+    for(i = 1; i < nr; i++)
     {
-        m[i] = m[i-1] + nc;
+        m[i] = m[i - 1] + nc;
     }
     return m;
 }
@@ -808,13 +853,12 @@ malloc_matrix_c(size_t nr, size_t nc)
 inline void
 free_matrix_c(float _Complex** m)
 {
-
     free_vector_c(m[0]);
-    #ifdef __MINGW32__
-        __mingw_aligned_free (m);
-    #else
-        free(m);
-    #endif
+#ifdef __MINGW32__
+    __mingw_aligned_free(m);
+#else
+    free(m);
+#endif
 }
 
 // No filter
@@ -824,58 +868,55 @@ filter_none(float x, int i, int j, int fwidth, const float* pars)
     return 1.0;
 }
 
-
 // Shepp-Logan filter
 float
 filter_shepp(float x, int i, int j, int fwidth, const float* pars)
 {
-    if(i==0) return 0.0;
-    return fabsf(2*x)*(sinf(M_PI*x)/(M_PI*x));
+    if(i == 0)
+        return 0.0;
+    return fabsf(2 * x) * (sinf(M_PI * x) / (M_PI * x));
 }
-
 
 // Cosine filter
 float
 filter_cosine(float x, int i, int j, int fwidth, const float* pars)
 {
-    return fabsf(2*x)*(cosf(M_PI*x));
+    return fabsf(2 * x) * (cosf(M_PI * x));
 }
-
 
 // Hann filter
 float
 filter_hann(float x, int i, int j, int fwidth, const float* pars)
 {
-    return fabsf(2*x)*0.5*(1.+cosf(2*M_PI*x/pars[0]));
+    return fabsf(2 * x) * 0.5 * (1. + cosf(2 * M_PI * x / pars[0]));
 }
-
 
 // Hamming filter
 float
 filter_hamming(float x, int i, int j, int fwidth, const float* pars)
 {
-    return fabsf(2*x)*(0.54+0.46*cosf(2*M_PI*x/pars[0]));
+    return fabsf(2 * x) * (0.54 + 0.46 * cosf(2 * M_PI * x / pars[0]));
 }
 
 // Ramlak filter
 float
 filter_ramlak(float x, int i, int j, int fwidth, const float* pars)
 {
-    return fabsf(2*x);
+    return fabsf(2 * x);
 }
 
 // Parzen filter
 float
 filter_parzen(float x, int i, int j, int fwidth, const float* pars)
 {
-    return fabsf(2*x)*pow(1-fabs(x)/pars[0], 3);
+    return fabsf(2 * x) * pow(1 - fabs(x) / pars[0], 3);
 }
 
 // Butterworth filter
 float
 filter_butterworth(float x, int i, int j, int fwidth, const float* pars)
 {
-    return fabsf(2*x)/(1+pow(x/pars[0], 2*pars[1]));
+    return fabsf(2 * x) / (1 + pow(x / pars[0], 2 * pars[1]));
 }
 
 // Custom filter
@@ -889,30 +930,24 @@ filter_custom(float x, int i, int j, int fwidth, const float* pars)
 float
 filter_custom2d(float x, int i, int j, int fwidth, const float* pars)
 {
-    return pars[j*fwidth+i];
+    return pars[j * fwidth + i];
 }
 
-
-float (*get_filter(const char *name))(float, int, int, int, const float*)
+float (*get_filter(const char* name))(float, int, int, int, const float*)
 {
     struct
     {
         const char* name;
-        float (* const fp)(float, int, int, int, const float*);
+        float (*const fp)(float, int, int, int, const float*);
     } fltbl[] = {
-        {"none", filter_none},
-        {"shepp", filter_shepp}, // Default
-        {"cosine", filter_cosine},
-        {"hann", filter_hann},
-        {"hamming", filter_hamming},
-        {"ramlak", filter_ramlak},
-        {"parzen", filter_parzen},
-        {"butterworth", filter_butterworth},
-        {"custom", filter_custom},
-        {"custom2d", filter_custom2d}
+        { "none", filter_none },       { "shepp", filter_shepp },  // Default
+        { "cosine", filter_cosine },   { "hann", filter_hann },
+        { "hamming", filter_hamming }, { "ramlak", filter_ramlak },
+        { "parzen", filter_parzen },   { "butterworth", filter_butterworth },
+        { "custom", filter_custom },   { "custom2d", filter_custom2d }
     };
 
-    for(int i=0; i<10; i++)
+    for(int i = 0; i < 10; i++)
     {
         if(!strncmp(name, fltbl[i].name, 16))
         {
@@ -923,8 +958,9 @@ float (*get_filter(const char *name))(float, int, int, int, const float*)
 }
 
 unsigned char
-filter_is_2d(const char *name)
+filter_is_2d(const char* name)
 {
-    if(!strncmp(name, "custom2d", 16)) return 1;
+    if(!strncmp(name, "custom2d", 16))
+        return 1;
     return 0;
 }

--- a/src/mlem.c
+++ b/src/mlem.c
@@ -1,174 +1,166 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratongridx (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratongridx (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binangridx forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binangridx forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binangridx form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binangridx form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratongridx, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratongridx, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLAngridx, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEOngridx OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLAngridx, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEOngridx OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-mlem(
-    const float *data, int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter)
+void
+mlem(const float* data, int dy, int dt, int dx, const float* center,
+     const float* theta, float* recon, int ngridx, int ngridy, int num_iter)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
-    float *simdata = (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *sum_dist = (float *)malloc((ngridx*ngridy)*sizeof(float));
-    float *update = (float *)malloc((ngridx*ngridy)*sizeof(float));
+    float* gridx    = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy    = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx   = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy   = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi     = (int*) malloc((ngridx + ngridy) * sizeof(int));
+    float* simdata  = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* sum_dist = (float*) malloc((ngridx * ngridy) * sizeof(float));
+    float* update   = (float*) malloc((ngridx * ngridy) * sizeof(float));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-		indi != NULL && simdata != NULL && sum_dist != NULL &&
-        update != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL && simdata != NULL &&
+           sum_dist != NULL && update != NULL);
 
-    int s, p, d, i, m, n;
-    int quadrant;
+    int   s, p, d, i, m, n;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float mov, xi, yi;
-    int asize, bsize, csize;
+    int   asize, bsize, csize;
     float upd;
-    int ind_data, ind_recon;
+    int   ind_data, ind_recon;
     float sum_dist2;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-    	// initialize simdata to zero
-    	memset(simdata, 0, dy*dt*dx*sizeof(float));
+        // initialize simdata to zero
+        memset(simdata, 0, dy * dt * dx * sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
+
             // initialize sum_dist and update to zero
-            memset(sum_dist, 0, (ngridx*ngridy)*sizeof(float));
-            memset(update, 0, (ngridx*ngridy)*sizeof(float));
-            
-            // For each projection angle 
-            for (p=0; p<dt; p++)
+            memset(sum_dist, 0, (ngridx * ngridy) * sizeof(float));
+            memset(update, 0, (ngridx * ngridy) * sizeof(float));
+
+            // For each projection angle
+            for(p = 0; p < dt; p++)
             {
-                // Calculate the sin and cos values 
+                // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
-                // For each detector pixel 
-                for (d=0; d<dx; d++)
+                // For each detector pixel
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                        coordx, coordy);
+                    xi = -ngridx - ngridy;
+                    yi = 0.5f * (1 - dx) + d + mov;
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
-                    // (bx, by). The new sorted intersection points are 
-                    // stored in (coorx, coory). Total number of points 
+                    // (bx, by). The new sorted intersection points are
+                    // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by, 
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
-                    // Calculate the distances (dist) between the 
-                    // intersection points (coorx, coory). Find the 
+                    // Calculate the distances (dist) between the
+                    // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist(
-                        ngridx, ngridy, csize, coorx, coory, 
-                        indi, dist);
+                    calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
-                    // Calculate simdata 
-                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indi, dist, recon,
-                        simdata); // Output: simdata
-
+                    // Calculate simdata
+                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize, indi,
+                                 dist, recon,
+                                 simdata);  // Output: simdata
 
                     // Calculate dist*dist
-                    sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++) 
+                    sum_dist2 = 0.0f;
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
+                        sum_dist2 += dist[n] * dist[n];
                         sum_dist[indi[n]] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0) 
+                    if(sum_dist2 != 0.0f)
                     {
-                        ind_data = d+p*dx+s*dt*dx;
-                        upd = data[ind_data]/simdata[ind_data];
-                        for (n=0; n<csize-1; n++) 
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd      = data[ind_data] / simdata[ind_data];
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update[indi[n]] += upd*dist[n];
+                            update[indi[n]] += upd * dist[n];
                         }
                     }
                 }
             }
 
             m = 0;
-            for (n = 0; n < ngridx*ngridy; n++) {
-                if (sum_dist[n] != 0.0) {
-                    ind_recon = s*ngridx*ngridy;
-                    recon[m+ind_recon] *= update[m]/sum_dist[n];
+            for(n = 0; n < ngridx * ngridy; n++)
+            {
+                if(sum_dist[n] != 0.0f)
+                {
+                    ind_recon = s * ngridx * ngridy;
+                    recon[m + ind_recon] *= update[m] / sum_dist[n];
                 }
                 m++;
             }

--- a/src/morph.c
+++ b/src/morph.c
@@ -1,135 +1,132 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "morph.h"
 #include "assert.h"
 #include <limits.h>
 
-DLL void 
-sample(
-    int mode, const float* data, int dx, int dy, int dz,
-    int level, int axis, float* out)
+DLL void
+sample(int mode, const float* data, int dx, int dy, int dz, int level, int axis,
+       float* out)
 {
-    if (mode == 0) 
+    if(mode == 0)
     {
         downsample(data, dx, dy, dz, level, axis, out);
     }
-    
-    else if (mode == 1)
+
+    else if(mode == 1)
     {
         upsample(data, dx, dy, dz, level, axis, out);
     }
 }
 
-
-DLL void 
-downsample(
-    const float* data, int dx, int dy, int dz,
-    int level, int axis, float* out) 
+DLL void
+downsample(const float* data, int dx, int dy, int dz, int level, int axis,
+           float* out)
 {
-    unsigned m, n, p, binsize;
+    unsigned           m, n, p, binsize;
     unsigned long long i, j, k, ind;
 
     binsize = pow(2, level);
     // Ensure that largest array is small enough to be indexable
-    assert(ULLONG_MAX/dx/dy/dz > 0);
+    assert(ULLONG_MAX / dx / dy / dz > 0);
     // Ensure safe comparison between unsigned (ijk) and signed (xyz)
     assert(dx >= 0 && dy >= 0 && dz >= 0);
 
-    if (axis == 0)
+    if(axis == 0)
     {
         dx /= binsize;
-        for (m = 0, ind = 0; m < dx; m++) 
+        for(m = 0, ind = 0; m < (unsigned) dx; m++)
         {
             i = m * (dy * dz);
-            for (p = 0; p < binsize; p++) 
+            for(p = 0; p < binsize; p++)
             {
-                for (n = 0; n < dy; n++) 
+                for(n = 0; n < (unsigned) dy; n++)
                 {
                     j = n * dz;
-                    for (k = 0; k < dz; k++)
+                    for(k = 0; k < (unsigned) dz; k++)
                     {
-                        out[i+j+k] += data[ind]/binsize;
+                        out[i + j + k] += data[ind] / binsize;
                         ind++;
                     }
                 }
             }
         }
     }
-    else if (axis == 1)
+    else if(axis == 1)
     {
         dy /= binsize;
-        for (m = 0, ind = 0; m < dx; m++) 
+        for(m = 0, ind = 0; m < (unsigned) dx; m++)
         {
             i = m * (dy * dz);
-            for (n = 0; n < dy; n++) 
+            for(n = 0; n < (unsigned) dy; n++)
             {
                 j = n * dz;
-                for (p = 0; p < binsize; p++) 
+                for(p = 0; p < binsize; p++)
                 {
-                    for (k = 0; k < dz; k++)
+                    for(k = 0; k < (unsigned) dz; k++)
                     {
-                        out[i+j+k] += data[ind]/binsize;
+                        out[i + j + k] += data[ind] / binsize;
                         ind++;
                     }
                 }
             }
         }
     }
-    else if (axis == 2)
+    else if(axis == 2)
     {
         dz /= binsize;
-        for (m = 0, ind = 0; m < dx; m++) 
+        for(m = 0, ind = 0; m < (unsigned) dx; m++)
         {
             i = m * (dy * dz);
-            for (n = 0; n < dy; n++) 
+            for(n = 0; n < (unsigned) dy; n++)
             {
                 j = n * dz;
-                for (k = 0; k < dz; k++) 
+                for(k = 0; k < (unsigned) dz; k++)
                 {
-                    for (p = 0; p < binsize; p++) 
+                    for(p = 0; p < binsize; p++)
                     {
-                        out[i+j+k] += data[ind]/binsize;
+                        out[i + j + k] += data[ind] / binsize;
                         ind++;
                     }
                 }
@@ -138,72 +135,70 @@ downsample(
     }
 }
 
-
-DLL void 
-upsample(
-    const float* data, int dx, int dy, int dz,
-    int level, int axis, float* out) {
-
-    unsigned m, n, p, binsize;
+DLL void
+upsample(const float* data, int dx, int dy, int dz, int level, int axis,
+         float* out)
+{
+    unsigned           m, n, p, binsize;
     unsigned long long k, i, j, ind;
-    
+
     binsize = pow(2, level);
     // Ensure that largest array is small enough to be indexable
-    assert(ULLONG_MAX/binsize/dy/dz/dx > 0);
+    assert(ULLONG_MAX / binsize / dy / dz / dx > 0);
     // Ensure safe comparison between unsigned (ijk) and signed (xyz)
     assert(dx >= 0 && dy >= 0 && dz >= 0);
 
-    if (axis == 0)
+    if(axis == 0)
     {
-        for (m = 0, ind = 0; m < dx; m++) 
+        for(m = 0, ind = 0; m < (unsigned) dx; m++)
         {
             i = m * (dy * dz);
-            for (p = 0; p < binsize; p++) 
+            for(p = 0; p < binsize; p++)
             {
-                for (n = 0; n < dy; n++) 
+                for(n = 0; n < (unsigned) dy; n++)
                 {
                     j = n * dz;
-                    for (k = 0; k < dz; k++)
+                    for(k = 0; k < (unsigned) dz; k++)
                     {
-                        out[ind] = data[i+j+k];
+                        out[ind] = data[i + j + k];
                         ind++;
                     }
                 }
             }
         }
     }
-    else if (axis == 1)
+    else if(axis == 1)
     {
-        for (m = 0, ind = 0; m < dx; m++) 
+        for(m = 0, ind = 0; m < (unsigned) dx; m++)
         {
             i = m * (dy * dz);
-            for (n = 0; n < dy; n++) 
+            for(n = 0; n < (unsigned) dy; n++)
             {
                 j = n * dz;
-                for (p = 0; p < binsize; p++) 
+                for(p = 0; p < binsize; p++)
                 {
-                    for (k = 0; k < dz; k++)
+                    for(k = 0; k < (unsigned) dz; k++)
                     {
-                        out[ind] = data[i+j+k];
+                        out[ind] = data[i + j + k];
                         ind++;
                     }
                 }
             }
         }
     }
-    else if (axis == 2)
+    else if(axis == 2)
     {
-        for (m = 0, ind = 0; m < dx; m++) 
+        for(m = 0, ind = 0; m < (unsigned) dx; m++)
         {
             i = m * (dy * dz);
-            for (n = 0; n < dy; n++) 
+            for(n = 0; n < (unsigned) dy; n++)
             {
                 j = n * dz;
-                for (k = 0; k < dz; k++) 
+                for(k = 0; k < (unsigned) dz; k++)
                 {
-                    for (p = 0; p < binsize; p++) 
+                    for(p = 0; p < binsize; p++)
                     {
-                        out[ind] = data[i+j+k];
+                        out[ind] = data[i + j + k];
                         ind++;
                     }
                 }

--- a/src/osem.c
+++ b/src/osem.c
@@ -1,189 +1,182 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-osem(
-    const float *data, int dy, int dt, int dx,
-	const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter, 
-    int num_block, const float *ind_block)
+void
+osem(const float* data, int dy, int dt, int dx, const float* center,
+     const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+     int num_block, const float* ind_block)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
-    float *simdata = (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *sum_dist = (float *)malloc((ngridx*ngridy)*sizeof(float));
-    float *update = (float *)malloc((ngridx*ngridy)*sizeof(float));
+    float* gridx    = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy    = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx   = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy   = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi     = (int*) malloc((ngridx + ngridy) * sizeof(int));
+    float* simdata  = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* sum_dist = (float*) malloc((ngridx * ngridy) * sizeof(float));
+    float* update   = (float*) malloc((ngridx * ngridy) * sizeof(float));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-        indi != NULL && simdata != NULL && sum_dist != NULL &&
-        update != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL && simdata != NULL &&
+           sum_dist != NULL && update != NULL);
 
-    int s, q, p, d, i, m, n, os;
-    int quadrant;
+    int   s, q, p, d, i, m, n, os;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float mov, xi, yi;
-    int asize, bsize, csize;
+    int   asize, bsize, csize;
     float upd;
-    int ind_data, ind_recon;
+    int   ind_data, ind_recon;
     float sum_dist2;
-    int subset_ind1, subset_ind2;
+    int   subset_ind1, subset_ind2;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-    	// initialize simdata to zero
-    	memset(simdata, 0, dy*dt*dx*sizeof(float));
+        // initialize simdata to zero
+        memset(simdata, 0, dy * dt * dx * sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s], 
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
-            subset_ind1 = dt/num_block;
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
+
+            subset_ind1 = dt / num_block;
             subset_ind2 = subset_ind1;
-            
+
             // For each ordered-subset num_subset
-            for (os=0; os<num_block+1; os++) 
+            for(os = 0; os < num_block + 1; os++)
             {
-                if (os == num_block) 
+                if(os == num_block)
                 {
-                    subset_ind2 = dt%num_block;
+                    subset_ind2 = dt % num_block;
                 }
 
                 // initialize sum_dist and update to zero
-                memset(sum_dist, 0, (ngridx*ngridy)*sizeof(float));
-                memset(update, 0, (ngridx*ngridy)*sizeof(float));
-                
-                // For each projection angle 
-                for (q=0; q<subset_ind2; q++) 
-                {
-                    p = ind_block[q+os*subset_ind1];
+                memset(sum_dist, 0, (ngridx * ngridy) * sizeof(float));
+                memset(update, 0, (ngridx * ngridy) * sizeof(float));
 
-                    // Calculate the sin and cos values 
+                // For each projection angle
+                for(q = 0; q < subset_ind2; q++)
+                {
+                    p = ind_block[q + os * subset_ind1];
+
+                    // Calculate the sin and cos values
                     // of the projection angle and find
                     // at which quadrant on the cartesian grid.
-                    theta_p = fmod(theta[p], 2*M_PI);
+                    theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                     quadrant = calc_quadrant(theta_p);
-                    sin_p = sinf(theta_p);
-                    cos_p = cosf(theta_p);
+                    sin_p    = sinf(theta_p);
+                    cos_p    = cosf(theta_p);
 
-                    // For each detector pixel 
-                    for (d=0; d<dx; d++) 
+                    // For each detector pixel
+                    for(d = 0; d < dx; d++)
                     {
                         // Calculate coordinates
-                        xi = -ngridx-ngridy;
-                        yi = (1-dx)/2.0+d+mov;
-                        calc_coords(
-                            ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                            coordx, coordy);
+                        xi = -ngridx - ngridy;
+                        yi = 0.5f * (1 - dx) + d + mov;
+                        calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                    gridy, coordx, coordy);
 
                         // Merge the (coordx, gridy) and (gridx, coordy)
-                        trim_coords(
-                            ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                            &asize, ax, ay, &bsize, bx, by);
+                        trim_coords(ngridx, ngridy, coordx, coordy, gridx,
+                                    gridy, &asize, ax, ay, &bsize, bx, by);
 
                         // Sort the array of intersection points (ax, ay) and
-                        // (bx, by). The new sorted intersection points are 
-                        // stored in (coorx, coory). Total number of points 
+                        // (bx, by). The new sorted intersection points are
+                        // stored in (coorx, coory). Total number of points
                         // are csize.
-                        sort_intersections(
-                            quadrant, asize, ax, ay, bsize, bx, by, 
-                            &csize, coorx, coory);
+                        sort_intersections(quadrant, asize, ax, ay, bsize, bx,
+                                           by, &csize, coorx, coory);
 
-                        // Calculate the distances (dist) between the 
-                        // intersection points (coorx, coory). Find the 
+                        // Calculate the distances (dist) between the
+                        // intersection points (coorx, coory). Find the
                         // indices of the pixels on the reconstruction grid.
-                        calc_dist(
-                            ngridx, ngridy, csize, coorx, coory, 
-                            indi, dist);
+                        calc_dist(ngridx, ngridy, csize, coorx, coory, indi,
+                                  dist);
 
-                        // Calculate simdata 
-                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
-
+                        // Calculate simdata
+                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize,
+                                     indi, dist, recon,
+                                     simdata);  // Output: simdata
 
                         // Calculate dist*dist
-                        sum_dist2 = 0.0;
-                        for (n=0; n<csize-1; n++) 
+                        sum_dist2 = 0.0f;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            sum_dist2 += dist[n]*dist[n];
+                            sum_dist2 += dist[n] * dist[n];
                             sum_dist[indi[n]] += dist[n];
                         }
 
                         // Update
-                        if (sum_dist2 != 0.0) 
+                        if(sum_dist2 != 0.0f)
                         {
-                            ind_data = d+p*dx+s*dt*dx;
-                            upd = data[ind_data]/simdata[ind_data];
-                            for (n=0; n<csize-1; n++) 
+                            ind_data = d + p * dx + s * dt * dx;
+                            upd      = data[ind_data] / simdata[ind_data];
+                            for(n = 0; n < csize - 1; n++)
                             {
-                                update[indi[n]] += upd*dist[n];
+                                update[indi[n]] += upd * dist[n];
                             }
                         }
                     }
                 }
 
                 m = 0;
-                for (n = 0; n < ngridx*ngridy; n++) {
-                    if (sum_dist[n] != 0.0) {
-                        ind_recon = s*ngridx*ngridy;
-                        recon[m+ind_recon] *= update[m]/sum_dist[n];
+                for(n = 0; n < ngridx * ngridy; n++)
+                {
+                    if(sum_dist[n] != 0.0f)
+                    {
+                        ind_recon = s * ngridx * ngridy;
+                        recon[m + ind_recon] *= update[m] / sum_dist[n];
                     }
                     m++;
                 }

--- a/src/ospml_hybrid.c
+++ b/src/ospml_hybrid.c
@@ -1,392 +1,407 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-ospml_hybrid(
-    const float *data, int dy, int dt, int dx,
-	const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter,
-	const float *reg_pars, int num_block, const float *ind_block)
+void
+ospml_hybrid(const float* data, int dy, int dt, int dx, const float* center,
+             const float* theta, float* recon, int ngridx, int ngridy,
+             int num_iter, const float* reg_pars, int num_block,
+             const float* ind_block)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi   = (int*) malloc((ngridx + ngridy) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, q, p, d, i, m, n, os;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data, ind_recon;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, q, p, d, i, m, n, os;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data, ind_recon;
+    float* sum_dist;
+    float  sum_dist2;
     float *E, *F, *G;
-    int ind0, ind1, indg[8];
-    float totalwg, wg[8], mg[8], rg[8], gammag[8];
-    int subset_ind1, subset_ind2;
+    int    ind0, ind1, indg[8];
+    float  totalwg, wg[8], mg[8], rg[8], gammag[8];
+    int    subset_ind1, subset_ind2;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
-            subset_ind1 = dt/num_block;
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
+
+            subset_ind1 = dt / num_block;
             subset_ind2 = subset_ind1;
-        
+
             // For each ordered-subset num_subset
-            for (os=0; os<num_block+1; os++) 
+            for(os = 0; os < num_block + 1; os++)
             {
-                if (os == num_block) 
+                if(os == num_block)
                 {
-                    subset_ind2 = dt%num_block;
+                    subset_ind2 = dt % num_block;
                 }
 
-                sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-                E = (float *)calloc((ngridx*ngridy), sizeof(float));
-                F = (float *)calloc((ngridx*ngridy), sizeof(float));
-                G = (float *)calloc((ngridx*ngridy), sizeof(float));
-                
-                // For each projection angle 
-                for (q=0; q<subset_ind2; q++) 
-                {
-                    p = ind_block[q+os*subset_ind1];
+                sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+                E        = (float*) calloc((ngridx * ngridy), sizeof(float));
+                F        = (float*) calloc((ngridx * ngridy), sizeof(float));
+                G        = (float*) calloc((ngridx * ngridy), sizeof(float));
 
-                    // Calculate the sin and cos values 
+                // For each projection angle
+                for(q = 0; q < subset_ind2; q++)
+                {
+                    p = ind_block[q + os * subset_ind1];
+
+                    // Calculate the sin and cos values
                     // of the projection angle and find
                     // at which quadrant on the cartesian grid.
-                    theta_p = fmod(theta[p], 2*M_PI);
+                    theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                     quadrant = calc_quadrant(theta_p);
-                    sin_p = sinf(theta_p);
-                    cos_p = cosf(theta_p);
+                    sin_p    = sinf(theta_p);
+                    cos_p    = cosf(theta_p);
 
-                    // For each detector pixel 
-                    for (d=0; d<dx; d++)
+                    // For each detector pixel
+                    for(d = 0; d < dx; d++)
                     {
                         // Calculate coordinates
-                        xi = -ngridx-ngridy;
-                        yi = (1-dx)/2.0+d+mov;
-                        calc_coords(
-                            ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                            coordx, coordy);
+                        xi = -ngridx - ngridy;
+                        yi = 0.5f * (1 - dx) + d + mov;
+                        calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                    gridy, coordx, coordy);
 
                         // Merge the (coordx, gridy) and (gridx, coordy)
-                        trim_coords(
-                            ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                            &asize, ax, ay, &bsize, bx, by);
+                        trim_coords(ngridx, ngridy, coordx, coordy, gridx,
+                                    gridy, &asize, ax, ay, &bsize, bx, by);
 
                         // Sort the array of intersection points (ax, ay) and
-                        // (bx, by). The new sorted intersection points are 
-                        // stored in (coorx, coory). Total number of points 
+                        // (bx, by). The new sorted intersection points are
+                        // stored in (coorx, coory). Total number of points
                         // are csize.
-                        sort_intersections(
-                            quadrant, asize, ax, ay, bsize, bx, by, 
-                            &csize, coorx, coory);
+                        sort_intersections(quadrant, asize, ax, ay, bsize, bx,
+                                           by, &csize, coorx, coory);
 
-                        // Calculate the distances (dist) between the 
-                        // intersection points (coorx, coory). Find the 
+                        // Calculate the distances (dist) between the
+                        // intersection points (coorx, coory). Find the
                         // indices of the pixels on the reconstruction grid.
-                        calc_dist(
-                            ngridx, ngridy, csize, coorx, coory, 
-                            indi, dist);
+                        calc_dist(ngridx, ngridy, csize, coorx, coory, indi,
+                                  dist);
 
-                        // Calculate simdata 
-                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
-
+                        // Calculate simdata
+                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize,
+                                     indi, dist, recon,
+                                     simdata);  // Output: simdata
 
                         // Calculate dist*dist
-                        sum_dist2 = 0.0;
-                        for (n=0; n<csize-1; n++) 
+                        sum_dist2 = 0.0f;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            sum_dist2 += dist[n]*dist[n];
+                            sum_dist2 += dist[n] * dist[n];
                             sum_dist[indi[n]] += dist[n];
                         }
 
                         // Update
-                        if (sum_dist2 != 0.0) 
+                        if(sum_dist2 != 0.0f)
                         {
-                            ind_data = d+p*dx+s*dt*dx;
-                            ind_recon = s*ngridx*ngridy;
-                            upd = data[ind_data]/simdata[ind_data];
-                            for (n=0; n<csize-1; n++) 
+                            ind_data  = d + p * dx + s * dt * dx;
+                            ind_recon = s * ngridx * ngridy;
+                            upd       = data[ind_data] / simdata[ind_data];
+                            for(n = 0; n < csize - 1; n++)
                             {
-                                E[indi[n]] -= recon[indi[n]+ind_recon]*upd*dist[n];
+                                E[indi[n]] -=
+                                    recon[indi[n] + ind_recon] * upd * dist[n];
                             }
                         }
                     }
                 }
 
                 // Weights for inner neighborhoods.
-                totalwg = 4+4/sqrt(2);
-                wg[0] = 1/totalwg;
-                wg[1] = 1/totalwg;
-                wg[2] = 1/totalwg;
-                wg[3] = 1/totalwg;
-                wg[4] = 1/sqrt(2)/totalwg;
-                wg[5] = 1/sqrt(2)/totalwg;
-                wg[6] = 1/sqrt(2)/totalwg;
-                wg[7] = 1/sqrt(2)/totalwg;
+                totalwg = 4 + 4 / sqrt(2);
+                wg[0]   = 1 / totalwg;
+                wg[1]   = 1 / totalwg;
+                wg[2]   = 1 / totalwg;
+                wg[3]   = 1 / totalwg;
+                wg[4]   = 1 / sqrt(2) / totalwg;
+                wg[5]   = 1 / sqrt(2) / totalwg;
+                wg[6]   = 1 / sqrt(2) / totalwg;
+                wg[7]   = 1 / sqrt(2) / totalwg;
 
                 // (inner region)
-                for (n = 1; n < ngridx-1; n++) {
-                    for (m = 1; m < ngridy-1; m++) {
-                        ind0 = m + n*ngridy;
-                        ind1 = ind0 + s*ngridx*ngridy;
-                        
-                        indg[0] = ind1+1;
-                        indg[1] = ind1-1;
-                        indg[2] = ind1+ngridy;
-                        indg[3] = ind1-ngridy;
-                        indg[4] = ind1+ngridy+1; 
-                        indg[5] = ind1+ngridy-1;
-                        indg[6] = ind1-ngridy+1;
-                        indg[7] = ind1-ngridy-1;
-                        
+                for(n = 1; n < ngridx - 1; n++)
+                {
+                    for(m = 1; m < ngridy - 1; m++)
+                    {
+                        ind0 = m + n * ngridy;
+                        ind1 = ind0 + s * ngridx * ngridy;
 
-                        for (q = 0; q < 8; q++) {
-                            mg[q] = recon[ind1]+recon[indg[q]];
-                            rg[q] = recon[ind1]-recon[indg[q]];
-                            gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                            F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                            G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                        indg[0] = ind1 + 1;
+                        indg[1] = ind1 - 1;
+                        indg[2] = ind1 + ngridy;
+                        indg[3] = ind1 - ngridy;
+                        indg[4] = ind1 + ngridy + 1;
+                        indg[5] = ind1 + ngridy - 1;
+                        indg[6] = ind1 - ngridy + 1;
+                        indg[7] = ind1 - ngridy - 1;
+
+                        for(q = 0; q < 8; q++)
+                        {
+                            mg[q]     = recon[ind1] + recon[indg[q]];
+                            rg[q]     = recon[ind1] - recon[indg[q]];
+                            gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                            F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                            G[ind0] -=
+                                2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                         }
                     }
                 }
 
                 // Weights for edges.
-                totalwg = 3+2/sqrt(2);
-                wg[0] = 1/totalwg;
-                wg[1] = 1/totalwg;
-                wg[2] = 1/totalwg;
-                wg[3] = 1/sqrt(2)/totalwg;
-                wg[4] = 1/sqrt(2)/totalwg;
-                
+                totalwg = 3 + 2 / sqrt(2);
+                wg[0]   = 1 / totalwg;
+                wg[1]   = 1 / totalwg;
+                wg[2]   = 1 / totalwg;
+                wg[3]   = 1 / sqrt(2) / totalwg;
+                wg[4]   = 1 / sqrt(2) / totalwg;
+
                 // (top)
-                for (m = 1; m < ngridy-1; m++) {
+                for(m = 1; m < ngridy - 1; m++)
+                {
                     ind0 = m;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1-1;
-                    indg[2] = ind1+ngridy;
-                    indg[3] = ind1+ngridy+1; 
-                    indg[4] = ind1+ngridy-1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        rg[q] = recon[ind1]-recon[indg[q]];
-                        gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                        F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 - 1;
+                    indg[2] = ind1 + ngridy;
+                    indg[3] = ind1 + ngridy + 1;
+                    indg[4] = ind1 + ngridy - 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q]     = recon[ind1] + recon[indg[q]];
+                        rg[q]     = recon[ind1] - recon[indg[q]];
+                        gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                        F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                     }
                 }
 
                 // (bottom)
-                for (m = 1; m < ngridy-1; m++) {
-                    ind0 = m + (ngridx-1)*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1-1;
-                    indg[2] = ind1-ngridy;
-                    indg[3] = ind1-ngridy+1;
-                    indg[4] = ind1-ngridy-1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        rg[q] = recon[ind1]-recon[indg[q]];
-                        gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                        F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                for(m = 1; m < ngridy - 1; m++)
+                {
+                    ind0 = m + (ngridx - 1) * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 - 1;
+                    indg[2] = ind1 - ngridy;
+                    indg[3] = ind1 - ngridy + 1;
+                    indg[4] = ind1 - ngridy - 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q]     = recon[ind1] + recon[indg[q]];
+                        rg[q]     = recon[ind1] - recon[indg[q]];
+                        gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                        F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                     }
                 }
 
-                // (left)  
-                for (n = 1; n < ngridx-1; n++) {
-                    ind0 = n*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1+ngridy;
-                    indg[2] = ind1-ngridy;
-                    indg[3] = ind1+ngridy+1; 
-                    indg[4] = ind1-ngridy+1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        rg[q] = recon[ind1]-recon[indg[q]];
-                        gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                        F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                // (left)
+                for(n = 1; n < ngridx - 1; n++)
+                {
+                    ind0 = n * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 + ngridy;
+                    indg[2] = ind1 - ngridy;
+                    indg[3] = ind1 + ngridy + 1;
+                    indg[4] = ind1 - ngridy + 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q]     = recon[ind1] + recon[indg[q]];
+                        rg[q]     = recon[ind1] - recon[indg[q]];
+                        gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                        F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                     }
                 }
 
-                // (right)                
-                for (n = 1; n < ngridx-1; n++) {
-                    ind0 = (ngridy-1) + n*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1-1;
-                    indg[1] = ind1+ngridy;
-                    indg[2] = ind1-ngridy;
-                    indg[3] = ind1+ngridy-1;
-                    indg[4] = ind1-ngridy-1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        rg[q] = recon[ind1]-recon[indg[q]];
-                        gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                        F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                // (right)
+                for(n = 1; n < ngridx - 1; n++)
+                {
+                    ind0 = (ngridy - 1) + n * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 - 1;
+                    indg[1] = ind1 + ngridy;
+                    indg[2] = ind1 - ngridy;
+                    indg[3] = ind1 + ngridy - 1;
+                    indg[4] = ind1 - ngridy - 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q]     = recon[ind1] + recon[indg[q]];
+                        rg[q]     = recon[ind1] - recon[indg[q]];
+                        gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                        F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                     }
                 }
-                
+
                 // Weights for corners.
-                totalwg = 2+1/sqrt(2);
-                wg[0] = 1/totalwg;
-                wg[1] = 1/totalwg;
-                wg[2] = 1/sqrt(2)/totalwg;
-                
+                totalwg = 2 + 1 / sqrt(2);
+                wg[0]   = 1 / totalwg;
+                wg[1]   = 1 / totalwg;
+                wg[2]   = 1 / sqrt(2) / totalwg;
+
                 // (top-left)
                 ind0 = 0;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1+ngridy+1; 
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 + ngridy + 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
 
                 // (top-right)
-                ind0 = (ngridy-1);
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1-1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1+ngridy-1;
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                ind0 = (ngridy - 1);
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 - 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 + ngridy - 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
 
-                // (bottom-left)  
-                ind0 = (ngridx-1)*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1-ngridy;
-                indg[2] = ind1-ngridy+1;
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                // (bottom-left)
+                ind0 = (ngridx - 1) * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 - ngridy;
+                indg[2] = ind1 - ngridy + 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
 
-                // (bottom-right)           
-                ind0 = (ngridy-1) + (ngridx-1)*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1-1;
-                indg[1] = ind1-ngridy;
-                indg[2] = ind1-ngridy-1;
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                // (bottom-right)
+                ind0 = (ngridy - 1) + (ngridx - 1) * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 - 1;
+                indg[1] = ind1 - ngridy;
+                indg[2] = ind1 - ngridy - 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
 
                 q = 0;
-                for (n = 0; n < ngridx*ngridy; n++) {
+                for(n = 0; n < ngridx * ngridy; n++)
+                {
                     G[q] += sum_dist[n];
                     q++;
                 }
 
-                for (n = 0; n < ngridx; n++) {
-                    for (m = 0; m < ngridy; m++) {
-                        q = m + n*ngridy;
-                        if (F[q] != 0.0) {
-                            ind0 = q + s*ngridx*ngridy;
-                            recon[ind0] = (-G[q]+sqrt(G[q]*G[q]-8*E[q]*F[q]))/(4*F[q]);
+                for(n = 0; n < ngridx; n++)
+                {
+                    for(m = 0; m < ngridy; m++)
+                    {
+                        q = m + n * ngridy;
+                        if(F[q] != 0.0)
+                        {
+                            ind0 = q + s * ngridx * ngridy;
+                            recon[ind0] =
+                                (-G[q] + sqrt(G[q] * G[q] - 8 * E[q] * F[q])) /
+                                (4 * F[q]);
                         }
                     }
                 }
@@ -397,7 +412,7 @@ ospml_hybrid(
                 free(G);
             }
         }
-            
+
         free(simdata);
     }
 

--- a/src/ospml_quad.c
+++ b/src/ospml_quad.c
@@ -1,374 +1,388 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-ospml_quad(
-    const float *data, int dy, int dt, int dx,
-	const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter,
-	const float *reg_pars, int num_block, const float *ind_block)
+void
+ospml_quad(const float* data, int dy, int dt, int dx, const float* center,
+           const float* theta, float* recon, int ngridx, int ngridy,
+           int num_iter, const float* reg_pars, int num_block,
+           const float* ind_block)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi   = (int*) malloc((ngridx + ngridy) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, q, p, d, i, m, n, os;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data, ind_recon;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, q, p, d, i, m, n, os;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data, ind_recon;
+    float* sum_dist;
+    float  sum_dist2;
     float *E, *F, *G;
-    int ind0, ind1, indg[8];
-    float totalwg, wg[8], mg[8];
-    int subset_ind1, subset_ind2;
+    int    ind0, ind1, indg[8];
+    float  totalwg, wg[8], mg[8];
+    int    subset_ind1, subset_ind2;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s], 
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
-            subset_ind1 = dt/num_block;
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
+
+            subset_ind1 = dt / num_block;
             subset_ind2 = subset_ind1;
 
             // For each ordered-subset num_subset
-            for (os=0; os<num_block+1; os++) 
+            for(os = 0; os < num_block + 1; os++)
             {
-                if (os == num_block) 
+                if(os == num_block)
                 {
-                    subset_ind2 = dt%num_block;
+                    subset_ind2 = dt % num_block;
                 }
 
-                sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-                E = (float *)calloc((ngridx*ngridy), sizeof(float));
-                F = (float *)calloc((ngridx*ngridy), sizeof(float));
-                G = (float *)calloc((ngridx*ngridy), sizeof(float));
-                
-                // For each projection angle 
-                for (q=0; q<subset_ind2; q++) 
-                {
-                    p = ind_block[q+os*subset_ind1];
+                sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+                E        = (float*) calloc((ngridx * ngridy), sizeof(float));
+                F        = (float*) calloc((ngridx * ngridy), sizeof(float));
+                G        = (float*) calloc((ngridx * ngridy), sizeof(float));
 
-                    // Calculate the sin and cos values 
+                // For each projection angle
+                for(q = 0; q < subset_ind2; q++)
+                {
+                    p = ind_block[q + os * subset_ind1];
+
+                    // Calculate the sin and cos values
                     // of the projection angle and find
                     // at which quadrant on the cartesian grid.
-                    theta_p = fmod(theta[p], 2*M_PI);
+                    theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                     quadrant = calc_quadrant(theta_p);
-                    sin_p = sinf(theta_p);
-                    cos_p = cosf(theta_p);
+                    sin_p    = sinf(theta_p);
+                    cos_p    = cosf(theta_p);
 
-                    // For each detector pixel 
-                    for (d=0; d<dx; d++) 
+                    // For each detector pixel
+                    for(d = 0; d < dx; d++)
                     {
                         // Calculate coordinates
-                        xi = -ngridx-ngridy;
-                        yi = (1-dx)/2.0+d+mov;
-                        calc_coords(
-                            ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                            coordx, coordy);
+                        xi = -ngridx - ngridy;
+                        yi = 0.5f * (1 - dx) + d + mov;
+                        calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                    gridy, coordx, coordy);
 
                         // Merge the (coordx, gridy) and (gridx, coordy)
-                        trim_coords(
-                            ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                            &asize, ax, ay, &bsize, bx, by);
+                        trim_coords(ngridx, ngridy, coordx, coordy, gridx,
+                                    gridy, &asize, ax, ay, &bsize, bx, by);
 
                         // Sort the array of intersection points (ax, ay) and
-                        // (bx, by). The new sorted intersection points are 
-                        // stored in (coorx, coory). Total number of points 
+                        // (bx, by). The new sorted intersection points are
+                        // stored in (coorx, coory). Total number of points
                         // are csize.
-                        sort_intersections(
-                            quadrant, asize, ax, ay, bsize, bx, by, 
-                            &csize, coorx, coory);
+                        sort_intersections(quadrant, asize, ax, ay, bsize, bx,
+                                           by, &csize, coorx, coory);
 
-                        // Calculate the distances (dist) between the 
-                        // intersection points (coorx, coory). Find the 
+                        // Calculate the distances (dist) between the
+                        // intersection points (coorx, coory). Find the
                         // indices of the pixels on the reconstruction grid.
-                        calc_dist(
-                            ngridx, ngridy, csize, coorx, coory, 
-                            indi, dist);
+                        calc_dist(ngridx, ngridy, csize, coorx, coory, indi,
+                                  dist);
 
-                        // Calculate simdata 
-                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
-
+                        // Calculate simdata
+                        calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize,
+                                     indi, dist, recon,
+                                     simdata);  // Output: simdata
 
                         // Calculate dist*dist
-                        sum_dist2 = 0.0;
-                        for (n=0; n<csize-1; n++) 
+                        sum_dist2 = 0.0f;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            sum_dist2 += dist[n]*dist[n];
+                            sum_dist2 += dist[n] * dist[n];
                             sum_dist[indi[n]] += dist[n];
                         }
 
                         // Update
-                        if (sum_dist2 != 0.0) 
+                        if(sum_dist2 != 0.0f)
                         {
-                            ind_data = d+p*dx+s*dt*dx;
-                            ind_recon = s*ngridx*ngridy;
-                            upd = data[ind_data]/simdata[ind_data];
-                            for (n=0; n<csize-1; n++) 
+                            ind_data  = d + p * dx + s * dt * dx;
+                            ind_recon = s * ngridx * ngridy;
+                            upd       = data[ind_data] / simdata[ind_data];
+                            for(n = 0; n < csize - 1; n++)
                             {
-                                E[indi[n]] -= recon[indi[n]+ind_recon]*upd*dist[n];
+                                E[indi[n]] -=
+                                    recon[indi[n] + ind_recon] * upd * dist[n];
                             }
                         }
                     }
                 }
 
                 // Weights for inner neighborhoods.
-                totalwg = 4+4/sqrt(2);
-                wg[0] = 1/totalwg;
-                wg[1] = 1/totalwg;
-                wg[2] = 1/totalwg;
-                wg[3] = 1/totalwg;
-                wg[4] = 1/sqrt(2)/totalwg;
-                wg[5] = 1/sqrt(2)/totalwg;
-                wg[6] = 1/sqrt(2)/totalwg;
-                wg[7] = 1/sqrt(2)/totalwg;
+                totalwg = 4 + 4 / sqrt(2);
+                wg[0]   = 1 / totalwg;
+                wg[1]   = 1 / totalwg;
+                wg[2]   = 1 / totalwg;
+                wg[3]   = 1 / totalwg;
+                wg[4]   = 1 / sqrt(2) / totalwg;
+                wg[5]   = 1 / sqrt(2) / totalwg;
+                wg[6]   = 1 / sqrt(2) / totalwg;
+                wg[7]   = 1 / sqrt(2) / totalwg;
 
                 // (inner region)
-                for (n = 1; n < ngridx-1; n++) {
-                    for (m = 1; m < ngridy-1; m++) {
-                        ind0 = m + n*ngridy;
-                        ind1 = ind0 + s*ngridx*ngridy;
-                        
-                        indg[0] = ind1+1;
-                        indg[1] = ind1-1;
-                        indg[2] = ind1+ngridy;
-                        indg[3] = ind1-ngridy;
-                        indg[4] = ind1+ngridy+1; 
-                        indg[5] = ind1+ngridy-1;
-                        indg[6] = ind1-ngridy+1;
-                        indg[7] = ind1-ngridy-1;
-                        
+                for(n = 1; n < ngridx - 1; n++)
+                {
+                    for(m = 1; m < ngridy - 1; m++)
+                    {
+                        ind0 = m + n * ngridy;
+                        ind1 = ind0 + s * ngridx * ngridy;
 
-                        for (q = 0; q < 8; q++) {
-                            mg[q] = recon[ind1]+recon[indg[q]];
-                            F[ind0] += 2*reg_pars[0]*wg[q];
-                            G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                        indg[0] = ind1 + 1;
+                        indg[1] = ind1 - 1;
+                        indg[2] = ind1 + ngridy;
+                        indg[3] = ind1 - ngridy;
+                        indg[4] = ind1 + ngridy + 1;
+                        indg[5] = ind1 + ngridy - 1;
+                        indg[6] = ind1 - ngridy + 1;
+                        indg[7] = ind1 - ngridy - 1;
+
+                        for(q = 0; q < 8; q++)
+                        {
+                            mg[q] = recon[ind1] + recon[indg[q]];
+                            F[ind0] += 2 * reg_pars[0] * wg[q];
+                            G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                         }
                     }
                 }
 
                 // Weights for edges.
-                totalwg = 3+2/sqrt(2);
-                wg[0] = 1/totalwg;
-                wg[1] = 1/totalwg;
-                wg[2] = 1/totalwg;
-                wg[3] = 1/sqrt(2)/totalwg;
-                wg[4] = 1/sqrt(2)/totalwg;
-                
+                totalwg = 3 + 2 / sqrt(2);
+                wg[0]   = 1 / totalwg;
+                wg[1]   = 1 / totalwg;
+                wg[2]   = 1 / totalwg;
+                wg[3]   = 1 / sqrt(2) / totalwg;
+                wg[4]   = 1 / sqrt(2) / totalwg;
+
                 // (top)
-                for (m = 1; m < ngridy-1; m++) {
+                for(m = 1; m < ngridy - 1; m++)
+                {
                     ind0 = m;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1-1;
-                    indg[2] = ind1+ngridy;
-                    indg[3] = ind1+ngridy+1; 
-                    indg[4] = ind1+ngridy-1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        F[ind0] += 2*reg_pars[0]*wg[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 - 1;
+                    indg[2] = ind1 + ngridy;
+                    indg[3] = ind1 + ngridy + 1;
+                    indg[4] = ind1 + ngridy - 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q] = recon[ind1] + recon[indg[q]];
+                        F[ind0] += 2 * reg_pars[0] * wg[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                     }
                 }
 
                 // (bottom)
-                for (m = 1; m < ngridy-1; m++) {
-                    ind0 = m + (ngridx-1)*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1-1;
-                    indg[2] = ind1-ngridy;
-                    indg[3] = ind1-ngridy+1;
-                    indg[4] = ind1-ngridy-1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        F[ind0] += 2*reg_pars[0]*wg[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                for(m = 1; m < ngridy - 1; m++)
+                {
+                    ind0 = m + (ngridx - 1) * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 - 1;
+                    indg[2] = ind1 - ngridy;
+                    indg[3] = ind1 - ngridy + 1;
+                    indg[4] = ind1 - ngridy - 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q] = recon[ind1] + recon[indg[q]];
+                        F[ind0] += 2 * reg_pars[0] * wg[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                     }
                 }
 
-                // (left)  
-                for (n = 1; n < ngridx-1; n++) {
-                    ind0 = n*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1+ngridy;
-                    indg[2] = ind1-ngridy;
-                    indg[3] = ind1+ngridy+1; 
-                    indg[4] = ind1-ngridy+1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        F[ind0] += 2*reg_pars[0]*wg[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                // (left)
+                for(n = 1; n < ngridx - 1; n++)
+                {
+                    ind0 = n * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 + ngridy;
+                    indg[2] = ind1 - ngridy;
+                    indg[3] = ind1 + ngridy + 1;
+                    indg[4] = ind1 - ngridy + 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q] = recon[ind1] + recon[indg[q]];
+                        F[ind0] += 2 * reg_pars[0] * wg[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                     }
                 }
 
-                // (right)                
-                for (n = 1; n < ngridx-1; n++) {
-                    ind0 = (ngridy-1) + n*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1-1;
-                    indg[1] = ind1+ngridy;
-                    indg[2] = ind1-ngridy;
-                    indg[3] = ind1+ngridy-1;
-                    indg[4] = ind1-ngridy-1;
-                        
-                    for (q = 0; q < 5; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        F[ind0] += 2*reg_pars[0]*wg[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                // (right)
+                for(n = 1; n < ngridx - 1; n++)
+                {
+                    ind0 = (ngridy - 1) + n * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
+
+                    indg[0] = ind1 - 1;
+                    indg[1] = ind1 + ngridy;
+                    indg[2] = ind1 - ngridy;
+                    indg[3] = ind1 + ngridy - 1;
+                    indg[4] = ind1 - ngridy - 1;
+
+                    for(q = 0; q < 5; q++)
+                    {
+                        mg[q] = recon[ind1] + recon[indg[q]];
+                        F[ind0] += 2 * reg_pars[0] * wg[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                     }
                 }
-                
+
                 // Weights for corners.
-                totalwg = 2+1/sqrt(2);
-                wg[0] = 1/totalwg;
-                wg[1] = 1/totalwg;
-                wg[2] = 1/sqrt(2)/totalwg;
-                
+                totalwg = 2 + 1 / sqrt(2);
+                wg[0]   = 1 / totalwg;
+                wg[1]   = 1 / totalwg;
+                wg[2]   = 1 / sqrt(2) / totalwg;
+
                 // (top-left)
                 ind0 = 0;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1+ngridy+1; 
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 + ngridy + 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
 
                 // (top-right)
-                ind0 = (ngridy-1);
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1-1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1+ngridy-1;
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                ind0 = (ngridy - 1);
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 - 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 + ngridy - 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
 
-                // (bottom-left)  
-                ind0 = (ngridx-1)*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1-ngridy;
-                indg[2] = ind1-ngridy+1;
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                // (bottom-left)
+                ind0 = (ngridx - 1) * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 - ngridy;
+                indg[2] = ind1 - ngridy + 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
 
-                // (bottom-right)           
-                ind0 = (ngridy-1) + (ngridx-1)*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1-1;
-                indg[1] = ind1-ngridy;
-                indg[2] = ind1-ngridy-1;
-                        
-                for (q = 0; q < 3; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                // (bottom-right)
+                ind0 = (ngridy - 1) + (ngridx - 1) * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 - 1;
+                indg[1] = ind1 - ngridy;
+                indg[2] = ind1 - ngridy - 1;
+
+                for(q = 0; q < 3; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
 
                 q = 0;
-                for (n = 0; n < ngridx*ngridy; n++) {
+                for(n = 0; n < ngridx * ngridy; n++)
+                {
                     G[q] += sum_dist[n];
                     q++;
                 }
 
-                for (n = 0; n < ngridx; n++) {
-                    for (m = 0; m < ngridy; m++) {
-                        q = m + n*ngridy;
-                        if (F[q] != 0.0) {
-                            ind0 = q + s*ngridx*ngridy;
-                            recon[ind0] = (-G[q]+sqrt(G[q]*G[q]-8*E[q]*F[q]))/(4*F[q]);
+                for(n = 0; n < ngridx; n++)
+                {
+                    for(m = 0; m < ngridy; m++)
+                    {
+                        q = m + n * ngridy;
+                        if(F[q] != 0.0)
+                        {
+                            ind0 = q + s * ngridx * ngridy;
+                            recon[ind0] =
+                                (-G[q] + sqrt(G[q] * G[q] - 8 * E[q] * F[q])) /
+                                (4 * F[q]);
                         }
                     }
                 }
@@ -379,7 +393,7 @@ ospml_quad(
                 free(G);
             }
         }
-            
+
         free(simdata);
     }
 

--- a/src/pml_hybrid.c
+++ b/src/pml_hybrid.c
@@ -1,378 +1,390 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-pml_hybrid(
-    const float *data, int dy, int dt, int dx,
-	const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter,
-	const float *reg_pars)
+void
+pml_hybrid(const float* data, int dy, int dt, int dx, const float* center,
+           const float* theta, float* recon, int ngridx, int ngridy,
+           int num_iter, const float* reg_pars)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi   = (int*) malloc((ngridx + ngridy) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d, i, m, n, q;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data, ind_recon;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, p, d, i, m, n, q;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data, ind_recon;
+    float* sum_dist;
+    float  sum_dist2;
     float *E, *F, *G;
-    int ind0, ind1, indg[8];
-    float totalwg, wg[8], mg[8], rg[8], gammag[8];
+    int    ind0, ind1, indg[8];
+    float  totalwg, wg[8], mg[8], rg[8], gammag[8];
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            E = (float *)calloc((ngridx*ngridy), sizeof(float));
-            F = (float *)calloc((ngridx*ngridy), sizeof(float));
-            G = (float *)calloc((ngridx*ngridy), sizeof(float));
-            
-            // For each projection angle 
-            for (p=0; p<dt; p++)
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
+
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            E        = (float*) calloc((ngridx * ngridy), sizeof(float));
+            F        = (float*) calloc((ngridx * ngridy), sizeof(float));
+            G        = (float*) calloc((ngridx * ngridy), sizeof(float));
+
+            // For each projection angle
+            for(p = 0; p < dt; p++)
             {
-                // Calculate the sin and cos values 
+                // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
-                // For each detector pixel 
-                for (d=0; d<dx; d++)
+                // For each detector pixel
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                        coordx, coordy);
+                    xi = -ngridx - ngridy;
+                    yi = 0.5f * (1 - dx) + d + mov;
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
-                    // (bx, by). The new sorted intersection points are 
-                    // stored in (coorx, coory). Total number of points 
+                    // (bx, by). The new sorted intersection points are
+                    // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by, 
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
-                    // Calculate the distances (dist) between the 
-                    // intersection points (coorx, coory). Find the 
+                    // Calculate the distances (dist) between the
+                    // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist(
-                        ngridx, ngridy, csize, coorx, coory, 
-                        indi, dist);
+                    calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
-                    // Calculate simdata 
-                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indi, dist, recon,
-                        simdata); // Output: simdata
-
+                    // Calculate simdata
+                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize, indi,
+                                 dist, recon,
+                                 simdata);  // Output: simdata
 
                     // Calculate dist*dist
-                    sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++) 
+                    sum_dist2 = 0.0f;
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
+                        sum_dist2 += dist[n] * dist[n];
                         sum_dist[indi[n]] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0) 
+                    if(sum_dist2 != 0.0f)
                     {
-                        ind_data = d+p*dx+s*dt*dx;
-                        ind_recon = s*ngridx*ngridy;
-                        upd = data[ind_data]/simdata[ind_data];
-                        for (n=0; n<csize-1; n++) 
+                        ind_data  = d + p * dx + s * dt * dx;
+                        ind_recon = s * ngridx * ngridy;
+                        upd       = data[ind_data] / simdata[ind_data];
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            E[indi[n]] -= recon[indi[n]+ind_recon]*upd*dist[n];
+                            E[indi[n]] -=
+                                recon[indi[n] + ind_recon] * upd * dist[n];
                         }
                     }
                 }
             }
 
             // Weights for inner neighborhoods.
-            totalwg = 4+4/sqrt(2);
-            wg[0] = 1/totalwg;
-            wg[1] = 1/totalwg;
-            wg[2] = 1/totalwg;
-            wg[3] = 1/totalwg;
-            wg[4] = 1/sqrt(2)/totalwg;
-            wg[5] = 1/sqrt(2)/totalwg;
-            wg[6] = 1/sqrt(2)/totalwg;
-            wg[7] = 1/sqrt(2)/totalwg;
+            totalwg = 4 + 4 / sqrt(2);
+            wg[0]   = 1 / totalwg;
+            wg[1]   = 1 / totalwg;
+            wg[2]   = 1 / totalwg;
+            wg[3]   = 1 / totalwg;
+            wg[4]   = 1 / sqrt(2) / totalwg;
+            wg[5]   = 1 / sqrt(2) / totalwg;
+            wg[6]   = 1 / sqrt(2) / totalwg;
+            wg[7]   = 1 / sqrt(2) / totalwg;
 
             // (inner region)
-            for (n = 1; n < ngridx-1; n++) {
-                for (m = 1; m < ngridy-1; m++) {
-                    ind0 = m + n*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1-1;
-                    indg[2] = ind1+ngridy;
-                    indg[3] = ind1-ngridy;
-                    indg[4] = ind1+ngridy+1; 
-                    indg[5] = ind1+ngridy-1;
-                    indg[6] = ind1-ngridy+1;
-                    indg[7] = ind1-ngridy-1;
-                    
+            for(n = 1; n < ngridx - 1; n++)
+            {
+                for(m = 1; m < ngridy - 1; m++)
+                {
+                    ind0 = m + n * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
 
-                    for (q = 0; q < 8; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        rg[q] = recon[ind1]-recon[indg[q]];
-                        gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                        F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 - 1;
+                    indg[2] = ind1 + ngridy;
+                    indg[3] = ind1 - ngridy;
+                    indg[4] = ind1 + ngridy + 1;
+                    indg[5] = ind1 + ngridy - 1;
+                    indg[6] = ind1 - ngridy + 1;
+                    indg[7] = ind1 - ngridy - 1;
+
+                    for(q = 0; q < 8; q++)
+                    {
+                        mg[q]     = recon[ind1] + recon[indg[q]];
+                        rg[q]     = recon[ind1] - recon[indg[q]];
+                        gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                        F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                     }
                 }
             }
 
             // Weights for edges.
-            totalwg = 3+2/sqrt(2);
-            wg[0] = 1/totalwg;
-            wg[1] = 1/totalwg;
-            wg[2] = 1/totalwg;
-            wg[3] = 1/sqrt(2)/totalwg;
-            wg[4] = 1/sqrt(2)/totalwg;
-            
+            totalwg = 3 + 2 / sqrt(2);
+            wg[0]   = 1 / totalwg;
+            wg[1]   = 1 / totalwg;
+            wg[2]   = 1 / totalwg;
+            wg[3]   = 1 / sqrt(2) / totalwg;
+            wg[4]   = 1 / sqrt(2) / totalwg;
+
             // (top)
-            for (m = 1; m < ngridy-1; m++) {
+            for(m = 1; m < ngridy - 1; m++)
+            {
                 ind0 = m;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1-1;
-                indg[2] = ind1+ngridy;
-                indg[3] = ind1+ngridy+1; 
-                indg[4] = ind1+ngridy-1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 - 1;
+                indg[2] = ind1 + ngridy;
+                indg[3] = ind1 + ngridy + 1;
+                indg[4] = ind1 + ngridy - 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
             }
 
             // (bottom)
-            for (m = 1; m < ngridy-1; m++) {
-                ind0 = m + (ngridx-1)*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1-1;
-                indg[2] = ind1-ngridy;
-                indg[3] = ind1-ngridy+1;
-                indg[4] = ind1-ngridy-1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            for(m = 1; m < ngridy - 1; m++)
+            {
+                ind0 = m + (ngridx - 1) * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 - 1;
+                indg[2] = ind1 - ngridy;
+                indg[3] = ind1 - ngridy + 1;
+                indg[4] = ind1 - ngridy - 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
             }
 
-            // (left)  
-            for (n = 1; n < ngridx-1; n++) {
-                ind0 = n*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1-ngridy;
-                indg[3] = ind1+ngridy+1; 
-                indg[4] = ind1-ngridy+1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            // (left)
+            for(n = 1; n < ngridx - 1; n++)
+            {
+                ind0 = n * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 - ngridy;
+                indg[3] = ind1 + ngridy + 1;
+                indg[4] = ind1 - ngridy + 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
             }
 
-            // (right)                
-            for (n = 1; n < ngridx-1; n++) {
-                ind0 = (ngridy-1) + n*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1-1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1-ngridy;
-                indg[3] = ind1+ngridy-1;
-                indg[4] = ind1-ngridy-1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    rg[q] = recon[ind1]-recon[indg[q]];
-                    gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                    F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            // (right)
+            for(n = 1; n < ngridx - 1; n++)
+            {
+                ind0 = (ngridy - 1) + n * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 - 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 - ngridy;
+                indg[3] = ind1 + ngridy - 1;
+                indg[4] = ind1 - ngridy - 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q]     = recon[ind1] + recon[indg[q]];
+                    rg[q]     = recon[ind1] - recon[indg[q]];
+                    gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                    F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
                 }
             }
-            
+
             // Weights for corners.
-            totalwg = 2+1/sqrt(2);
-            wg[0] = 1/totalwg;
-            wg[1] = 1/totalwg;
-            wg[2] = 1/sqrt(2)/totalwg;
-            
+            totalwg = 2 + 1 / sqrt(2);
+            wg[0]   = 1 / totalwg;
+            wg[1]   = 1 / totalwg;
+            wg[2]   = 1 / sqrt(2) / totalwg;
+
             // (top-left)
             ind0 = 0;
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1+1;
-            indg[1] = ind1+ngridy;
-            indg[2] = ind1+ngridy+1; 
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                rg[q] = recon[ind1]-recon[indg[q]];
-                gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 + 1;
+            indg[1] = ind1 + ngridy;
+            indg[2] = ind1 + ngridy + 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q]     = recon[ind1] + recon[indg[q]];
+                rg[q]     = recon[ind1] - recon[indg[q]];
+                gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
             }
 
             // (top-right)
-            ind0 = (ngridy-1);
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1-1;
-            indg[1] = ind1+ngridy;
-            indg[2] = ind1+ngridy-1;
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                rg[q] = recon[ind1]-recon[indg[q]];
-                gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            ind0 = (ngridy - 1);
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 - 1;
+            indg[1] = ind1 + ngridy;
+            indg[2] = ind1 + ngridy - 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q]     = recon[ind1] + recon[indg[q]];
+                rg[q]     = recon[ind1] - recon[indg[q]];
+                gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
             }
 
-            // (bottom-left)  
-            ind0 = (ngridx-1)*ngridy;
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1+1;
-            indg[1] = ind1-ngridy;
-            indg[2] = ind1-ngridy+1;
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                rg[q] = recon[ind1]-recon[indg[q]];
-                gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            // (bottom-left)
+            ind0 = (ngridx - 1) * ngridy;
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 + 1;
+            indg[1] = ind1 - ngridy;
+            indg[2] = ind1 - ngridy + 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q]     = recon[ind1] + recon[indg[q]];
+                rg[q]     = recon[ind1] - recon[indg[q]];
+                gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
             }
 
-            // (bottom-right)           
-            ind0 = (ngridy-1) + (ngridx-1)*ngridy;
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1-1;
-            indg[1] = ind1-ngridy;
-            indg[2] = ind1-ngridy-1;
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                rg[q] = recon[ind1]-recon[indg[q]];
-                gammag[q] = 1/(1+fabs(rg[q]/reg_pars[1]));
-                F[ind0] += 2*reg_pars[0]*wg[q]*gammag[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*gammag[q]*mg[q];
+            // (bottom-right)
+            ind0 = (ngridy - 1) + (ngridx - 1) * ngridy;
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 - 1;
+            indg[1] = ind1 - ngridy;
+            indg[2] = ind1 - ngridy - 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q]     = recon[ind1] + recon[indg[q]];
+                rg[q]     = recon[ind1] - recon[indg[q]];
+                gammag[q] = 1 / (1 + fabs(rg[q] / reg_pars[1]));
+                F[ind0] += 2 * reg_pars[0] * wg[q] * gammag[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * gammag[q] * mg[q];
             }
 
             q = 0;
-            for (n = 0; n < ngridx*ngridy; n++) {
+            for(n = 0; n < ngridx * ngridy; n++)
+            {
                 G[q] += sum_dist[n];
                 q++;
             }
 
-            for (n = 0; n < ngridx; n++) {
-                for (m = 0; m < ngridy; m++) {
-                    q = m + n*ngridy;
-                    if (F[q] != 0.0) {
-                        ind0 = q + s*ngridx*ngridy;
-                        recon[ind0] = (-G[q]+sqrt(G[q]*G[q]-8*E[q]*F[q]))/(4*F[q]);
+            for(n = 0; n < ngridx; n++)
+            {
+                for(m = 0; m < ngridy; m++)
+                {
+                    q = m + n * ngridy;
+                    if(F[q] != 0.0)
+                    {
+                        ind0 = q + s * ngridx * ngridy;
+                        recon[ind0] =
+                            (-G[q] + sqrt(G[q] * G[q] - 8 * E[q] * F[q])) /
+                            (4 * F[q]);
                     }
                 }
             }

--- a/src/pml_quad.c
+++ b/src/pml_quad.c
@@ -1,359 +1,372 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-pml_quad(
-    const float *data, int dy, int dt, int dx,
-	const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter, const float *reg_pars)
+void
+pml_quad(const float* data, int dy, int dt, int dx, const float* center,
+         const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+         const float* reg_pars)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi   = (int*) malloc((ngridx + ngridy) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d, i, m, n, q;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data, ind_recon;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, p, d, i, m, n, q;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data, ind_recon;
+    float* sum_dist;
+    float  sum_dist2;
     float *E, *F, *G;
-    int ind0, ind1, indg[8];
-    float totalwg, wg[8], mg[8];
+    int    ind0, ind1, indg[8];
+    float  totalwg, wg[8], mg[8];
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s], 
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
-            
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            E = (float *)calloc((ngridx*ngridy), sizeof(float));
-            F = (float *)calloc((ngridx*ngridy), sizeof(float));
-            G = (float *)calloc((ngridx*ngridy), sizeof(float));
-            
-            // For each projection angle 
-            for (p=0; p<dt; p++) 
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
+
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            E        = (float*) calloc((ngridx * ngridy), sizeof(float));
+            F        = (float*) calloc((ngridx * ngridy), sizeof(float));
+            G        = (float*) calloc((ngridx * ngridy), sizeof(float));
+
+            // For each projection angle
+            for(p = 0; p < dt; p++)
             {
-                // Calculate the sin and cos values 
+                // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
-                // For each detector pixel 
-                for (d=0; d<dx; d++) 
+                // For each detector pixel
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                        coordx, coordy);
+                    xi = -ngridx - ngridy;
+                    yi = 0.5f * (1 - dx) + d + mov;
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
-                    // (bx, by). The new sorted intersection points are 
-                    // stored in (coorx, coory). Total number of points 
+                    // (bx, by). The new sorted intersection points are
+                    // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by, 
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
-                    // Calculate the distances (dist) between the 
-                    // intersection points (coorx, coory). Find the 
+                    // Calculate the distances (dist) between the
+                    // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist(
-                        ngridx, ngridy, csize, coorx, coory, 
-                        indi, dist);
+                    calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
-                    // Calculate simdata 
-                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indi, dist, recon,
-                        simdata); // Output: simdata
-
+                    // Calculate simdata
+                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize, indi,
+                                 dist, recon,
+                                 simdata);  // Output: simdata
 
                     // Calculate dist*dist
-                    sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++) 
+                    sum_dist2 = 0.0f;
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
+                        sum_dist2 += dist[n] * dist[n];
                         sum_dist[indi[n]] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0) 
+                    if(sum_dist2 != 0.0f)
                     {
-                        ind_data = d+p*dx+s*dt*dx;
-                        ind_recon = s*ngridx*ngridy;
-                        upd = data[ind_data]/simdata[ind_data];
-                        for (n=0; n<csize-1; n++) 
+                        ind_data  = d + p * dx + s * dt * dx;
+                        ind_recon = s * ngridx * ngridy;
+                        upd       = data[ind_data] / simdata[ind_data];
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            E[indi[n]] -= recon[indi[n]+ind_recon]*upd*dist[n];
+                            E[indi[n]] -=
+                                recon[indi[n] + ind_recon] * upd * dist[n];
                         }
                     }
                 }
             }
 
             // Weights for inner neighborhoods.
-            totalwg = 4+4/sqrt(2);
-            wg[0] = 1/totalwg;
-            wg[1] = 1/totalwg;
-            wg[2] = 1/totalwg;
-            wg[3] = 1/totalwg;
-            wg[4] = 1/sqrt(2)/totalwg;
-            wg[5] = 1/sqrt(2)/totalwg;
-            wg[6] = 1/sqrt(2)/totalwg;
-            wg[7] = 1/sqrt(2)/totalwg;
+            totalwg = 4 + 4 / sqrt(2);
+            wg[0]   = 1 / totalwg;
+            wg[1]   = 1 / totalwg;
+            wg[2]   = 1 / totalwg;
+            wg[3]   = 1 / totalwg;
+            wg[4]   = 1 / sqrt(2) / totalwg;
+            wg[5]   = 1 / sqrt(2) / totalwg;
+            wg[6]   = 1 / sqrt(2) / totalwg;
+            wg[7]   = 1 / sqrt(2) / totalwg;
 
             // (inner region)
-            for (n = 1; n < ngridx-1; n++) {
-                for (m = 1; m < ngridy-1; m++) {
-                    ind0 = m + n*ngridy;
-                    ind1 = ind0 + s*ngridx*ngridy;
-                    
-                    indg[0] = ind1+1;
-                    indg[1] = ind1-1;
-                    indg[2] = ind1+ngridy;
-                    indg[3] = ind1-ngridy;
-                    indg[4] = ind1+ngridy+1; 
-                    indg[5] = ind1+ngridy-1;
-                    indg[6] = ind1-ngridy+1;
-                    indg[7] = ind1-ngridy-1;
-                    
+            for(n = 1; n < ngridx - 1; n++)
+            {
+                for(m = 1; m < ngridy - 1; m++)
+                {
+                    ind0 = m + n * ngridy;
+                    ind1 = ind0 + s * ngridx * ngridy;
 
-                    for (q = 0; q < 8; q++) {
-                        mg[q] = recon[ind1]+recon[indg[q]];
-                        F[ind0] += 2*reg_pars[0]*wg[q];
-                        G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                    indg[0] = ind1 + 1;
+                    indg[1] = ind1 - 1;
+                    indg[2] = ind1 + ngridy;
+                    indg[3] = ind1 - ngridy;
+                    indg[4] = ind1 + ngridy + 1;
+                    indg[5] = ind1 + ngridy - 1;
+                    indg[6] = ind1 - ngridy + 1;
+                    indg[7] = ind1 - ngridy - 1;
+
+                    for(q = 0; q < 8; q++)
+                    {
+                        mg[q] = recon[ind1] + recon[indg[q]];
+                        F[ind0] += 2 * reg_pars[0] * wg[q];
+                        G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                     }
                 }
             }
 
             // Weights for edges.
-            totalwg = 3+2/sqrt(2);
-            wg[0] = 1/totalwg;
-            wg[1] = 1/totalwg;
-            wg[2] = 1/totalwg;
-            wg[3] = 1/sqrt(2)/totalwg;
-            wg[4] = 1/sqrt(2)/totalwg;
-            
+            totalwg = 3 + 2 / sqrt(2);
+            wg[0]   = 1 / totalwg;
+            wg[1]   = 1 / totalwg;
+            wg[2]   = 1 / totalwg;
+            wg[3]   = 1 / sqrt(2) / totalwg;
+            wg[4]   = 1 / sqrt(2) / totalwg;
+
             // (top)
-            for (m = 1; m < ngridy-1; m++) {
+            for(m = 1; m < ngridy - 1; m++)
+            {
                 ind0 = m;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1-1;
-                indg[2] = ind1+ngridy;
-                indg[3] = ind1+ngridy+1; 
-                indg[4] = ind1+ngridy-1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 - 1;
+                indg[2] = ind1 + ngridy;
+                indg[3] = ind1 + ngridy + 1;
+                indg[4] = ind1 + ngridy - 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
             }
 
             // (bottom)
-            for (m = 1; m < ngridy-1; m++) {
-                ind0 = m + (ngridx-1)*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1-1;
-                indg[2] = ind1-ngridy;
-                indg[3] = ind1-ngridy+1;
-                indg[4] = ind1-ngridy-1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            for(m = 1; m < ngridy - 1; m++)
+            {
+                ind0 = m + (ngridx - 1) * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 - 1;
+                indg[2] = ind1 - ngridy;
+                indg[3] = ind1 - ngridy + 1;
+                indg[4] = ind1 - ngridy - 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
             }
 
-            // (left)  
-            for (n = 1; n < ngridx-1; n++) {
-                ind0 = n*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1+1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1-ngridy;
-                indg[3] = ind1+ngridy+1; 
-                indg[4] = ind1-ngridy+1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            // (left)
+            for(n = 1; n < ngridx - 1; n++)
+            {
+                ind0 = n * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 + 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 - ngridy;
+                indg[3] = ind1 + ngridy + 1;
+                indg[4] = ind1 - ngridy + 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
             }
 
-            // (right)                
-            for (n = 1; n < ngridx-1; n++) {
-                ind0 = (ngridy-1) + n*ngridy;
-                ind1 = ind0 + s*ngridx*ngridy;
-                
-                indg[0] = ind1-1;
-                indg[1] = ind1+ngridy;
-                indg[2] = ind1-ngridy;
-                indg[3] = ind1+ngridy-1;
-                indg[4] = ind1-ngridy-1;
-                    
-                for (q = 0; q < 5; q++) {
-                    mg[q] = recon[ind1]+recon[indg[q]];
-                    F[ind0] += 2*reg_pars[0]*wg[q];
-                    G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            // (right)
+            for(n = 1; n < ngridx - 1; n++)
+            {
+                ind0 = (ngridy - 1) + n * ngridy;
+                ind1 = ind0 + s * ngridx * ngridy;
+
+                indg[0] = ind1 - 1;
+                indg[1] = ind1 + ngridy;
+                indg[2] = ind1 - ngridy;
+                indg[3] = ind1 + ngridy - 1;
+                indg[4] = ind1 - ngridy - 1;
+
+                for(q = 0; q < 5; q++)
+                {
+                    mg[q] = recon[ind1] + recon[indg[q]];
+                    F[ind0] += 2 * reg_pars[0] * wg[q];
+                    G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
                 }
             }
-            
+
             // Weights for corners.
-            totalwg = 2+1/sqrt(2);
-            wg[0] = 1/totalwg;
-            wg[1] = 1/totalwg;
-            wg[2] = 1/sqrt(2)/totalwg;
-            
+            totalwg = 2 + 1 / sqrt(2);
+            wg[0]   = 1 / totalwg;
+            wg[1]   = 1 / totalwg;
+            wg[2]   = 1 / sqrt(2) / totalwg;
+
             // (top-left)
             ind0 = 0;
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1+1;
-            indg[1] = ind1+ngridy;
-            indg[2] = ind1+ngridy+1; 
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                F[ind0] += 2*reg_pars[0]*wg[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 + 1;
+            indg[1] = ind1 + ngridy;
+            indg[2] = ind1 + ngridy + 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q] = recon[ind1] + recon[indg[q]];
+                F[ind0] += 2 * reg_pars[0] * wg[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
             }
 
             // (top-right)
-            ind0 = (ngridy-1);
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1-1;
-            indg[1] = ind1+ngridy;
-            indg[2] = ind1+ngridy-1;
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                F[ind0] += 2*reg_pars[0]*wg[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            ind0 = (ngridy - 1);
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 - 1;
+            indg[1] = ind1 + ngridy;
+            indg[2] = ind1 + ngridy - 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q] = recon[ind1] + recon[indg[q]];
+                F[ind0] += 2 * reg_pars[0] * wg[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
             }
 
-            // (bottom-left)  
-            ind0 = (ngridx-1)*ngridy;
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1+1;
-            indg[1] = ind1-ngridy;
-            indg[2] = ind1-ngridy+1;
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                F[ind0] += 2*reg_pars[0]*wg[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            // (bottom-left)
+            ind0 = (ngridx - 1) * ngridy;
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 + 1;
+            indg[1] = ind1 - ngridy;
+            indg[2] = ind1 - ngridy + 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q] = recon[ind1] + recon[indg[q]];
+                F[ind0] += 2 * reg_pars[0] * wg[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
             }
 
             // (bottom-right)
-            ind0 = (ngridy-1) + (ngridx-1)*ngridy;
-            ind1 = ind0 + s*ngridx*ngridy;
-            
-            indg[0] = ind1-1;
-            indg[1] = ind1-ngridy;
-            indg[2] = ind1-ngridy-1;
-                    
-            for (q = 0; q < 3; q++) {
-                mg[q] = recon[ind1]+recon[indg[q]];
-                F[ind0] += 2*reg_pars[0]*wg[q];
-                G[ind0] -= 2*reg_pars[0]*wg[q]*mg[q];
+            ind0 = (ngridy - 1) + (ngridx - 1) * ngridy;
+            ind1 = ind0 + s * ngridx * ngridy;
+
+            indg[0] = ind1 - 1;
+            indg[1] = ind1 - ngridy;
+            indg[2] = ind1 - ngridy - 1;
+
+            for(q = 0; q < 3; q++)
+            {
+                mg[q] = recon[ind1] + recon[indg[q]];
+                F[ind0] += 2 * reg_pars[0] * wg[q];
+                G[ind0] -= 2 * reg_pars[0] * wg[q] * mg[q];
             }
 
             q = 0;
-            for (n = 0; n < ngridx*ngridy; n++) {
+            for(n = 0; n < ngridx * ngridy; n++)
+            {
                 G[q] += sum_dist[n];
                 q++;
             }
 
-            for (n = 0; n < ngridx; n++) {
-                for (m = 0; m < ngridy; m++) {
-                    q = m + n*ngridy;
-                    if (F[q] != 0.0) {
-                        ind0 = q + s*ngridx*ngridy;
-                        recon[ind0] = (-G[q]+sqrt(G[q]*G[q]-8*E[q]*F[q]))/(4*F[q]);
+            for(n = 0; n < ngridx; n++)
+            {
+                for(m = 0; m < ngridy; m++)
+                {
+                    q = m + n * ngridy;
+                    if(F[q] != 0.0)
+                    {
+                        ind0 = q + s * ngridx * ngridy;
+                        recon[ind0] =
+                            (-G[q] + sqrt(G[q] * G[q] - 8 * E[q] * F[q])) /
+                            (4 * F[q]);
                     }
                 }
             }

--- a/src/prep.c
+++ b/src/prep.c
@@ -1,88 +1,86 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "prep.h"
 
-
-DLL void 
-normalize_bg(
-    float* data, int dx, int dy, int dz, int nair)
+DLL void
+normalize_bg(float* data, int dx, int dy, int dz, int nair)
 {
-    int n, m, i, j, iproj;
+    int   n, m, i, j, iproj;
     float air_left, air_right, air_slope, air;
 
-    for (m = 0; m < dx; m++)
+    for(m = 0; m < dx; m++)
     {
         iproj = m * (dz * dy);
-            
-        for (n = 0; n < dy; n++) 
+
+        for(n = 0; n < dy; n++)
         {
             i = iproj + n * dz;
 
-            for (j = 0, air_left = 0, air_right = 0; j < nair; j++) 
+            for(j = 0, air_left = 0, air_right = 0; j < nair; j++)
             {
-                air_left += data[i+j];
-                air_right += data[i+dz-1-j];
+                air_left += data[i + j];
+                air_right += data[i + dz - 1 - j];
             }
-            
-            air_left /= (float)nair;
-            air_right /= (float)nair;
-            
-            if (air_left <= 0.) 
+
+            air_left /= (float) nair;
+            air_right /= (float) nair;
+
+            if(air_left <= 0.)
             {
                 air_left = 1.;
             }
-            if (air_right <= 0.) 
+            if(air_right <= 0.)
             {
                 air_right = 1.;
             }
-            
+
             air_slope = (air_right - air_left) / (dz - 1);
 
-            for (j = 0; j < dz; j++) 
+            for(j = 0; j < dz; j++)
             {
-                air = air_left + air_slope*j;
-                data[i+j] = data[i+j] / air;
+                air         = air_left + air_slope * j;
+                data[i + j] = data[i + j] / air;
             }
         }
     }

--- a/src/project.c
+++ b/src/project.c
@@ -1,128 +1,119 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-project(
-    const float *obj, int oy, int ox, int oz, 
-    float *data, int dy, int dt, int dx,
-    const float *center, const float *theta)
+void
+project(const float* obj, int oy, int ox, int oz, float* data, int dy, int dt,
+        int dx, const float* center, const float* theta)
 {
-    float *gridx = (float *)malloc((ox+1)*sizeof(float));
-    float *gridy = (float *)malloc((oz+1)*sizeof(float));
-    float *coordx = (float *)malloc((oz+1)*sizeof(float));
-    float *coordy = (float *)malloc((ox+1)*sizeof(float));
-    float *ax = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *ay = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *bx = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *by = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *coorx = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *coory = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *dist = (float *)malloc((ox+oz+1)*sizeof(float));
-    int *indi = (int *)malloc((ox+oz+1)*sizeof(int));
+    float* gridx  = (float*) malloc((ox + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((oz + 1) * sizeof(float));
+    float* coordx = (float*) malloc((oz + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ox + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* ay     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* bx     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* by     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* coorx  = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* coory  = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* dist   = (float*) malloc((ox + oz + 1) * sizeof(float));
+    int*   indi   = (int*) malloc((ox + oz + 1) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d;
-    int quadrant;
+    int   s, p, d;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float mov, xi, yi;
-    int asize, bsize, csize;
+    int   asize, bsize, csize;
 
-    preprocessing(ox, oz, dx, center[0], 
-        &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+    preprocessing(ox, oz, dx, center[0], &mov, gridx,
+                  gridy);  // Outputs: mov, gridx, gridy
 
     // For each projection angle
-    for (p=0; p<dt; p++)
+    for(p = 0; p < dt; p++)
     {
-        // Calculate the sin and cos values 
+        // Calculate the sin and cos values
         // of the projection angle and find
         // at which quadrant on the cartesian grid.
-        theta_p = fmod(theta[p], 2*M_PI);
+        theta_p  = fmod(theta[p], 2 * M_PI);
         quadrant = calc_quadrant(theta_p);
-        sin_p = sinf(theta_p);
-        cos_p = cosf(theta_p);
+        sin_p    = sinf(theta_p);
+        cos_p    = cosf(theta_p);
 
-        for (d=0; d<dx; d++) 
+        for(d = 0; d < dx; d++)
         {
             // Calculate coordinates
-            xi = -ox-oz;
-            yi = (1-dx)/2.0+d+mov;
-            calc_coords(
-                ox, oz, xi, yi, sin_p, cos_p, gridx, gridy, 
-                coordx, coordy);
+            xi = -ox - oz;
+            yi = (1 - dx) / 2.0 + d + mov;
+            calc_coords(ox, oz, xi, yi, sin_p, cos_p, gridx, gridy, coordx,
+                        coordy);
 
             // Merge the (coordx, gridy) and (gridx, coordy)
-            trim_coords(
-                ox, oz, coordx, coordy, gridx, gridy, 
-                &asize, ax, ay, &bsize, bx, by);
+            trim_coords(ox, oz, coordx, coordy, gridx, gridy, &asize, ax, ay,
+                        &bsize, bx, by);
 
             // Sort the array of intersection points (ax, ay) and
-            // (bx, by). The new sorted intersection points are 
-            // stored in (coorx, coory). Total number of points 
+            // (bx, by). The new sorted intersection points are
+            // stored in (coorx, coory). Total number of points
             // are csize.
-            sort_intersections(
-                quadrant, asize, ax, ay, bsize, bx, by, 
-                &csize, coorx, coory);
+            sort_intersections(quadrant, asize, ax, ay, bsize, bx, by, &csize,
+                               coorx, coory);
 
-            // Calculate the distances (dist) between the 
-            // intersection points (coorx, coory). Find the 
+            // Calculate the distances (dist) between the
+            // intersection points (coorx, coory). Find the
             // indices of the pixels on the object grid.
-            calc_dist(
-                ox, oz, csize, coorx, coory, 
-                indi, dist);
+            calc_dist(ox, oz, csize, coorx, coory, indi, dist);
 
             // For each slice
-            for (s=0; s<dy; s++) 
+            for(s = 0; s < dy; s++)
             {
-                // Calculate simdata 
-                calc_simdata(s, p, d, ox, oz, dt, dx,
-                    csize, indi, dist, obj,
-                    data); // Output: simulated data
+                // Calculate simdata
+                calc_simdata(s, p, d, ox, oz, dt, dx, csize, indi, dist, obj,
+                             data);  // Output: simulated data
             }
         }
     }
@@ -141,100 +132,92 @@ project(
     free(indi);
 }
 
-
-void 
-project2(
-    const float *objx, const float *objy, int oy, int ox, int oz, 
-    float *data, int dy, int dt, int dx,
-    const float *center, const float *theta)
+void
+project2(const float* objx, const float* objy, int oy, int ox, int oz,
+         float* data, int dy, int dt, int dx, const float* center,
+         const float* theta)
 {
-    float *gridx = (float *)malloc((ox+1)*sizeof(float));
-    float *gridy = (float *)malloc((oz+1)*sizeof(float));
-    float *coordx = (float *)malloc((oz+1)*sizeof(float));
-    float *coordy = (float *)malloc((ox+1)*sizeof(float));
-    float *ax = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *ay = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *bx = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *by = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *coorx = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *coory = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *dist = (float *)malloc((ox+oz+1)*sizeof(float));
-    int *indx = (int *)malloc((ox+oz+1)*sizeof(int));
-    int *indy = (int *)malloc((ox+oz+1)*sizeof(int));
-    int *indi = (int *)malloc((ox+oz+1)*sizeof(int));
+    float* gridx  = (float*) malloc((ox + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((oz + 1) * sizeof(float));
+    float* coordx = (float*) malloc((oz + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ox + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* ay     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* bx     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* by     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* coorx  = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* coory  = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* dist   = (float*) malloc((ox + oz + 1) * sizeof(float));
+    int*   indx   = (int*) malloc((ox + oz + 1) * sizeof(int));
+    int*   indy   = (int*) malloc((ox + oz + 1) * sizeof(int));
+    int*   indi   = (int*) malloc((ox + oz + 1) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d;
-    int quadrant;
+    int   s, p, d;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float srcx, srcy, detx, dety, dv, vx, vy;
     float mov, xi, yi;
-    int asize, bsize, csize;
+    int   asize, bsize, csize;
 
-    preprocessing(ox, oz, dx, center[0], 
-    &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+    preprocessing(ox, oz, dx, center[0], &mov, gridx,
+                  gridy);  // Outputs: mov, gridx, gridy
 
     // For each projection angle
-    for (p=0; p<dt; p++)
+    for(p = 0; p < dt; p++)
     {
-        // Calculate the sin and cos values 
+        // Calculate the sin and cos values
         // of the projection angle and find
         // at which quadrant on the cartesian grid.
-        theta_p = fmod(theta[p], 2*M_PI);
+        theta_p  = fmod(theta[p], 2 * M_PI);
         quadrant = calc_quadrant(theta_p);
-        sin_p = sinf(theta_p);
-        cos_p = cosf(theta_p);
+        sin_p    = sinf(theta_p);
+        cos_p    = cosf(theta_p);
 
-        for (d=0; d<dx; d++) 
+        for(d = 0; d < dx; d++)
         {
-            
             // Calculate coordinates
-            xi = -ox-oz;
-            yi = (1-dx)/2.0+d+mov;
+            xi = -ox - oz;
+            yi = (1 - dx) / 2.0 + d + mov;
 
-            srcx = xi*cos_p-yi*sin_p;
-            srcy = xi*sin_p+yi*cos_p;
-            detx = -xi*cos_p-yi*sin_p;
-            dety = -xi*sin_p+yi*cos_p;
+            srcx = xi * cos_p - yi * sin_p;
+            srcy = xi * sin_p + yi * cos_p;
+            detx = -xi * cos_p - yi * sin_p;
+            dety = -xi * sin_p + yi * cos_p;
 
-            dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-            vx = (srcx-detx)/dv;
-            vy = (srcy-dety)/dv;
+            dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+            vx = (srcx - detx) / dv;
+            vy = (srcy - dety) / dv;
 
-            calc_coords(
-                ox, oz, xi, yi, sin_p, cos_p, gridx, gridy, 
-                coordx, coordy);
+            calc_coords(ox, oz, xi, yi, sin_p, cos_p, gridx, gridy, coordx,
+                        coordy);
 
             // Merge the (coordx, gridy) and (gridx, coordy)
-            trim_coords(
-                ox, oz, coordx, coordy, gridx, gridy, 
-                &asize, ax, ay, &bsize, bx, by);
+            trim_coords(ox, oz, coordx, coordy, gridx, gridy, &asize, ax, ay,
+                        &bsize, bx, by);
 
             // Sort the array of intersection points (ax, ay) and
-            // (bx, by). The new sorted intersection points are 
-            // stored in (coorx, coory). Total number of points 
+            // (bx, by). The new sorted intersection points are
+            // stored in (coorx, coory). Total number of points
             // are csize.
-            sort_intersections(
-                quadrant, asize, ax, ay, bsize, bx, by, 
-                &csize, coorx, coory);
+            sort_intersections(quadrant, asize, ax, ay, bsize, bx, by, &csize,
+                               coorx, coory);
 
-            // Calculate the distances (dist) between the 
-            // intersection points (coorx, coory). Find the 
+            // Calculate the distances (dist) between the
+            // intersection points (coorx, coory). Find the
             // indices of the pixels on the object grid.
-            calc_dist2(
-                ox, oz, csize, coorx, coory, 
-                indx, indy, dist);
+            calc_dist2(ox, oz, csize, coorx, coory, indx, indy, dist);
 
             // For each slice
-            for (s=0; s<dy; s++) 
+            for(s = 0; s < dy; s++)
             {
-                // Calculate simdata 
-                calc_simdata2(s, p, d, ox, oz, dt, dx,
-                    csize, indx, indy, dist, vx, vy, objx, objy,
-                    data); // Output: simulated data
+                // Calculate simdata
+                calc_simdata2(s, p, d, ox, oz, dt, dx, csize, indx, indy, dist,
+                              vx, vy, objx, objy,
+                              data);  // Output: simulated data
             }
         }
     }
@@ -251,103 +234,94 @@ project2(
     free(coory);
     free(dist);
     free(indi);
-    
 }
 
-
-void 
-project3(
-    const float *objx, const float *objy, const float *objz,
-    int oy, int ox, int oz, 
-    float *data, int dy, int dt, int dx,
-    const float *center, const float *theta, int axis)
+void
+project3(const float* objx, const float* objy, const float* objz, int oy,
+         int ox, int oz, float* data, int dy, int dt, int dx,
+         const float* center, const float* theta, int axis)
 {
-    float *gridx = (float *)malloc((ox+1)*sizeof(float));
-    float *gridy = (float *)malloc((oz+1)*sizeof(float));
-    float *coordx = (float *)malloc((oz+1)*sizeof(float));
-    float *coordy = (float *)malloc((ox+1)*sizeof(float));
-    float *ax = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *ay = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *bx = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *by = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *coorx = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *coory = (float *)malloc((ox+oz+2)*sizeof(float));
-    float *dist = (float *)malloc((ox+oz+1)*sizeof(float));
-    int *indx = (int *)malloc((ox+oz+1)*sizeof(int));
-    int *indy = (int *)malloc((ox+oz+1)*sizeof(int));
-    int *indi = (int *)malloc((ox+oz+1)*sizeof(int));
+    float* gridx  = (float*) malloc((ox + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((oz + 1) * sizeof(float));
+    float* coordx = (float*) malloc((oz + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ox + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* ay     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* bx     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* by     = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* coorx  = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* coory  = (float*) malloc((ox + oz + 2) * sizeof(float));
+    float* dist   = (float*) malloc((ox + oz + 1) * sizeof(float));
+    int*   indx   = (int*) malloc((ox + oz + 1) * sizeof(int));
+    int*   indy   = (int*) malloc((ox + oz + 1) * sizeof(int));
+    int*   indi   = (int*) malloc((ox + oz + 1) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d;
-    int quadrant;
+    int   s, p, d;
+    int   quadrant;
     float theta_p, sin_p, cos_p;
     float srcx, srcy, detx, dety, dv, vx, vy;
     float mov, xi, yi;
-    int asize, bsize, csize;
-    
-    preprocessing(ox, oz, dx, center[0], 
-    &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+    int   asize, bsize, csize;
+
+    preprocessing(ox, oz, dx, center[0], &mov, gridx,
+                  gridy);  // Outputs: mov, gridx, gridy
 
     // For each projection angle
-    for (p=0; p<dt; p++)
+    for(p = 0; p < dt; p++)
     {
-        // Calculate the sin and cos values 
+        // Calculate the sin and cos values
         // of the projection angle and find
         // at which quadrant on the cartesian grid.
-        theta_p = fmod(theta[p], 2*M_PI);
+        theta_p  = fmod(theta[p], 2 * M_PI);
         quadrant = calc_quadrant(theta_p);
-        sin_p = sinf(theta_p);
-        cos_p = cosf(theta_p);
+        sin_p    = sinf(theta_p);
+        cos_p    = cosf(theta_p);
 
-        for (d=0; d<dx; d++) 
+        for(d = 0; d < dx; d++)
         {
             // Calculate coordinates
-            xi = -ox-oz;
-            yi = (1-dx)/2.0+d+mov;
+            xi = -ox - oz;
+            yi = (1 - dx) / 2.0 + d + mov;
 
-            srcx = xi*cos_p-yi*sin_p;
-            srcy = xi*sin_p+yi*cos_p;
-            detx = -xi*cos_p-yi*sin_p;
-            dety = -xi*sin_p+yi*cos_p;
+            srcx = xi * cos_p - yi * sin_p;
+            srcy = xi * sin_p + yi * cos_p;
+            detx = -xi * cos_p - yi * sin_p;
+            dety = -xi * sin_p + yi * cos_p;
 
-            dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-            vx = (srcx-detx)/dv;
-            vy = (srcy-dety)/dv;
-            
-            calc_coords(
-                ox, oz, xi, yi, sin_p, cos_p, gridx, gridy, 
-                coordx, coordy);
+            dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+            vx = (srcx - detx) / dv;
+            vy = (srcy - dety) / dv;
+
+            calc_coords(ox, oz, xi, yi, sin_p, cos_p, gridx, gridy, coordx,
+                        coordy);
 
             // Merge the (coordx, gridy) and (gridx, coordy)
-            trim_coords(
-                ox, oz, coordx, coordy, gridx, gridy, 
-                &asize, ax, ay, &bsize, bx, by);
+            trim_coords(ox, oz, coordx, coordy, gridx, gridy, &asize, ax, ay,
+                        &bsize, bx, by);
 
             // Sort the array of intersection points (ax, ay) and
-            // (bx, by). The new sorted intersection points are 
-            // stored in (coorx, coory). Total number of points 
+            // (bx, by). The new sorted intersection points are
+            // stored in (coorx, coory). Total number of points
             // are csize.
-            sort_intersections(
-                quadrant, asize, ax, ay, bsize, bx, by, 
-                &csize, coorx, coory);
+            sort_intersections(quadrant, asize, ax, ay, bsize, bx, by, &csize,
+                               coorx, coory);
 
-            // Calculate the distances (dist) between the 
-            // intersection points (coorx, coory). Find the 
+            // Calculate the distances (dist) between the
+            // intersection points (coorx, coory). Find the
             // indices of the pixels on the object grid.
-            calc_dist2(
-                ox, oz, csize, coorx, coory, 
-                indx, indy, dist);
+            calc_dist2(ox, oz, csize, coorx, coory, indx, indy, dist);
 
             // For each slice
-            for (s=0; s<dy; s++) 
+            for(s = 0; s < dy; s++)
             {
-                // Calculate simdata 
-                calc_simdata3(s, p, d, ox, oz, dt, dx,
-                    csize, indx, indy, dist, vx, vy, objx, objy, objz, axis,
-                    data); // Output: simulated data
+                // Calculate simdata
+                calc_simdata3(s, p, d, ox, oz, dt, dx, csize, indx, indy, dist,
+                              vx, vy, objx, objy, objz, axis,
+                              data);  // Output: simulated data
             }
         }
     }
@@ -364,5 +338,4 @@ project3(
     free(coory);
     free(dist);
     free(indi);
-    
 }

--- a/src/remove_ring.c
+++ b/src/remove_ring.c
@@ -41,568 +41,671 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-//Original author: Justin Blair
+// Original author: Justin Blair
 
 #include "remove_ring.h"
 
 #define INT_MODE_WRAP 0
 #define INT_MODE_REFLECT 1
 
-void remove_ring(
-	float* data, float center_x, float center_y, int dx, int dy,
-	int dz, float thresh_max, float thresh_min, float threshold,
-	int angular_min, int ring_width, int int_mode, int istart, int iend)
+void
+remove_ring(float* data, float center_x, float center_y, int dx, int dy, int dz,
+            float thresh_max, float thresh_min, float threshold,
+            int angular_min, int ring_width, int int_mode, int istart, int iend)
 {
-	int pol_width=0;
-	int pol_height=0;
-	int m_rad = 30;
-	int r_scale = 1;
-	int ang_scale = 1;
-	int m_azi;
-	float** polar_image = 0;
-	float** ring_image = 0;
-	float** image = (float**) calloc(dy, sizeof(float *));
+    int     pol_width  = 0;
+    int     pol_height = 0;
+    int     m_rad      = 30;
+    int     r_scale    = 1;
+    int     ang_scale  = 1;
+    int     m_azi;
+    float** polar_image = 0;
+    float** ring_image  = 0;
+    float** image       = (float**) calloc(dy, sizeof(float*));
 
-	// For each reconstructed slice
-	for (int s = istart; s < iend; s++)
-	{
-		// Fill in reconstructed slice data array into reshaped 2D array
-		image[0] = data + s*dy*dx;
-		for (int i=1; i<dy; i++) {
-			image[i] = image[i-1] + dx;
-		}
-		//Translate Image to Polar Coordinates
-		polar_image = polar_transform(image, center_x, center_y, dx, dy,
-					                  &pol_width, &pol_height, thresh_max,
-					                  thresh_min, r_scale, ang_scale,
-					                  ring_width);
-		m_azi = ceil((float)pol_height/360.0)*angular_min;
-		m_rad = 2*ring_width+1;
+    // For each reconstructed slice
+    for(int s = istart; s < iend; s++)
+    {
+        // Fill in reconstructed slice data array into reshaped 2D array
+        image[0] = data + s * dy * dx;
+        for(int i = 1; i < dy; i++)
+        {
+            image[i] = image[i - 1] + dx;
+        }
+        // Translate Image to Polar Coordinates
+        polar_image = polar_transform(
+            image, center_x, center_y, dx, dy, &pol_width, &pol_height,
+            thresh_max, thresh_min, r_scale, ang_scale, ring_width);
+        m_azi = ceil((float) pol_height / 360.0) * angular_min;
+        m_rad = 2 * ring_width + 1;
 
-		//Call Ring Algorithm
-		ring_filter(&polar_image, pol_height, pol_width,
-					threshold, m_rad, m_azi, ring_width, int_mode);
+        // Call Ring Algorithm
+        ring_filter(&polar_image, pol_height, pol_width, threshold, m_rad,
+                    m_azi, ring_width, int_mode);
 
-		//Translate Ring-Image to Cartesian Coordinates
-		ring_image = inverse_polar_transform(polar_image, center_x, center_y,
-						                     pol_width, pol_height, dx, dy,
-						                     r_scale, ring_width);
+        // Translate Ring-Image to Cartesian Coordinates
+        ring_image =
+            inverse_polar_transform(polar_image, center_x, center_y, pol_width,
+                                    pol_height, dx, dy, r_scale, ring_width);
 
-		//Subtract Ring-Image from Image
-		for(int row=0; row < dy; row++){
-			for(int col=0; col < dx; col++){
-				image[row][col] -= ring_image[row][col];
-			}
-		}
+        // Subtract Ring-Image from Image
+        for(int row = 0; row < dy; row++)
+        {
+            for(int col = 0; col < dx; col++)
+            {
+                image[row][col] -= ring_image[row][col];
+            }
+        }
 
-		//Flatten 2D filtered array
-		for(int j = 0; j < dy; j++){
-			for(int i = 0; i < dx; i++){
-				data[i+(j*dx)+s*dy*dx] = image[j][i];
-			}
-		}
+        // Flatten 2D filtered array
+        for(int j = 0; j < dy; j++)
+        {
+            for(int i = 0; i < dx; i++)
+            {
+                data[i + (j * dx) + s * dy * dx] = image[j][i];
+            }
+        }
 
-		free(polar_image[0]);
-		free(polar_image);
+        free(polar_image[0]);
+        free(polar_image);
 
-		free(ring_image[0]);
-		free(ring_image);
+        free(ring_image[0]);
+        free(ring_image);
+    }
 
-	}
+    free(image);
 
-	free(image);
-
-	return;
+    return;
 }
 
-int min_distance_to_edge(
-	float center_x, float center_y,
-	int width, int height)
+int
+min_distance_to_edge(float center_x, float center_y, int width, int height)
 {
-	int* dist = calloc(4, sizeof(int));
-	dist[0] = center_x+1;
-	dist[1] = center_y+1;
-	dist[2] = width - center_x;
-	dist[3] = height - center_y;
-	int min = dist[0];
-	for(int i = 1; i < 4; i++){
-		if(min > dist[i]){
-			min = dist[i];
-		}
-	}
-	free(dist);
-	return min;
+    int* dist = calloc(4, sizeof(int));
+    dist[0]   = center_x + 1;
+    dist[1]   = center_y + 1;
+    dist[2]   = width - center_x;
+    dist[3]   = height - center_y;
+    int min   = dist[0];
+    for(int i = 1; i < 4; i++)
+    {
+        if(min > dist[i])
+        {
+            min = dist[i];
+        }
+    }
+    free(dist);
+    return min;
 }
 
-
-int iroundf(float x)
+int
+iroundf(float x)
 {
-	return (x != 0.0) ? floor(x+0.5) : 0;
+    return (x != 0.0) ? floor(x + 0.5) : 0;
 }
 
-
-float** polar_transform(
-	float** image, float center_x, float center_y,
-	int width, int height, int* p_pol_width,
-	int* p_pol_height, float thresh_max, float thresh_min,
-	int r_scale, int ang_scale, int overhang)
+float**
+polar_transform(float** image, float center_x, float center_y, int width,
+                int height, int* p_pol_width, int* p_pol_height,
+                float thresh_max, float thresh_min, int r_scale, int ang_scale,
+                int overhang)
 {
-	int max_r = min_distance_to_edge(center_x, center_y, width, height);
-	int pol_width = r_scale*max_r;
-	int pol_height = iroundf((float)ang_scale*2.0*PI*(float)max_r);
-	*p_pol_width = pol_width;
-	*p_pol_height = pol_height;
+    int max_r      = min_distance_to_edge(center_x, center_y, width, height);
+    int pol_width  = r_scale * max_r;
+    int pol_height = iroundf((float) ang_scale * 2.0 * PI * (float) max_r);
+    *p_pol_width   = pol_width;
+    *p_pol_height  = pol_height;
 
-	float* image_block = (float *) calloc(pol_height*pol_width, sizeof(float));
-	float** polar_image = (float **) calloc(pol_height, sizeof(float *));
-	polar_image[0] = image_block;
-	for(int i=1; i<pol_height; i++){
-		polar_image[i] = polar_image[i-1] + pol_width;
-	}
-	for(int row = 0; row<pol_height; row++){
-		for(int r = 0; r <= pol_width - r_scale; r++){
-			float theta = (float)row*2.0*PI/(float)pol_height;
-			float fl_x = (float)r*cos(theta + (PI/(float)pol_height))/(float)r_scale;
-			float fl_y = (float)r*sin(theta + (PI/(float)pol_height))/(float)r_scale;
-			int x = iroundf(fl_x + center_x);
-			int y = iroundf(fl_y + center_y);
+    float* image_block = (float*) calloc(pol_height * pol_width, sizeof(float));
+    float** polar_image = (float**) calloc(pol_height, sizeof(float*));
+    polar_image[0]      = image_block;
+    for(int i = 1; i < pol_height; i++)
+    {
+        polar_image[i] = polar_image[i - 1] + pol_width;
+    }
+    for(int row = 0; row < pol_height; row++)
+    {
+        for(int r = 0; r <= pol_width - r_scale; r++)
+        {
+            float theta = (float) row * 2.0 * PI / (float) pol_height;
+            float fl_x  = (float) r * cos(theta + (PI / (float) pol_height)) /
+                         (float) r_scale;
+            float fl_y = (float) r * sin(theta + (PI / (float) pol_height)) /
+                         (float) r_scale;
+            int x = iroundf(fl_x + center_x);
+            int y = iroundf(fl_y + center_y);
 
-			polar_image[row][r] = image[y][x];
-			if(polar_image[row][r] > thresh_max){
-				polar_image[row][r] = thresh_max;
-			}else if(polar_image[row][r] < thresh_min){
-				polar_image[row][r] = thresh_min;
-			}
-		}
-	}
+            polar_image[row][r] = image[y][x];
+            if(polar_image[row][r] > thresh_max)
+            {
+                polar_image[row][r] = thresh_max;
+            }
+            else if(polar_image[row][r] < thresh_min)
+            {
+                polar_image[row][r] = thresh_min;
+            }
+        }
+    }
 
-	return polar_image;
+    return polar_image;
 }
 
-
-float** inverse_polar_transform(
-	float** polar_image, float center_x,
-    float center_y, int pol_width, int  pol_height,
-    int width, int height, int r_scale,
-    int over_hang)
+float**
+inverse_polar_transform(float** polar_image, float center_x, float center_y,
+                        int pol_width, int pol_height, int width, int height,
+                        int r_scale, int over_hang)
 {
-	float* image_block = (float *) calloc(height*width, sizeof(float));
-	float** cart_image = (float **) calloc(height, sizeof(float *));
-	cart_image[0] = image_block;
-	for(int i = 1; i < height; i++){
-		cart_image[i] = cart_image[i-1]+width;
-	}
-	for(int row=0; row < height; row++){
-		for(int col = 0; col < width; col++){
-			float theta = atan2((float)(row - center_y), (float)(col-center_x)
-								- (PI/(float)pol_height));
-			if(theta < 0){
-				theta+= 2.0*PI;
-			}
-			int pol_row = iroundf(theta*(float)pol_height/(2.0*PI));
-			int pol_col = iroundf((float)r_scale*sqrtf(((float)row-center_y) *
-								  ((float)row-center_y) + ((float)col-center_x)
-								  * ((float)col-center_x)));
-			if(pol_row < pol_height && pol_col < pol_width){
-				cart_image[row][col] = polar_image[pol_row][pol_col];
-			}else{
-				cart_image[row][col] = 0.0;
-			}
-		}
-	}
-	return cart_image;
+    float*  image_block = (float*) calloc(height * width, sizeof(float));
+    float** cart_image  = (float**) calloc(height, sizeof(float*));
+    cart_image[0]       = image_block;
+    for(int i = 1; i < height; i++)
+    {
+        cart_image[i] = cart_image[i - 1] + width;
+    }
+    for(int row = 0; row < height; row++)
+    {
+        for(int col = 0; col < width; col++)
+        {
+            float theta =
+                atan2((float) (row - center_y),
+                      (float) (col - center_x) - (PI / (float) pol_height));
+            if(theta < 0)
+            {
+                theta += 2.0 * PI;
+            }
+            int pol_row = iroundf(theta * (float) pol_height / (2.0 * PI));
+            int pol_col = iroundf(
+                (float) r_scale *
+                sqrtf(((float) row - center_y) * ((float) row - center_y) +
+                      ((float) col - center_x) * ((float) col - center_x)));
+            if(pol_row < pol_height && pol_col < pol_width)
+            {
+                cart_image[row][col] = polar_image[pol_row][pol_col];
+            }
+            else
+            {
+                cart_image[row][col] = 0.0;
+            }
+        }
+    }
+    return cart_image;
 }
 
-
-void swap_float(float* arr, int index1, int index2)
+void
+swap_float(float* arr, int index1, int index2)
 {
-	float store_value = arr[index1];
-	arr[index1] = arr[index2];
-	arr[index2] = store_value;
-	return;
+    float store_value = arr[index1];
+    arr[index1]       = arr[index2];
+    arr[index2]       = store_value;
+    return;
 }
 
-
-void swap_integer(int* arr, int index1, int index2)
+void
+swap_integer(int* arr, int index1, int index2)
 {
-	int store_value = arr[index1];
-	arr[index1] = arr[index2];
-	arr[index2] = store_value;
-	return;
+    int store_value = arr[index1];
+    arr[index1]     = arr[index2];
+    arr[index2]     = store_value;
+    return;
 }
 
-
-int partition(float* median_array, int left, int right, int pivot_index)
+int
+partition(float* median_array, int left, int right, int pivot_index)
 {
-	float pivot_value = median_array[pivot_index];
-	swap_float(median_array, pivot_index, right);
-	int store_index = left;
-	for(int i=left; i < right; i++){
-		if(median_array[i] <= pivot_value){
-			swap_float(median_array, i, store_index);
-			store_index +=1;
-		}
-	}
-	swap_float(median_array, store_index, right);
-	return store_index;
+    float pivot_value = median_array[pivot_index];
+    swap_float(median_array, pivot_index, right);
+    int store_index = left;
+    for(int i = left; i < right; i++)
+    {
+        if(median_array[i] <= pivot_value)
+        {
+            swap_float(median_array, i, store_index);
+            store_index += 1;
+        }
+    }
+    swap_float(median_array, store_index, right);
+    return store_index;
 }
 
-
-int partition_2_arrays(
-	float* median_array, int* position_array, int left,
-    int right, int pivot_index)
+int
+partition_2_arrays(float* median_array, int* position_array, int left,
+                   int right, int pivot_index)
 {
-	float pivot_value = median_array[pivot_index];
-	swap_float(median_array, pivot_index, right);
-	swap_integer(position_array, pivot_index, right);
-	int store_index = left;
-	for(int i=left; i < right; i++){
-		if(median_array[i] <= pivot_value){
-			swap_float(median_array, i, store_index);
-			swap_integer(position_array, i, store_index);
-			store_index +=1;
-		}
-	}
-	swap_float(median_array, store_index, right);
-	swap_integer(position_array, store_index, right);
-	return store_index;
+    float pivot_value = median_array[pivot_index];
+    swap_float(median_array, pivot_index, right);
+    swap_integer(position_array, pivot_index, right);
+    int store_index = left;
+    for(int i = left; i < right; i++)
+    {
+        if(median_array[i] <= pivot_value)
+        {
+            swap_float(median_array, i, store_index);
+            swap_integer(position_array, i, store_index);
+            store_index += 1;
+        }
+    }
+    swap_float(median_array, store_index, right);
+    swap_integer(position_array, store_index, right);
+    return store_index;
 }
 
-
-void quick_sort(float* median_array, int left, int right)
+void
+quick_sort(float* median_array, int left, int right)
 {
-	if(left < right){
-		int pivot_index = (int)((left + right)/2);
-		int new_pivot_index = partition(median_array, left, right,
-										pivot_index);
-		quick_sort(median_array, left, new_pivot_index - 1);
-		quick_sort(median_array, new_pivot_index + 1, right);
-	}
+    if(left < right)
+    {
+        int pivot_index     = (int) ((left + right) / 2);
+        int new_pivot_index = partition(median_array, left, right, pivot_index);
+        quick_sort(median_array, left, new_pivot_index - 1);
+        quick_sort(median_array, new_pivot_index + 1, right);
+    }
 }
 
-
-void quick_sort_2_arrays(
-	float* median_array, int* position_array, int left,
-	int right)
+void
+quick_sort_2_arrays(float* median_array, int* position_array, int left,
+                    int right)
 {
-	if(left < right){
-		int pivot_index = (int)((left + right)/2);
-		int new_pivot_index = partition_2_arrays(median_array, position_array,
-												 left, right, pivot_index);
-		quick_sort_2_arrays(median_array, position_array, left,
-							new_pivot_index - 1);
-		quick_sort_2_arrays(median_array, position_array, new_pivot_index + 1,
-							right);
-	}
-	return;
+    if(left < right)
+    {
+        int pivot_index     = (int) ((left + right) / 2);
+        int new_pivot_index = partition_2_arrays(median_array, position_array,
+                                                 left, right, pivot_index);
+        quick_sort_2_arrays(median_array, position_array, left,
+                            new_pivot_index - 1);
+        quick_sort_2_arrays(median_array, position_array, new_pivot_index + 1,
+                            right);
+    }
+    return;
 }
 
-
-void bubble_2_arrays(
-	float* median_array, int* position_array, int index,
-	int length)
+void
+bubble_2_arrays(float* median_array, int* position_array, int index, int length)
 {
-	if(index > 0 && index < length -1){
-		if(median_array[index] < median_array[index-1]){
-			swap_float(median_array, index, index-1);
-			swap_integer(position_array, index, index-1);
-			bubble_2_arrays(median_array, position_array, index-1, length);
-		}else if(median_array[index] > median_array[index+1]){
-			swap_float(median_array, index, index+1);
-			swap_integer(position_array, index, index+1);
-			bubble_2_arrays(median_array, position_array, index+1, length);
-		}
-	}else if(index == 0){
-		if(median_array[index] > median_array[index+1]){
-			swap_float(median_array, index, index+1);
-			swap_integer(position_array, index, index+1);
-			bubble_2_arrays(median_array, position_array, index+1, length);
-		}
-	}else if(index == length -1){
-		 if(median_array[index] < median_array[index-1]){
-			swap_float(median_array, index, index-1);
-			swap_integer(position_array, index, index-1);
-			bubble_2_arrays(median_array, position_array, index-1, length);
-		}
-	}
-	return;
+    if(index > 0 && index < length - 1)
+    {
+        if(median_array[index] < median_array[index - 1])
+        {
+            swap_float(median_array, index, index - 1);
+            swap_integer(position_array, index, index - 1);
+            bubble_2_arrays(median_array, position_array, index - 1, length);
+        }
+        else if(median_array[index] > median_array[index + 1])
+        {
+            swap_float(median_array, index, index + 1);
+            swap_integer(position_array, index, index + 1);
+            bubble_2_arrays(median_array, position_array, index + 1, length);
+        }
+    }
+    else if(index == 0)
+    {
+        if(median_array[index] > median_array[index + 1])
+        {
+            swap_float(median_array, index, index + 1);
+            swap_integer(position_array, index, index + 1);
+            bubble_2_arrays(median_array, position_array, index + 1, length);
+        }
+    }
+    else if(index == length - 1)
+    {
+        if(median_array[index] < median_array[index - 1])
+        {
+            swap_float(median_array, index, index - 1);
+            swap_integer(position_array, index, index - 1);
+            bubble_2_arrays(median_array, position_array, index - 1, length);
+        }
+    }
+    return;
 }
 
-
-void median_filter_fast_1D(
-	float*** filtered_image, float*** image, int start_row,
-	int start_col, int end_row, int end_col, char axis,
-	int kernel_rad, int filter_width, int width, int height)
+void
+median_filter_fast_1D(float*** filtered_image, float*** image, int start_row,
+                      int start_col, int end_row, int end_col, char axis,
+                      int kernel_rad, int filter_width, int width, int height)
 {
-	int row, col;
-	float* median_array = (float*) calloc(2*kernel_rad+1, sizeof(float));
-	int* position_array = (int*) calloc(2*kernel_rad+1, sizeof(int));
-	if(axis == 'x'){
-		for(row = start_row; row <= end_row; row++){
-			col = start_col;
-			for(int n = -kernel_rad; n < kernel_rad + 1; n++){
-				int adjusted_col = col + n;
-				int adjusted_row = row;
-				if(adjusted_col < 0){
-					adjusted_col = -adjusted_col;
-					if(row < height/2){
-						adjusted_row += height/2;
-					}else{
-						adjusted_row -= height/2;
-					}
-					median_array[n+kernel_rad] = image[0][adjusted_row][adjusted_col];
-				}else{
-					median_array[n+kernel_rad] = image[0][row][adjusted_col];
-				}
-				position_array[n+kernel_rad] = n+kernel_rad;
-			}
-			//Sort the array
-			quick_sort_2_arrays(median_array, position_array, 0, 2*kernel_rad);
-			filtered_image[0][row][col] = median_array[kernel_rad];
+    int    row, col;
+    float* median_array   = (float*) calloc(2 * kernel_rad + 1, sizeof(float));
+    int*   position_array = (int*) calloc(2 * kernel_rad + 1, sizeof(int));
+    if(axis == 'x')
+    {
+        for(row = start_row; row <= end_row; row++)
+        {
+            col = start_col;
+            for(int n = -kernel_rad; n < kernel_rad + 1; n++)
+            {
+                int adjusted_col = col + n;
+                int adjusted_row = row;
+                if(adjusted_col < 0)
+                {
+                    adjusted_col = -adjusted_col;
+                    if(row < height / 2)
+                    {
+                        adjusted_row += height / 2;
+                    }
+                    else
+                    {
+                        adjusted_row -= height / 2;
+                    }
+                    median_array[n + kernel_rad] =
+                        image[0][adjusted_row][adjusted_col];
+                }
+                else
+                {
+                    median_array[n + kernel_rad] = image[0][row][adjusted_col];
+                }
+                position_array[n + kernel_rad] = n + kernel_rad;
+            }
+            // Sort the array
+            quick_sort_2_arrays(median_array, position_array, 0,
+                                2 * kernel_rad);
+            filtered_image[0][row][col] = median_array[kernel_rad];
 
-			//Roll filter along the rest of the row
-			for(col = start_col+1; col <= end_col; col++){
-				float next_value = 0.0;
-				int next_value_col = col + kernel_rad;
-				if (next_value_col < width){
-					next_value = image[0][row][next_value_col];
-				}
-				int last_value_index = 0;
-				for(int i = 0; i < 2*kernel_rad+1; i++){
-					position_array[i] -= 1;
-					if(position_array[i] < 0){
-						last_value_index = i;
-						position_array[i] = 2*kernel_rad;
-						median_array[i] = next_value;
-					}
-				}
-				bubble_2_arrays(median_array, position_array, last_value_index, 2*kernel_rad+1);
-				filtered_image[0][row][col] = median_array[kernel_rad];
-			}
-		}
-	}else if(axis == 'y'){
-		for(col = start_col; col <= end_col; col++){
-			row = start_row;
-			for(int n = -kernel_rad; n < kernel_rad + 1; n++){
-				int adjusted_row = row + n;
-				int adjusted_col = col;
-				if(adjusted_row < 0){
-				// Handle edge cases
-					adjusted_row += height;
-					median_array[n+kernel_rad] = image[0][adjusted_row][adjusted_col];
-				}else{
-					median_array[n+kernel_rad] = image[0][adjusted_row][adjusted_col];
-				}
-				position_array[n+kernel_rad] = n+kernel_rad;
-			}
-			//Sort the array
-			quick_sort_2_arrays(median_array, position_array, 0, 2*kernel_rad);
-			filtered_image[0][row][col] = median_array[kernel_rad];
+            // Roll filter along the rest of the row
+            for(col = start_col + 1; col <= end_col; col++)
+            {
+                float next_value     = 0.0;
+                int   next_value_col = col + kernel_rad;
+                if(next_value_col < width)
+                {
+                    next_value = image[0][row][next_value_col];
+                }
+                int last_value_index = 0;
+                for(int i = 0; i < 2 * kernel_rad + 1; i++)
+                {
+                    position_array[i] -= 1;
+                    if(position_array[i] < 0)
+                    {
+                        last_value_index  = i;
+                        position_array[i] = 2 * kernel_rad;
+                        median_array[i]   = next_value;
+                    }
+                }
+                bubble_2_arrays(median_array, position_array, last_value_index,
+                                2 * kernel_rad + 1);
+                filtered_image[0][row][col] = median_array[kernel_rad];
+            }
+        }
+    }
+    else if(axis == 'y')
+    {
+        for(col = start_col; col <= end_col; col++)
+        {
+            row = start_row;
+            for(int n = -kernel_rad; n < kernel_rad + 1; n++)
+            {
+                int adjusted_row = row + n;
+                int adjusted_col = col;
+                if(adjusted_row < 0)
+                {
+                    // Handle edge cases
+                    adjusted_row += height;
+                    median_array[n + kernel_rad] =
+                        image[0][adjusted_row][adjusted_col];
+                }
+                else
+                {
+                    median_array[n + kernel_rad] =
+                        image[0][adjusted_row][adjusted_col];
+                }
+                position_array[n + kernel_rad] = n + kernel_rad;
+            }
+            // Sort the array
+            quick_sort_2_arrays(median_array, position_array, 0,
+                                2 * kernel_rad);
+            filtered_image[0][row][col] = median_array[kernel_rad];
 
-			//Roll filter along the rest of the col
-			for(row = start_row+1; row <= end_row; row++){
-				float next_value = 0.0;
-				int next_value_row = row + kernel_rad;
-				if (next_value_row < height){
-					next_value = image[0][next_value_row][col];
-				}
-				int last_value_index = 0;
-				for(int i = 0; i < 2*kernel_rad+1; i++){
-					position_array[i] -= 1;
-					if(position_array[i] < 0){
-						last_value_index = i;
-						position_array[i] = 2*kernel_rad;
-						median_array[i] = next_value;
-					}
-				}
-				bubble_2_arrays(median_array, position_array, last_value_index, 2*kernel_rad+1);
-				filtered_image[0][row][col] = median_array[kernel_rad];
-			}
-		}
-	}
-	free(median_array);
-	free(position_array);
-	return;
+            // Roll filter along the rest of the col
+            for(row = start_row + 1; row <= end_row; row++)
+            {
+                float next_value     = 0.0;
+                int   next_value_row = row + kernel_rad;
+                if(next_value_row < height)
+                {
+                    next_value = image[0][next_value_row][col];
+                }
+                int last_value_index = 0;
+                for(int i = 0; i < 2 * kernel_rad + 1; i++)
+                {
+                    position_array[i] -= 1;
+                    if(position_array[i] < 0)
+                    {
+                        last_value_index  = i;
+                        position_array[i] = 2 * kernel_rad;
+                        median_array[i]   = next_value;
+                    }
+                }
+                bubble_2_arrays(median_array, position_array, last_value_index,
+                                2 * kernel_rad + 1);
+                filtered_image[0][row][col] = median_array[kernel_rad];
+            }
+        }
+    }
+    free(median_array);
+    free(position_array);
+    return;
 }
 
-
-/* Runs slightly faster than the above mean filter, but floating-point rounding causes errors on
- * the order of 1E-10. Should be small enough error to not care about, but be careful...
+/* Runs slightly faster than the above mean filter, but floating-point rounding
+ * causes errors on the order of 1E-10. Should be small enough error to not care
+ * about, but be careful...
  */
-void mean_filter_fast_1D(
-	float*** filtered_image, float*** image,
- 	int start_row, int start_col, int end_row, int end_col,
-	int int_mode, int kernel_rad, int width, int height)
+void
+mean_filter_fast_1D(float*** filtered_image, float*** image, int start_row,
+                    int start_col, int end_row, int end_col, int int_mode,
+                    int kernel_rad, int width, int height)
 {
-	long double mean = 0, sum = 0, previous_sum = 0, num_elems = (double)(2*kernel_rad + 1);
-	int row, col;
-	if(int_mode == INT_MODE_WRAP){
-		//iterate over each row of the image subset
-		for(col = start_col; col <= end_col; col++){
-			sum = 0;
-			//calculate average of first element of the column
-			for(int n = - kernel_rad; n < (kernel_rad + 1); n++){
-				row = n + start_row;
-				if(row < 0){
-					row += height;
-				}else if(row >= height){
-					row -= height;
-				}
-				sum += image[0][row][col];
-			}
-			mean = sum/num_elems;
-			filtered_image[0][start_row][col] = mean;
-			previous_sum = sum;
+    long double mean = 0, sum = 0, previous_sum = 0,
+                num_elems = (double) (2 * kernel_rad + 1);
+    int row, col;
+    if(int_mode == INT_MODE_WRAP)
+    {
+        // iterate over each row of the image subset
+        for(col = start_col; col <= end_col; col++)
+        {
+            sum = 0;
+            // calculate average of first element of the column
+            for(int n = -kernel_rad; n < (kernel_rad + 1); n++)
+            {
+                row = n + start_row;
+                if(row < 0)
+                {
+                    row += height;
+                }
+                else if(row >= height)
+                {
+                    row -= height;
+                }
+                sum += image[0][row][col];
+            }
+            mean                              = sum / num_elems;
+            filtered_image[0][start_row][col] = mean;
+            previous_sum                      = sum;
 
-			for(row = start_row+1; row <= end_row; row++){
-				int last_row = (row - 1) - (kernel_rad);
-				int next_row = row + (kernel_rad);
-				if(last_row < 0){
-					last_row += height;
-				}
-				if(next_row >= height){
-					next_row -= height;
-				}
-				sum = previous_sum - image[0][last_row][col] + image[0][next_row][col];
-				if(image[0][row][col] != 0){
-					filtered_image[0][row][col] = sum/num_elems;
-				}else{
-					filtered_image[0][row][col] = 0.0;
-				}
-				previous_sum = sum;
-			}
-		}
-	}else if(int_mode == INT_MODE_REFLECT){
-		//iterate over each column of the image subset
-		for(col = start_col; col <= end_col; col++){
-			sum = 0;
-			//calculate average of first element of the column
-			for(int n = - kernel_rad; n < (kernel_rad + 1); n++){
-				row = n;
-				if(row < 0){
-					row = -row;
-				}else if(row >= height/2){
-					row = height/2 - (row - height/2) - 2;
-				}
-				sum += image[0][row][col];
-			}
-			mean = sum/num_elems;
-			filtered_image[0][0][col] = mean;
-			previous_sum = sum;
+            for(row = start_row + 1; row <= end_row; row++)
+            {
+                int last_row = (row - 1) - (kernel_rad);
+                int next_row = row + (kernel_rad);
+                if(last_row < 0)
+                {
+                    last_row += height;
+                }
+                if(next_row >= height)
+                {
+                    next_row -= height;
+                }
+                sum = previous_sum - image[0][last_row][col] +
+                      image[0][next_row][col];
+                if(image[0][row][col] != 0)
+                {
+                    filtered_image[0][row][col] = sum / num_elems;
+                }
+                else
+                {
+                    filtered_image[0][row][col] = 0.0;
+                }
+                previous_sum = sum;
+            }
+        }
+    }
+    else if(int_mode == INT_MODE_REFLECT)
+    {
+        // iterate over each column of the image subset
+        for(col = start_col; col <= end_col; col++)
+        {
+            sum = 0;
+            // calculate average of first element of the column
+            for(int n = -kernel_rad; n < (kernel_rad + 1); n++)
+            {
+                row = n;
+                if(row < 0)
+                {
+                    row = -row;
+                }
+                else if(row >= height / 2)
+                {
+                    row = height / 2 - (row - height / 2) - 2;
+                }
+                sum += image[0][row][col];
+            }
+            mean                      = sum / num_elems;
+            filtered_image[0][0][col] = mean;
+            previous_sum              = sum;
 
-			for(row = 1; row < height/2; row++){
-				int last_row = (row - 1) - (kernel_rad);
-				int next_row = row + (kernel_rad);
-				if(last_row < 0){
-					last_row = -last_row;
-				}
-				if(next_row >= height/2){
-					next_row = height/2 - (next_row - height/2) - 2;
-				}
-				sum = previous_sum - image[0][last_row][col] + image[0][next_row][col];
-				if(image[0][row][col] != 0){
-					filtered_image[0][row][col] = sum/num_elems;
-				}else{
-					filtered_image[0][row][col] = 0.0;
-				}
-				previous_sum = sum;
-			}
+            for(row = 1; row < height / 2; row++)
+            {
+                int last_row = (row - 1) - (kernel_rad);
+                int next_row = row + (kernel_rad);
+                if(last_row < 0)
+                {
+                    last_row = -last_row;
+                }
+                if(next_row >= height / 2)
+                {
+                    next_row = height / 2 - (next_row - height / 2) - 2;
+                }
+                sum = previous_sum - image[0][last_row][col] +
+                      image[0][next_row][col];
+                if(image[0][row][col] != 0)
+                {
+                    filtered_image[0][row][col] = sum / num_elems;
+                }
+                else
+                {
+                    filtered_image[0][row][col] = 0.0;
+                }
+                previous_sum = sum;
+            }
 
-			sum = 0;
-			//calculate average of first element of the column
-			for(int n = - kernel_rad; n < (kernel_rad + 1); n++){
-				row = n + height/2;
-				if(row < height/2){
-					row = height/2 + (height/2 - row);
-				}else if(row >= height){
-					row = height - (row - height) - 2;
-				}
-				sum += image[0][row][col];
-			}
-			mean = sum/num_elems;
-			filtered_image[0][height/2][col] = mean;
-			previous_sum = sum;
+            sum = 0;
+            // calculate average of first element of the column
+            for(int n = -kernel_rad; n < (kernel_rad + 1); n++)
+            {
+                row = n + height / 2;
+                if(row < height / 2)
+                {
+                    row = height / 2 + (height / 2 - row);
+                }
+                else if(row >= height)
+                {
+                    row = height - (row - height) - 2;
+                }
+                sum += image[0][row][col];
+            }
+            mean                               = sum / num_elems;
+            filtered_image[0][height / 2][col] = mean;
+            previous_sum                       = sum;
 
-			for(row = height/2+1; row < height; row++){
-				int last_row = (row - 1) - (kernel_rad);
-				int next_row = row + (kernel_rad);
-				if(last_row < height/2){
-					last_row = height/2 + (height/2 - last_row);
-				}
-				if(next_row >= height){
-					next_row = height - (next_row - height) - 2;
-				}
-				sum = previous_sum - image[0][last_row][col] + image[0][next_row][col];
-				if(image[0][row][col] != 0){
-					filtered_image[0][row][col] = sum/num_elems;
-				}else{
-					filtered_image[0][row][col] = 0.0;
-				}
-				previous_sum = sum;
-
-			}
-
-		}
-	}
-	return;
+            for(row = height / 2 + 1; row < height; row++)
+            {
+                int last_row = (row - 1) - (kernel_rad);
+                int next_row = row + (kernel_rad);
+                if(last_row < height / 2)
+                {
+                    last_row = height / 2 + (height / 2 - last_row);
+                }
+                if(next_row >= height)
+                {
+                    next_row = height - (next_row - height) - 2;
+                }
+                sum = previous_sum - image[0][last_row][col] +
+                      image[0][next_row][col];
+                if(image[0][row][col] != 0)
+                {
+                    filtered_image[0][row][col] = sum / num_elems;
+                }
+                else
+                {
+                    filtered_image[0][row][col] = 0.0;
+                }
+                previous_sum = sum;
+            }
+        }
+    }
+    return;
 }
 
-
-void ring_filter(
-	float*** polar_image, int pol_height, int pol_width,
-	float threshold, int m_rad, int m_azi, int ring_width, int int_mode)
+void
+ring_filter(float*** polar_image, int pol_height, int pol_width,
+            float threshold, int m_rad, int m_azi, int ring_width, int int_mode)
 {
+    float* image_block = (float*) calloc(pol_height * pol_width, sizeof(float));
+    float** filtered_image = (float**) calloc(pol_height, sizeof(float*));
+    filtered_image[0]      = image_block;
+    for(int i = 1; i < pol_height; i++)
+    {
+        filtered_image[i] = filtered_image[i - 1] + pol_width;
+    }
 
-	float* image_block = (float *) calloc(pol_height*pol_width, sizeof(float ));
-	float** filtered_image = (float **) calloc(pol_height, sizeof(float*));
-	filtered_image[0] = image_block;
-	for(int i=1; i<pol_height; i++){
-		filtered_image[i] = filtered_image[i-1] + pol_width;
-	}
+    median_filter_fast_1D(&filtered_image, polar_image, 0, 0, pol_height - 1,
+                          pol_width / 3 - 1, 'x', m_rad / 3, ring_width,
+                          pol_width, pol_height);
+    median_filter_fast_1D(&filtered_image, polar_image, 0, pol_width / 3,
+                          pol_height - 1, 2 * pol_width / 3 - 1, 'x',
+                          2 * m_rad / 3, ring_width, pol_width, pol_height);
+    median_filter_fast_1D(&filtered_image, polar_image, 0, 2 * pol_width / 3,
+                          pol_height - 1, pol_width - 1, 'x', m_rad, ring_width,
+                          pol_width, pol_height);
 
-	median_filter_fast_1D(&filtered_image, polar_image, 0, 0, pol_height-1,
-						  pol_width/3 -1, 'x', m_rad/3, ring_width, pol_width,
-						  pol_height);
-	median_filter_fast_1D(&filtered_image, polar_image, 0, pol_width/3,
-						  pol_height-1, 2*pol_width/3 -1, 'x', 2*m_rad/3,
-						  ring_width, pol_width, pol_height);
-	median_filter_fast_1D(&filtered_image, polar_image, 0, 2*pol_width/3,
-		 				  pol_height-1, pol_width-1, 'x', m_rad, ring_width,
-		 				  pol_width, pol_height);
+    // subtract filtered image from polar image to get difference image & do
+    // last thresholding
 
-	//subtract filtered image from polar image to get difference image & do last thresholding
+    for(int row = 0; row < pol_height; row++)
+    {
+        for(int col = 0; col < pol_width; col++)
+        {
+            polar_image[0][row][col] -= filtered_image[row][col];
+            if(polar_image[0][row][col] > threshold ||
+               polar_image[0][row][col] < -threshold)
+            {
+                polar_image[0][row][col] = 0;
+            }
+        }
+    }
 
-	for(int row = 0; row < pol_height; row++){
-		for(int col = 0; col <  pol_width; col++){
-			polar_image[0][row][col] -= filtered_image[row][col];
-			if(polar_image[0][row][col] > threshold || polar_image[0][row][col] < -threshold){
-				polar_image[0][row][col] = 0;
-			}
-		}
-	}
+    /* Do Azimuthal filter #2 (faster mean, does whole column in one call)
+     * using different kernel sizes for the different regions of the image
+     * (based on radius)
+     */
 
-	/* Do Azimuthal filter #2 (faster mean, does whole column in one call)
-	 * using different kernel sizes for the different regions of the image
-	 * (based on radius)
-	 */
+    mean_filter_fast_1D(&filtered_image, polar_image, 0, 0, pol_height - 1,
+                        pol_width / 3 - 1, int_mode, m_azi / 3, pol_width,
+                        pol_height);
+    mean_filter_fast_1D(&filtered_image, polar_image, 0, pol_width / 3,
+                        pol_height - 1, 2 * pol_width / 3 - 1, int_mode,
+                        2 * m_azi / 3, pol_width, pol_height);
+    mean_filter_fast_1D(&filtered_image, polar_image, 0, 2 * pol_width / 3,
+                        pol_height - 1, pol_width - 1, int_mode, m_azi,
+                        pol_width, pol_height);
 
-	mean_filter_fast_1D(&filtered_image, polar_image, 0, 0, pol_height-1,
-			    pol_width/3-1, int_mode, m_azi/3, pol_width, pol_height);
-	mean_filter_fast_1D(&filtered_image, polar_image, 0, pol_width/3,
-			    pol_height-1, 2*pol_width/3-1, int_mode, 2*m_azi/3,
-			    pol_width, pol_height);
-	mean_filter_fast_1D(&filtered_image, polar_image, 0, 2*pol_width/3,
-			    pol_height-1, pol_width-1, int_mode, m_azi, pol_width,
-			    pol_height);
+    // Set "polar_image" to the fully filtered data
+    for(int row = 0; row < pol_height; row++)
+    {
+        for(int col = 0; col < pol_width; col++)
+        {
+            polar_image[0][row][col] = filtered_image[row][col];
+        }
+    }
 
-	//Set "polar_image" to the fully filtered data
-	for(int row = 0; row < pol_height; row++){
-		for(int col = 0; col < pol_width; col++){
-			polar_image[0][row][col] = filtered_image[row][col];
-		}
-	}
-
-	free(filtered_image[0]);
-	free(filtered_image);
-	return;
+    free(filtered_image[0]);
+    free(filtered_image);
+    return;
 }

--- a/src/sirt.c
+++ b/src/sirt.c
@@ -1,169 +1,162 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-sirt(
-    const float *data, int dy, int dt, int dx,
-	const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter)
+void
+sirt(const float* data, int dy, int dt, int dx, const float* center,
+     const float* theta, float* recon, int ngridx, int ngridy, int num_iter)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi   = (int*) malloc((ngridx + ngridy) * sizeof(int));
 
-    assert(coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL && indi != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL);
 
-    int s, p, d, i, n;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data, ind_recon;
-    float *sum_dist;
-    float sum_dist2;
-    float *update;
+    int    s, p, d, i, n;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data, ind_recon;
+    float* sum_dist;
+    float  sum_dist2;
+    float* update;
 
-    for (i=0; i<num_iter; i++) 
+    for(i = 0; i < num_iter; i++)
     {
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s], 
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update = (float *)calloc((ngridx*ngridy), sizeof(float));
-            
-            // For each projection angle 
-            for (p=0; p<dt; p++) 
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update   = (float*) calloc((ngridx * ngridy), sizeof(float));
+
+            // For each projection angle
+            for(p = 0; p < dt; p++)
             {
-                // Calculate the sin and cos values 
+                // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
-                // For each detector pixel 
-                for (d=0; d<dx; d++) 
+                // For each detector pixel
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                        coordx, coordy);
+                    xi = -ngridx - ngridy;
+                    yi = 0.5f * (1 - dx) + d + mov;
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
-                    // (bx, by). The new sorted intersection points are 
-                    // stored in (coorx, coory). Total number of points 
+                    // (bx, by). The new sorted intersection points are
+                    // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by, 
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
-                    // Calculate the distances (dist) between the 
-                    // intersection points (coorx, coory). Find the 
+                    // Calculate the distances (dist) between the
+                    // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist(
-                        ngridx, ngridy, csize, coorx, coory, 
-                        indi, dist);
+                    calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
-                    // Calculate simdata 
-                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indi, dist, recon,
-                        simdata); // Output: simdata
-
+                    // Calculate simdata
+                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize, indi,
+                                 dist, recon,
+                                 simdata);  // Output: simdata
 
                     // Calculate dist*dist
-                    sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++) 
+                    sum_dist2 = 0.0f;
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
+                        sum_dist2 += dist[n] * dist[n];
                         sum_dist[indi[n]] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0) 
+                    if(sum_dist2 != 0.0f)
                     {
-                        ind_data = d+p*dx+s*dt*dx;
-                        upd = (data[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++) 
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update[indi[n]] += upd*dist[n];
+                            update[indi[n]] += upd * dist[n];
                         }
                     }
                 }
             }
 
-            for (n = 0; n < ngridx*ngridy; n++) {
-                if (sum_dist[n] != 0.0) {
-                    ind_recon = s*ngridx*ngridy;
-                    recon[n+ind_recon] += update[n]/sum_dist[n];
+            for(n = 0; n < ngridx * ngridy; n++)
+            {
+                if(sum_dist[n] != 0.0f)
+                {
+                    ind_recon = s * ngridx * ngridy;
+                    recon[n + ind_recon] += update[n] / sum_dist[n];
                 }
             }
 

--- a/src/stripe.c
+++ b/src/stripe.c
@@ -1,94 +1,97 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "stripe.h"
 
-void 
-remove_stripe_sf(
-    float *data, int dx, int dy, int dz, int size, int istart, int iend)
+void
+remove_stripe_sf(float* data, int dx, int dy, int dz, int size, int istart,
+                 int iend)
 {
-    int i, j, k, p, s;
-    float *avrage_row;
-    float *smooth_row;
+    int    i, j, k, p, s;
+    float* avrage_row;
+    float* smooth_row;
 
     // For each slice.
-    for (s=istart; s<iend; s++)
+    for(s = istart; s < iend; s++)
     {
-        avrage_row = (float *) calloc(dz, sizeof(float));
-        smooth_row = (float *) calloc(dz, sizeof(float));
-        
+        avrage_row = (float*) calloc(dz, sizeof(float));
+        smooth_row = (float*) calloc(dz, sizeof(float));
+
         // For each pixel.
-        for (j=0; j<dz; j++)
+        for(j = 0; j < dz; j++)
         {
             // For each projection.
-            for (p=0; p<dx; p++)
+            for(p = 0; p < dx; p++)
             {
-                avrage_row[j] += data[j+s*dz+p*dy*dz]/dx;
+                avrage_row[j] += data[j + s * dz + p * dy * dz] / dx;
             }
         }
 
         // We have now computed the average row of the sinogram.
         // Smooth it
-        for (i=0; i<dz; i++)
+        for(i = 0; i < dz; i++)
         {
             smooth_row[i] = 0;
-            for (j=0; j<size; j++)
+            for(j = 0; j < size; j++)
             {
-               k = i+j-size/2;
-               if (k < 0) k = 0;
-               if (k > dz - 1) k = dz -1;
-               smooth_row[i] += avrage_row[k];
+                k = i + j - size / 2;
+                if(k < 0)
+                    k = 0;
+                if(k > dz - 1)
+                    k = dz - 1;
+                smooth_row[i] += avrage_row[k];
             }
             smooth_row[i] /= size;
         }
 
         // For each projection.
-        for (p=0; p<dx; p++)
+        for(p = 0; p < dx; p++)
         {
-            // Subtract this difference from each row in sinogram.     
-            for (j=0; j<dz; j++)
+            // Subtract this difference from each row in sinogram.
+            for(j = 0; j < dz; j++)
             {
-                data[j+s*dz+p*dy*dz] -= (avrage_row[j] - smooth_row[j]);
+                data[j + s * dz + p * dy * dz] -=
+                    (avrage_row[j] - smooth_row[j]);
             }
         }
 

--- a/src/tv.c
+++ b/src/tv.c
@@ -1,257 +1,269 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratongridx (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratongridx (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binangridx forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binangridx forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binangridx form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binangridx form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratongridx, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratongridx, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLAngridx, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEOngridx OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLAngridx, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEOngridx OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-
-void 
-tv(
-    const float *data, int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon, int ngridx, int ngridy, int num_iter, const float *reg_pars)
+void
+tv(const float* data, int dy, int dt, int dx, const float* center,
+   const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+   const float* reg_pars)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indi = (int *)malloc((ngridx+ngridy)*sizeof(int));
-    float *simdata = (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *sum_dist = (float *)malloc((ngridx*ngridy)*sizeof(float));
+    float* gridx    = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy    = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx   = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy   = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by       = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory    = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indi     = (int*) malloc((ngridx + ngridy) * sizeof(int));
+    float* simdata  = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* sum_dist = (float*) malloc((ngridx * ngridy) * sizeof(float));
 
-    float *update = (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
-    float *prox0x = (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
-    float *prox0y = (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
+    float* update = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
+    float* prox0x = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
+    float* prox0y = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
 
-    float *prox1= (float *)malloc((dy*dt*dx)*sizeof(float));
-    float *adjdata = (float *)malloc((dy*ngridx*ngridy)*sizeof(float));
+    float* prox1   = (float*) malloc((dy * dt * dx) * sizeof(float));
+    float* adjdata = (float*) malloc((dy * ngridx * ngridy) * sizeof(float));
 
-    assert(coordx != NULL && coordy != NULL &&
-            ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-            coorx != NULL && coory != NULL && dist != NULL &&
-            indi != NULL && simdata != NULL && sum_dist != NULL &&
-            update != NULL);
+    assert(coordx != NULL && coordy != NULL && ax != NULL && ay != NULL &&
+           by != NULL && bx != NULL && coorx != NULL && coory != NULL &&
+           dist != NULL && indi != NULL && simdata != NULL &&
+           sum_dist != NULL && update != NULL);
 
-    int s, p, d, i, n;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;    
+    int    s, p, d, i, n;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
     double upd;
-    int ind_data, ind_recon;
-    float sum_dist2;
-    int ix,iy;
+    int    ind_data, ind_recon;
+    float  sum_dist2;
+    int    ix, iy;
 
-    //regularization parameters
-    float c;  
+    // regularization parameters
+    float c;
     float lambda;
 
-    //scaling constant r such that r*R(r*R^*(data)) ~ data
+    // scaling constant r such that r*R(r*R^*(data)) ~ data
     float r;
 
-    lambda = reg_pars[0];    
-    c =  0.35;
-    r = 1/sqrt(dx*dt/2.0);
+    lambda = reg_pars[0];
+    c      = 0.35;
+    r      = 1 / sqrt(dx * dt / 2.0);
 
-    //scale initial guess
-    for (s=0; s<dy; s++)
+    // scale initial guess
+    for(s = 0; s < dy; s++)
     {
-        ind_recon = s*ngridx*ngridy;
-        for (iy=0; iy<ngridy; iy++) 
-            for (ix=0; ix<ngridx; ix++) 
-                recon[ind_recon+iy*ngridx+ix] /= r;
+        ind_recon = s * ngridx * ngridy;
+        for(iy = 0; iy < ngridy; iy++)
+            for(ix = 0; ix < ngridx; ix++)
+                recon[ind_recon + iy * ngridx + ix] /= r;
     }
 
-    memcpy(update, recon, dy*ngridx*ngridy*sizeof(float));
-    memset(prox0x, 0, dy*ngridx*ngridy*sizeof(float));
-    memset(prox0y, 0, dy*ngridx*ngridy*sizeof(float));
-    memset(prox1, 0, dy*dt*dx*sizeof(float));
+    memcpy(update, recon, dy * ngridx * ngridy * sizeof(float));
+    memset(prox0x, 0, dy * ngridx * ngridy * sizeof(float));
+    memset(prox0y, 0, dy * ngridx * ngridy * sizeof(float));
+    memset(prox1, 0, dy * dt * dx * sizeof(float));
 
-    //Iterations    
-    for (i=0; i<num_iter; i++) 
+    // Iterations
+    for(i = 0; i < num_iter; i++)
     {
         // initialize simdata to 0
-        memset(simdata, 0, dy*dt*dx*sizeof(float));
-        memset(adjdata, 0, dy*ngridx*ngridy*sizeof(float));
+        memset(simdata, 0, dy * dt * dx * sizeof(float));
+        memset(adjdata, 0, dy * ngridx * ngridy * sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            ind_recon = s*ngridx*ngridy;
-            //compute proximal of the gradient in x and y directions
-            //prox0 = prox0+c*grad(recon);
-            //prox0 = prox0/max(1,abs(prox0)/lambda);
-            for (iy=0; iy<ngridy-1; iy++) 
-                for (ix=0; ix<ngridx-1; ix++) 
-                {                
-                    prox0x[ind_recon+iy*ngridx+ix] += c*(recon[ind_recon+iy*ngridx+ix+1]-recon[ind_recon+iy*ngridx+ix]);
-                    prox0y[ind_recon+iy*ngridx+ix] += c*(recon[ind_recon+(iy+1)*ngridx+ix]-recon[ind_recon+iy*ngridx+ix]);
-                }
-            for (iy=0; iy<ngridy-1; iy++) 
-                for (ix=0; ix<ngridx-1; ix++) 
+            ind_recon = s * ngridx * ngridy;
+            // compute proximal of the gradient in x and y directions
+            // prox0 = prox0+c*grad(recon);
+            // prox0 = prox0/max(1,abs(prox0)/lambda);
+            for(iy = 0; iy < ngridy - 1; iy++)
+                for(ix = 0; ix < ngridx - 1; ix++)
                 {
-                    upd = sqrt(prox0x[ind_recon+iy*ngridx+ix]*prox0x[ind_recon+iy*ngridx+ix]+
-                            prox0y[ind_recon+iy*ngridx+ix]*prox0y[ind_recon+iy*ngridx+ix])/lambda;
-                    upd = upd<1?1:upd;
-                    prox0x[ind_recon+iy*ngridx+ix] /= upd;
-                    prox0y[ind_recon+iy*ngridx+ix] /= upd;
+                    prox0x[ind_recon + iy * ngridx + ix] +=
+                        c * (recon[ind_recon + iy * ngridx + ix + 1] -
+                             recon[ind_recon + iy * ngridx + ix]);
+                    prox0y[ind_recon + iy * ngridx + ix] +=
+                        c * (recon[ind_recon + (iy + 1) * ngridx + ix] -
+                             recon[ind_recon + iy * ngridx + ix]);
+                }
+            for(iy = 0; iy < ngridy - 1; iy++)
+                for(ix = 0; ix < ngridx - 1; ix++)
+                {
+                    upd = sqrt(prox0x[ind_recon + iy * ngridx + ix] *
+                                   prox0x[ind_recon + iy * ngridx + ix] +
+                               prox0y[ind_recon + iy * ngridx + ix] *
+                                   prox0y[ind_recon + iy * ngridx + ix]) /
+                          lambda;
+                    upd = upd < 1 ? 1 : upd;
+                    prox0x[ind_recon + iy * ngridx + ix] /= upd;
+                    prox0y[ind_recon + iy * ngridx + ix] /= upd;
                 }
 
-            //compute proximal of the projections
-            //prox1 = 1*(prox1+c*R(recon)-c*data)/(1+c);
-            preprocessing(ngridx, ngridy, dx, center[s],
-                    &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            // compute proximal of the projections
+            // prox1 = 1*(prox1+c*R(recon)-c*data)/(1+c);
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
             // initialize sum_dist and update to zero
-            memset(sum_dist, 0, (ngridx*ngridy)*sizeof(float));
+            memset(sum_dist, 0, (ngridx * ngridy) * sizeof(float));
 
-            // For each projection angle 
-            for (p=0; p<dt; p++)
+            // For each projection angle
+            for(p = 0; p < dt; p++)
             {
-                // Calculate the sin and cos values 
+                // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmodf(theta[p], 2.0f * (float) M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
-                // For each detector pixel 
-                for (d=0; d<dx; d++)
+                // For each detector pixel
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
-                    calc_coords(
-                            ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy, 
-                            coordx, coordy);
+                    xi = -ngridx - ngridy;
+                    yi = 0.5f * (1 - dx) + d + mov;
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                            ngridx, ngridy, coordx, coordy, gridx, gridy, 
-                            &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
-                    // (bx, by). The new sorted intersection points are 
-                    // stored in (coorx, coory). Total number of points 
+                    // (bx, by). The new sorted intersection points are
+                    // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                            quadrant, asize, ax, ay, bsize, bx, by, 
-                            &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
-                    // Calculate the distances (dist) between the 
-                    // intersection points (coorx, coory). Find the 
+                    // Calculate the distances (dist) between the
+                    // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist(
-                            ngridx, ngridy, csize, coorx, coory, 
-                            indi, dist);
+                    calc_dist(ngridx, ngridy, csize, coorx, coory, indi, dist);
 
-                    // Calculate simdata 
-                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx,
-                            csize, indi, dist, recon,
-                            simdata); // Output: simdata
+                    // Calculate simdata
+                    calc_simdata(s, p, d, ngridx, ngridy, dt, dx, csize, indi,
+                                 dist, recon,
+                                 simdata);  // Output: simdata
 
-                    ind_data = d+p*dx+s*dt*dx;
-                    prox1[ind_data] = (prox1[ind_data]+c*simdata[ind_data]*r-c*data[ind_data])/(1+c);
+                    ind_data = d + p * dx + s * dt * dx;
+                    prox1[ind_data] =
+                        (prox1[ind_data] + c * simdata[ind_data] * r -
+                         c * data[ind_data]) /
+                        (1 + c);
 
                     // Calculate dist*dist
-                    sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++) 
+                    sum_dist2 = 0.0f;
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
+                        sum_dist2 += dist[n] * dist[n];
                         sum_dist[indi[n]] += dist[n];
                     }
 
-                    //adjoint Radon of the prox1 for further computations
-                    //adjdata = R^*(prox1)
-                    if (sum_dist2 != 0.0) 
-                        for (n=0; n<csize-1; n++) 
-                            adjdata[ind_recon+indi[n]] += r*prox1[ind_data]*dist[n];
+                    // adjoint Radon of the prox1 for further computations
+                    // adjdata = R^*(prox1)
+                    if(sum_dist2 != 0.0f)
+                        for(n = 0; n < csize - 1; n++)
+                            adjdata[ind_recon + indi[n]] +=
+                                r * prox1[ind_data] * dist[n];
                 }
             }
 
-            //copy recon = update
-            memcpy(&recon[ind_recon],&update[ind_recon],ngridx*ngridy*sizeof(float));
+            // copy recon = update
+            memcpy(&recon[ind_recon], &update[ind_recon],
+                   ngridx * ngridy * sizeof(float));
 
-            //backward step. update with the divergence of prox0 and the adjoint of prox1 
-            //update = update-c*R^*(prox1)-c*div(prox0);
-            for (iy=0; iy<ngridy; iy++) 
-                for (ix=0; ix<ngridx; ix++) 
+            // backward step. update with the divergence of prox0 and the
+            // adjoint of prox1 update = update-c*R^*(prox1)-c*div(prox0);
+            for(iy = 0; iy < ngridy; iy++)
+                for(ix = 0; ix < ngridx; ix++)
                 {
-                    update[ind_recon+iy*ngridx+ix] -= c*adjdata[ind_recon+iy*ngridx+ix];
-                    if(ix==0) 
-                        update[ind_recon+iy*ngridx+ix] += c*prox0x[ind_recon+iy*ngridx+ix];
-                    else 
-                        update[ind_recon+iy*ngridx+ix] += c*(prox0x[ind_recon+iy*ngridx+ix]-prox0x[ind_recon+iy*ngridx+ix-1]);
-                    if(iy==0) 
-                        update[ind_recon+iy*ngridx+ix] += c*prox0y[ind_recon+iy*ngridx+ix];
-                    else 
-                        update[ind_recon+iy*ngridx+ix] += c*(prox0y[ind_recon+iy*ngridx+ix]-prox0y[ind_recon+(iy-1)*ngridx+ix]);
-                }        
+                    update[ind_recon + iy * ngridx + ix] -=
+                        c * adjdata[ind_recon + iy * ngridx + ix];
+                    if(ix == 0)
+                        update[ind_recon + iy * ngridx + ix] +=
+                            c * prox0x[ind_recon + iy * ngridx + ix];
+                    else
+                        update[ind_recon + iy * ngridx + ix] +=
+                            c * (prox0x[ind_recon + iy * ngridx + ix] -
+                                 prox0x[ind_recon + iy * ngridx + ix - 1]);
+                    if(iy == 0)
+                        update[ind_recon + iy * ngridx + ix] +=
+                            c * prox0y[ind_recon + iy * ngridx + ix];
+                    else
+                        update[ind_recon + iy * ngridx + ix] +=
+                            c * (prox0y[ind_recon + iy * ngridx + ix] -
+                                 prox0y[ind_recon + (iy - 1) * ngridx + ix]);
+                }
 
-            //update of recon
-            //recon = 2*update - recon
-            for (iy=0; iy<ngridy; iy++) 
-                for (ix=0; ix<ngridx; ix++) 
-                    recon[ind_recon+iy*ngridx+ix] = 2*update[ind_recon+iy*ngridx+ix]-recon[ind_recon+iy*ngridx+ix];
+            // update of recon
+            // recon = 2*update - recon
+            for(iy = 0; iy < ngridy; iy++)
+                for(ix = 0; ix < ngridx; ix++)
+                    recon[ind_recon + iy * ngridx + ix] =
+                        2 * update[ind_recon + iy * ngridx + ix] -
+                        recon[ind_recon + iy * ngridx + ix];
         }
     }
 
-    //scale result
-    for (s=0; s<dy; s++)
+    // scale result
+    for(s = 0; s < dy; s++)
     {
-        ind_recon = s*ngridx*ngridy;
-        for (iy=0; iy<ngridy; iy++) 
-            for (ix=0; ix<ngridx; ix++) 
-                recon[ind_recon+iy*ngridx+ix] *= r;
+        ind_recon = s * ngridx * ngridy;
+        for(iy = 0; iy < ngridy; iy++)
+            for(ix = 0; ix < ngridx; ix++)
+                recon[ind_recon + iy * ngridx + ix] *= r;
     }
-
 
     free(gridx);
     free(gridy);

--- a/src/utils.c
+++ b/src/utils.c
@@ -75,7 +75,7 @@ preprocessing(int ry, int rz, int num_pixels, float center, float* mov,
         gridy[i] = -rz * 0.5f + i;
     }
 
-    *mov = ((float) num_pixels - 1) * 0.50f - center;
+    *mov = ((float) num_pixels - 1) * 0.5f - center;
     if(*mov - floor(*mov) < 0.01f)
     {
         *mov += 0.01f;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,342 +1,459 @@
 // Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
 
-// Copyright 2015. UChicago Argonne, LLC. This software was produced 
-// under U.S. Government contract DE-AC02-06CH11357 for Argonne National 
-// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the 
-// U.S. Department of Energy. The U.S. Government has rights to use, 
-// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR 
-// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
-// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is 
-// modified to produce derivative works, such modified software should 
-// be clearly marked, so as not to confuse it with the version available 
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
 // from ANL.
 
-// Additionally, redistribution and use in source and binary forms, with 
-// or without modification, are permitted provided that the following 
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
 // conditions are met:
 
-//     * Redistributions of source code must retain the above copyright 
-//       notice, this list of conditions and the following disclaimer. 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in 
-//       the documentation and/or other materials provided with the 
-//       distribution. 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
 
-//     * Neither the name of UChicago Argonne, LLC, Argonne National 
-//       Laboratory, ANL, the U.S. Government, nor the names of its 
-//       contributors may be used to endorse or promote products derived 
-//       from this software without specific prior written permission. 
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
 
-// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS 
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago 
-// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include <stdint.h>
 
-//for windows build
+// for windows build
 #ifdef WIN32
-	#ifdef PY3K
-	void PyInit_libtomopy(void){}
-	#else
-	void initlibtomopy(void){}
-	#endif
+#    ifdef PY3K
+void
+PyInit_libtomopy(void)
+{
+}
+#    else
+void
+initlibtomopy(void)
+{
+}
+#    endif
 #endif
 
+//============================================================================//
 
-void 
-preprocessing(
-    int ry, int rz,
-    int num_pixels, float center, 
-    float *mov, float *gridx, float *gridy) 
+void
+preprocessing(int ry, int rz, int num_pixels, float center, float* mov,
+              float* gridx, float* gridy)
 {
-    int i;
-
-    for(i=0; i<=ry; i++)
+    for(int i = 0; i <= ry; ++i)
     {
-        gridx[i] = -ry/2.+i;
+        gridx[i] = -ry * 0.5f + i;
     }
 
-    for(i=0; i<=rz; i++)
+    for(int i = 0; i <= rz; ++i)
     {
-        gridy[i] = -rz/2.+i;
+        gridy[i] = -rz * 0.5f + i;
     }
 
-    *mov = ((float)num_pixels-1)/2.0-center;
-    if(*mov-floor(*mov) < 0.01) {
-        *mov += 0.01;
+    *mov = ((float) num_pixels - 1) * 0.50f - center;
+    if(*mov - floor(*mov) < 0.01f)
+    {
+        *mov += 0.01f;
     }
     *mov += 0.5;
 }
 
+//============================================================================//
 
-int 
-calc_quadrant(
-    float theta_p) 
+int
+calc_quadrant(float theta_p)
 {
-    int quadrant;
-    if ((theta_p >= 0 && theta_p < M_PI/2) ||
-        (theta_p >= M_PI && theta_p < 3*M_PI/2) ||
-        (theta_p >= -M_PI && theta_p < -M_PI/2) ||
-        (theta_p >= -2*M_PI && theta_p < -3*M_PI/2)) 
-    {
-        quadrant = 1;
-    } 
-    else 
-    {
-        quadrant = 0;
-    }
-    return quadrant;
+    // here we cast the float to an integer and rescale the integer to
+    // near INT_MAX to retain the precision. This method was tested
+    // on 1M random random floating points between -2*pi and 2*pi and
+    // was found to produce a speed up of:
+    //
+    //  - 14.5x (Intel i7 MacBook)
+    //  - 2.2x  (NERSC KNL)
+    //  - 1.5x  (NERSC Edison)
+    //  - 1.7x  (NERSC Haswell)
+    //
+    // with a 0.0% incorrect quadrant determination rate
+    //
+    const int32_t ipi_c   = 340870420;
+    int32_t       theta_i = (int32_t)(theta_p * ipi_c);
+    theta_i += (theta_i < 0) ? (2.0f * M_PI * ipi_c) : 0;
+
+    return ((theta_i >= 0 && theta_i < 0.5f * M_PI * ipi_c) ||
+            (theta_i >= 1.0f * M_PI * ipi_c && theta_i < 1.5f * M_PI * ipi_c))
+               ? 1
+               : 0;
 }
 
+//============================================================================//
 
-void 
-calc_coords(
-    int ry, int rz,
-    float xi, float yi,
-    float sin_p, float cos_p,
-    const float *gridx, const float *gridy,
-    float *coordx, float *coordy)
+void
+calc_coords(int ry, int rz, float xi, float yi, float sin_p, float cos_p,
+            const float* gridx, const float* gridy, float* coordx,
+            float* coordy)
 {
     float srcx, srcy, detx, dety;
     float slope, islope;
-    int n;
+    int   n;
 
-    srcx = xi*cos_p-yi*sin_p;
-    srcy = xi*sin_p+yi*cos_p;
-    detx = -xi*cos_p-yi*sin_p;
-    dety = -xi*sin_p+yi*cos_p;
+    srcx = xi * cos_p - yi * sin_p;
+    srcy = xi * sin_p + yi * cos_p;
+    detx = -xi * cos_p - yi * sin_p;
+    dety = -xi * sin_p + yi * cos_p;
 
-    slope = (srcy-dety)/(srcx-detx);
-    islope = 1/slope;
-    for (n=0; n<=ry; n++) 
+    slope  = (srcy - dety) / (srcx - detx);
+    islope = (srcx - detx) / (srcy - dety);
+
+#pragma omp simd
+    for(n = 0; n <= ry; n++)
     {
-        coordy[n] = slope*(gridx[n]-srcx)+srcy;
+        coordy[n] = slope * (gridx[n] - srcx) + srcy;
     }
-    for (n=0; n<=rz; n++) 
+#pragma omp simd
+    for(n = 0; n <= rz; n++)
     {
-        coordx[n] = islope*(gridy[n]-srcy)+srcx;
+        coordx[n] = islope * (gridy[n] - srcy) + srcx;
     }
 }
 
+//============================================================================//
 
-void 
-trim_coords(
-    int ry, int rz,
-    const float *coordx, const float *coordy,
-    const float *gridx, const float* gridy,
-    int *asize, float *ax, float *ay, 
-    int *bsize, float *bx, float *by)
+void
+trim_coords(int ry, int rz, const float* coordx, const float* coordy,
+            const float* gridx, const float* gridy, int* asize, float* ax,
+            float* ay, int* bsize, float* bx, float* by)
 {
-    int n;
+    *asize         = 0;
+    *bsize         = 0;
+    float gridx_gt = gridx[0] + 0.01f;
+    float gridx_le = gridx[ry] - 0.01f;
 
-    *asize = 0;
-    *bsize = 0;
-    for (n=0; n<=rz; n++) 
+    for(int n = 0; n <= rz; ++n)
     {
-        if (coordx[n] >= gridx[0]+1e-2) 
+        if(coordx[n] >= gridx_gt && coordx[n] <= gridx_le)
         {
-            if (coordx[n] <= gridx[ry]-1e-2) 
-            {        
-                ax[*asize] = coordx[n];
-                ay[*asize] = gridy[n];
-                (*asize)++;
-            }
+            ax[*asize] = coordx[n];
+            ay[*asize] = gridy[n];
+            ++(*asize);
         }
     }
-    for (n=0; n<=ry; n++) 
+
+    float gridy_gt = gridy[0] + 0.01f;
+    float gridy_le = gridy[rz] - 0.01f;
+
+    for(int n = 0; n <= ry; ++n)
     {
-        if (coordy[n] >= gridy[0]+1e-2) 
+        if(coordy[n] >= gridy_gt && coordy[n] <= gridy_le)
         {
-            if (coordy[n] <= gridy[rz]-1e-2) 
+            bx[*bsize] = gridx[n];
+            by[*bsize] = coordy[n];
+            ++(*bsize);
+        }
+    }
+}
+
+//============================================================================//
+
+void
+sort_intersections(int ind_condition, int asize, const float* ax,
+                   const float* ay, int bsize, const float* bx, const float* by,
+                   int* csize, float* coorx, float* coory)
+{
+    int i = 0, j = 0, k = 0;
+    if(ind_condition == 0)
+    {
+        while(i < asize && j < bsize)
+        {
+            if(ax[asize - 1 - i] < bx[j])
             {
-                bx[*bsize] = gridx[n];
-                by[*bsize] = coordy[n];
-                (*bsize)++;
+                coorx[k] = ax[asize - 1 - i];
+                coory[k] = ay[asize - 1 - i];
+                ++i;
             }
+            else
+            {
+                coorx[k] = bx[j];
+                coory[k] = by[j];
+                ++j;
+            }
+            ++k;
         }
-    }
-}
 
-
-void 
-sort_intersections(
-    int ind_condition, 
-    int asize, const float *ax, const float *ay,
-    int bsize, const float *bx, const float *by,
-    int *csize, float *coorx, float *coory)
-{
-    int i=0, j=0, k=0;
-    int a_ind;
-    while (i<asize && j<bsize)
-    {
-        a_ind = (ind_condition) ? i : (asize-1-i);
-        if (ax[a_ind] < bx[j]) 
+        while(i < asize)
         {
-            coorx[k] = ax[a_ind];
-            coory[k] = ay[a_ind];
-            i++;
-            k++;
-        } 
-        else 
+            coorx[k] = ax[asize - 1 - i];
+            coory[k] = ay[asize - 1 - i];
+            ++i;
+            ++k;
+        }
+        while(j < bsize)
         {
             coorx[k] = bx[j];
             coory[k] = by[j];
-            j++;
-            k++;
+            ++j;
+            ++k;
+        }
+
+        (*csize) = asize + bsize;
+    }
+    else
+    {
+        while(i < asize && j < bsize)
+        {
+            if(ax[i] < bx[j])
+            {
+                coorx[k] = ax[i];
+                coory[k] = ay[i];
+                ++i;
+            }
+            else
+            {
+                coorx[k] = bx[j];
+                coory[k] = by[j];
+                ++j;
+            }
+            ++k;
+        }
+
+        while(i < asize)
+        {
+            coorx[k] = ax[i];
+            coory[k] = ay[i];
+            ++i;
+            ++k;
+        }
+        while(j < bsize)
+        {
+            coorx[k] = bx[j];
+            coory[k] = by[j];
+            ++j;
+            ++k;
+        }
+        (*csize) = asize + bsize;
+    }
+}
+
+//============================================================================//
+
+void
+calc_dist(int ry, int rz, int csize, const float* coorx, const float* coory,
+          int* indi, float* dist)
+{
+    const int _size = csize - 1;
+
+    //------------------------------------------------------------------------//
+    //              calculate dist
+    //------------------------------------------------------------------------//
+    {
+        float _diffx[_size];
+        float _diffy[_size];
+
+#pragma omp simd
+        for(int n = 0; n < _size; ++n)
+        {
+            _diffx[n] = (coorx[n + 1] - coorx[n]) * (coorx[n + 1] - coorx[n]);
+        }
+
+#pragma omp simd
+        for(int n = 0; n < _size; ++n)
+        {
+            _diffy[n] = (coory[n + 1] - coory[n]) * (coory[n + 1] - coory[n]);
+        }
+
+#pragma omp simd
+        for(int n = 0; n < _size; ++n)
+        {
+            dist[n] = sqrtf(_diffx[n] + _diffy[n]);
         }
     }
-    while (i < asize) 
+
+    //------------------------------------------------------------------------//
+    //              calculate indi
+    //------------------------------------------------------------------------//
+
+    float _midx[_size];
+    float _midy[_size];
+    float _x1[_size];
+    float _x2[_size];
+    int   _i1[_size];
+    int   _i2[_size];
+    int   _indx[_size];
+    int   _indy[_size];
+
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
     {
-        a_ind = (ind_condition) ? i : (asize-1-i);
-        coorx[k] = ax[a_ind];
-        coory[k] = ay[a_ind];
-        i++;
-        k++;
+        _midx[n] = 0.5f * (coorx[n + 1] + coorx[n]);
     }
-    while (j < bsize) 
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
     {
-        coorx[k] = bx[j];
-        coory[k] = by[j];
-        j++;
-        k++;
+        _midy[n] = 0.5f * (coory[n + 1] + coory[n]);
     }
-    *csize = asize+bsize;
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        _x1[n] = _midx[n] + 0.5f * ry;
+    }
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        _x2[n] = _midy[n] + 0.5f * rz;
+    }
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        _i1[n] = (int) (_midx[n] + 0.5f * ry);
+    }
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        _i2[n] = (int) (_midy[n] + 0.5f * rz);
+    }
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        _indx[n] = _i1[n] - (_i1[n] > _x1[n]);
+    }
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        _indy[n] = _i2[n] - (_i2[n] > _x2[n]);
+    }
+#pragma omp simd
+    for(int n = 0; n < _size; ++n)
+    {
+        indi[n] = _indy[n] + (_indx[n] * rz);
+    }
 }
 
+//============================================================================//
 
-void 
-calc_dist(
-    int ry, int rz, 
-    int csize, const float *coorx, const float *coory,
-    int *indi, float *dist)
+void
+calc_dist2(int ry, int rz, int csize, const float* coorx, const float* coory,
+           int* indx, int* indy, float* dist)
 {
-    int n, i1, i2;
-    float x1, x2;
-    float diffx, diffy, midx, midy;
-    int indx, indy;
-
-    for (n=0; n<csize-1; n++) 
+#pragma omp simd
+    for(int n = 0; n < csize - 1; ++n)
     {
-        diffx = coorx[n+1]-coorx[n];
-        diffy = coory[n+1]-coory[n];
-        dist[n] = sqrt(diffx*diffx+diffy*diffy);
-        midx = (coorx[n+1]+coorx[n])/2;
-        midy = (coory[n+1]+coory[n])/2;
-        x1 = midx+ry/2.;
-        x2 = midy+rz/2.;
-        i1 = (int)(midx+ry/2.);
-        i2 = (int)(midy+rz/2.);
-        indx = i1-(i1>x1);
-        indy = i2-(i2>x2);
-        indi[n] = indy+(indx*rz);
+        float diffx = coorx[n + 1] - coorx[n];
+        float diffy = coory[n + 1] - coory[n];
+        dist[n]     = sqrt(diffx * diffx + diffy * diffy);
+    }
+
+#pragma omp simd
+    for(int n = 0; n < csize - 1; ++n)
+    {
+        float midx = (coorx[n + 1] + coorx[n]) * 0.5f;
+        float midy = (coory[n + 1] + coory[n]) * 0.5f;
+        float x1   = midx + ry * 0.5f;
+        float x2   = midy + rz * 0.5f;
+        int   i1   = (int) (midx + ry * 0.5f);
+        int   i2   = (int) (midy + rz * 0.5f);
+        indx[n]    = i1 - (i1 > x1);
+        indy[n]    = i2 - (i2 > x2);
     }
 }
 
+//============================================================================//
 
-void 
-calc_dist2(
-    int ry, int rz, 
-    int csize, const float *coorx, const float *coory,
-    int *indx, int *indy, float *dist)
+void
+calc_simdata(int s, int p, int d, int ry, int rz, int dt, int dx, int csize,
+             const int* indi, const float* dist, const float* model,
+             float* simdata)
 {
-    int n, i1, i2;
-    float x1, x2;
-    float diffx, diffy, midx, midy;
-
-    for (n=0; n<csize-1; n++) 
+    int index_model = s * ry * rz;
+    int index_data  = d + p * dx + s * dt * dx;
+    for(int n = 0; n < csize - 1; ++n)
     {
-        diffx = coorx[n+1]-coorx[n];
-        diffy = coory[n+1]-coory[n];
-        dist[n] = sqrt(diffx*diffx+diffy*diffy);
-        midx = (coorx[n+1]+coorx[n])/2;
-        midy = (coory[n+1]+coory[n])/2;
-        x1 = midx+ry/2.;
-        x2 = midy+rz/2.;
-        i1 = (int)(midx+ry/2.);
-        i2 = (int)(midy+rz/2.);
-        indx[n] = i1-(i1>x1);
-        indy[n] = i2-(i2>x2);
+        simdata[index_data] += model[indi[n] + index_model] * dist[n];
     }
 }
 
+//============================================================================//
 
-void 
-calc_simdata(
-    int s, int p, int d,
-    int ry, int rz, 
-    int dt, int dx,
-    int csize, const int *indi, const float *dist,
-    const float *model, float *simdata)
+void
+calc_simdata2(int s, int p, int d, int ry, int rz, int dt, int dx, int csize,
+              const int* indx, const int* indy, const float* dist, float vx,
+              float vy, const float* modelx, const float* modely,
+              float* simdata)
 {
     int n;
 
-    int index_model = s*ry*rz;
-    int index_data = d+p*dx+s*dt*dx;
-    for (n=0; n<csize-1; n++) 
+    for(n = 0; n < csize - 1; n++)
     {
-        simdata[index_data] += model[indi[n]+index_model]*dist[n];
+        simdata[d + p * dx + s * dt * dx] +=
+            (modelx[indy[n] + indx[n] * rz + s * ry * rz] * vx +
+             modely[indy[n] + indx[n] * rz + s * ry * rz] * vy) *
+            dist[n];
     }
 }
 
+//============================================================================//
 
-void 
-calc_simdata2(
-    int s, int p, int d,
-    int ry, int rz, 
-    int dt, int dx,
-    int csize, const int *indx, const int *indy, const float *dist,
-    float vx, float vy, 
-    const float *modelx, const float *modely, float *simdata)
+void
+calc_simdata3(int s, int p, int d, int ry, int rz, int dt, int dx, int csize,
+              const int* indx, const int* indy, const float* dist, float vx,
+              float vy, const float* modelx, const float* modely,
+              const float* modelz, int axis, float* simdata)
 {
     int n;
 
-    for (n=0; n<csize-1; n++) 
+    if(axis == 0)
     {
-        simdata[d + p*dx + s*dt*dx] += (modelx[indy[n] + indx[n]*rz + s*ry*rz] * vx + modely[indy[n] + indx[n]*rz + s*ry*rz] * vy) * dist[n];
-    }
-}
-
-
-void 
-calc_simdata3(
-    int s, int p, int d,
-    int ry, int rz, 
-    int dt, int dx,
-    int csize, const int *indx, const int *indy, const float *dist,
-    float vx, float vy, 
-    const float *modelx, const float *modely, const float *modelz, int axis, float *simdata)
-{
-    int n;
-
-    if (axis==0)
-    {
-        for (n=0; n<csize-1; n++) 
+        for(n = 0; n < csize - 1; n++)
         {
-            simdata[d + p*dx + s*dt*dx] += (modelx[indy[n] + indx[n]*rz + s*ry*rz] * vx + modely[indy[n] + indx[n]*rz + s*ry*rz] * vy) * dist[n];
+            simdata[d + p * dx + s * dt * dx] +=
+                (modelx[indy[n] + indx[n] * rz + s * ry * rz] * vx +
+                 modely[indy[n] + indx[n] * rz + s * ry * rz] * vy) *
+                dist[n];
         }
     }
-    else if (axis==1)
+    else if(axis == 1)
     {
-        for (n=0; n<csize-1; n++) 
+        for(n = 0; n < csize - 1; n++)
         {
-            simdata[d + p*dx + s*dt*dx] += (modely[s + indx[n]*rz + indy[n]*ry*rz] * vx + modelz[s + indx[n]*rz + indy[n]*ry*rz] * vy) * dist[n];
+            simdata[d + p * dx + s * dt * dx] +=
+                (modely[s + indx[n] * rz + indy[n] * ry * rz] * vx +
+                 modelz[s + indx[n] * rz + indy[n] * ry * rz] * vy) *
+                dist[n];
         }
     }
-    else if (axis==2)
+    else if(axis == 2)
     {
-        for (n=0; n<csize-1; n++) 
+        for(n = 0; n < csize - 1; n++)
         {
-            simdata[d + p*dx + s*dt*dx] += (modelx[indx[n] + s*rz + indy[n]*ry*rz] * vx + modelz[indx[n] + s*rz + indy[n]*ry*rz] * vy) * dist[n];
+            simdata[d + p * dx + s * dt * dx] +=
+                (modelx[indx[n] + s * rz + indy[n] * ry * rz] * vx +
+                 modelz[indx[n] + s * rz + indy[n] * ry * rz] * vy) *
+                dist[n];
         }
     }
 }
+
+//============================================================================//

--- a/src/vector.c
+++ b/src/vector.c
@@ -43,142 +43,141 @@
 
 #include "utils.h"
 
-
 void
-vector(
-    const float *data, int dy, int dt, int dx,
-    const float *center, const float *theta,
-    float *recon1, float *recon2, int ngridx, int ngridy, int num_iter)
+vector(const float* data, int dy, int dt, int dx, const float* center,
+       const float* theta, float* recon1, float* recon2, int ngridx, int ngridy,
+       int num_iter)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indx = (int *)malloc((ngridx+ngridy+1)*sizeof(int));
-    int *indy = (int *)malloc((ngridx+ngridy+1)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indx   = (int*) malloc((ngridx + ngridy + 1) * sizeof(int));
+    int*   indy   = (int*) malloc((ngridx + ngridy + 1) * sizeof(int));
 
-    assert(gridx != NULL && gridy != NULL &&
-        coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-        indx != NULL && indy != NULL);
+    assert(gridx != NULL && gridy != NULL && coordx != NULL && coordy != NULL &&
+           ax != NULL && ay != NULL && by != NULL && bx != NULL &&
+           coorx != NULL && coory != NULL && dist != NULL && indx != NULL &&
+           indy != NULL);
 
-    int s, p, d, i, n, m;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data;
-    float srcx, srcy, detx, dety, dv, vx, vy;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, p, d, i, n, m;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data;
+    float  srcx, srcy, detx, dety, dv, vx, vy;
+    float* sum_dist;
+    float  sum_dist2;
     float *update1, *update2;
 
-    for (i=0; i<num_iter; i++)
+    for(i = 0; i < num_iter; i++)
     {
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update1 = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update2 = (float *)calloc((ngridx*ngridy), sizeof(float));
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update1  = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update2  = (float*) calloc((ngridx * ngridy), sizeof(float));
 
             // For each projection angle
-            for (p=0; p<dt; p++)
+            for(p = 0; p < dt; p++)
             {
                 // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta[p], 2*M_PI);
+                theta_p  = fmod(theta[p], 2 * M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
                 // For each detector pixel
-                for (d=0; d<dx; d++)
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
+                    xi = -ngridx - ngridy;
+                    yi = (1 - dx) / 2.0 + d + mov;
 
-                    srcx = xi*cos_p-yi*sin_p;
-                    srcy = xi*sin_p+yi*cos_p;
-                    detx = -xi*cos_p-yi*sin_p;
-                    dety = -xi*sin_p+yi*cos_p;
+                    srcx = xi * cos_p - yi * sin_p;
+                    srcy = xi * sin_p + yi * cos_p;
+                    detx = -xi * cos_p - yi * sin_p;
+                    dety = -xi * sin_p + yi * cos_p;
 
-                    dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-                    vx = (srcx-detx)/dv;
-                    vy = (srcy-dety)/dv;
+                    dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+                    vx = (srcx - detx) / dv;
+                    vy = (srcy - dety) / dv;
 
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
-                        coordx, coordy);
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy,
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
                     // (bx, by). The new sorted intersection points are
                     // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by,
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
                     // Calculate the distances (dist) between the
                     // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist2(
-                        ngridx, ngridy, csize, coorx, coory,
-                        indx, indy, dist);
+                    calc_dist2(ngridx, ngridy, csize, coorx, coory, indx, indy,
+                               dist);
 
                     // Calculate simdata
-                    calc_simdata2(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indx, indy, dist, vx, vy, recon1, recon2,
-                        simdata); // Output: simdata
+                    calc_simdata2(s, p, d, ngridx, ngridy, dt, dx, csize, indx,
+                                  indy, dist, vx, vy, recon1, recon2,
+                                  simdata);  // Output: simdata
 
                     // Calculate dist*dist
                     sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++)
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
-                        sum_dist[indy[n] + indx[n]*ngridy] += dist[n];
+                        sum_dist2 += dist[n] * dist[n];
+                        sum_dist[indy[n] + indx[n] * ngridy] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0)
+                    if(sum_dist2 != 0.0)
                     {
-                        ind_data = d + p*dx + s*dt*dx;
-                        upd = (data[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update1[indy[n] + indx[n]*ngridy] += upd*dist[n]*vx;
-                            update2[indy[n] + indx[n]*ngridy] += upd*dist[n]*vy;
+                            update1[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vx;
+                            update2[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vy;
                         }
                     }
                 }
             }
 
-            for (m = 0; m < ngridx; m++) {
-                for (n = 0; n < ngridy; n++) {
-                    recon1[n + m*ngridy + s*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
-                    recon2[n + m*ngridy + s*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
+            for(m = 0; m < ngridx; m++)
+            {
+                for(n = 0; n < ngridy; n++)
+                {
+                    recon1[n + m * ngridy + s * ngridx * ngridy] +=
+                        update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                    recon2[n + m * ngridy + s * ngridx * ngridy] +=
+                        update1[n + m * ngridy] / sum_dist[n + m * ngridy];
                 }
             }
 
@@ -205,146 +204,147 @@ vector(
     free(indy);
 }
 
-
 void
-vector2(
-    const float *data1, const float *data2, int dy, int dt, int dx,
-    const float *center1, const float *center2, const float *theta1, const float *theta2,
-    float *recon1, float *recon2, float *recon3, int ngridx, int ngridy, int num_iter, int axis1, int axis2)
+vector2(const float* data1, const float* data2, int dy, int dt, int dx,
+        const float* center1, const float* center2, const float* theta1,
+        const float* theta2, float* recon1, float* recon2, float* recon3,
+        int ngridx, int ngridy, int num_iter, int axis1, int axis2)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indx = (int *)malloc((ngridx+ngridy+1)*sizeof(int));
-    int *indy = (int *)malloc((ngridx+ngridy+1)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indx   = (int*) malloc((ngridx + ngridy + 1) * sizeof(int));
+    int*   indy   = (int*) malloc((ngridx + ngridy + 1) * sizeof(int));
 
-    assert(gridx != NULL && gridy != NULL &&
-        coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-        indx != NULL && indy != NULL);
+    assert(gridx != NULL && gridy != NULL && coordx != NULL && coordy != NULL &&
+           ax != NULL && ay != NULL && by != NULL && bx != NULL &&
+           coorx != NULL && coory != NULL && dist != NULL && indx != NULL &&
+           indy != NULL);
 
-    int s, p, d, i, n, m;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data;
-    float srcx, srcy, detx, dety, dv, vx, vy;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, p, d, i, n, m;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data;
+    float  srcx, srcy, detx, dety, dv, vx, vy;
+    float* sum_dist;
+    float  sum_dist2;
     float *update1, *update2;
 
-    for (i=0; i<num_iter; i++)
+    for(i = 0; i < num_iter; i++)
     {
-        printf ("iter=%d\n", i);
+        printf("iter=%d\n", i);
 
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center1[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center1[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update1 = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update2 = (float *)calloc((ngridx*ngridy), sizeof(float));
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update1  = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update2  = (float*) calloc((ngridx * ngridy), sizeof(float));
 
             // For each projection angle
-            for (p=0; p<dt; p++)
+            for(p = 0; p < dt; p++)
             {
                 // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta1[p], 2*M_PI);
+                theta_p  = fmod(theta1[p], 2 * M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
                 // For each detector pixel
-                for (d=0; d<dx; d++)
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
+                    xi = -ngridx - ngridy;
+                    yi = (1 - dx) / 2.0 + d + mov;
 
-                    srcx = xi*cos_p-yi*sin_p;
-                    srcy = xi*sin_p+yi*cos_p;
-                    detx = -xi*cos_p-yi*sin_p;
-                    dety = -xi*sin_p+yi*cos_p;
+                    srcx = xi * cos_p - yi * sin_p;
+                    srcy = xi * sin_p + yi * cos_p;
+                    detx = -xi * cos_p - yi * sin_p;
+                    dety = -xi * sin_p + yi * cos_p;
 
-                    dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-                    vx = (srcx-detx)/dv;
-                    vy = (srcy-dety)/dv;
+                    dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+                    vx = (srcx - detx) / dv;
+                    vy = (srcy - dety) / dv;
 
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
-                        coordx, coordy);
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy,
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
                     // (bx, by). The new sorted intersection points are
                     // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by,
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
                     // Calculate the distances (dist) between the
                     // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist2(
-                        ngridx, ngridy, csize, coorx, coory, 
-                        indx, indy, dist);
+                    calc_dist2(ngridx, ngridy, csize, coorx, coory, indx, indy,
+                               dist);
 
                     // Calculate simdata
-                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indx, indy, dist, vx, vy, recon1, recon2, recon3, axis1,
-                        simdata); // Output: simdata
+                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx, csize, indx,
+                                  indy, dist, vx, vy, recon1, recon2, recon3,
+                                  axis1,
+                                  simdata);  // Output: simdata
 
                     // Calculate dist*dist
                     sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++)
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
-                        sum_dist[indy[n] + indx[n]*ngridy] += dist[n];
+                        sum_dist2 += dist[n] * dist[n];
+                        sum_dist[indy[n] + indx[n] * ngridy] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0)
+                    if(sum_dist2 != 0.0)
                     {
-                        ind_data = d + p*dx + s*dt*dx;
-                        upd = (data1[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data1[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update1[indy[n] + indx[n]*ngridy] += upd*dist[n]*vx;
-                            update2[indy[n] + indx[n]*ngridy] += upd*dist[n]*vy;
+                            update1[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vx;
+                            update2[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vy;
                         }
                     }
                 }
             }
 
-            for (m = 0; m < ngridx; m++) {
-                for (n = 0; n < ngridy; n++) {
-                    if (sum_dist[n + m*ngridy] != 0.0)
+            for(m = 0; m < ngridx; m++)
+            {
+                for(n = 0; n < ngridy; n++)
+                {
+                    if(sum_dist[n + m * ngridy] != 0.0)
                     {
-                        recon2[s + m*ngridy + n*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
-                        recon3[s + m*ngridy + n*ngridx*ngridy] += update2[n + m*ngridy]/sum_dist[n + m*ngridy];
+                        recon2[s + m * ngridy + n * ngridx * ngridy] +=
+                            update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                        recon3[s + m * ngridy + n * ngridx * ngridy] +=
+                            update2[n + m * ngridy] / sum_dist[n + m * ngridy];
                     }
                 }
             }
@@ -356,102 +356,105 @@ vector2(
 
         free(simdata);
 
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center1[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center1[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update1 = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update2 = (float *)calloc((ngridx*ngridy), sizeof(float));
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update1  = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update2  = (float*) calloc((ngridx * ngridy), sizeof(float));
 
             // For each projection angle
-            for (p=0; p<dt; p++)
+            for(p = 0; p < dt; p++)
             {
                 // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta1[p], 2*M_PI);
+                theta_p  = fmod(theta1[p], 2 * M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
                 // For each detector pixel
-                for (d=0; d<dx; d++)
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
+                    xi = -ngridx - ngridy;
+                    yi = (1 - dx) / 2.0 + d + mov;
 
-                    srcx = xi*cos_p-yi*sin_p;
-                    srcy = xi*sin_p+yi*cos_p;
-                    detx = -xi*cos_p-yi*sin_p;
-                    dety = -xi*sin_p+yi*cos_p;
+                    srcx = xi * cos_p - yi * sin_p;
+                    srcy = xi * sin_p + yi * cos_p;
+                    detx = -xi * cos_p - yi * sin_p;
+                    dety = -xi * sin_p + yi * cos_p;
 
-                    dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-                    vx = (srcx-detx)/dv;
-                    vy = (srcy-dety)/dv;
+                    dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+                    vx = (srcx - detx) / dv;
+                    vy = (srcy - dety) / dv;
 
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
-                        coordx, coordy);
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy,
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
                     // (bx, by). The new sorted intersection points are
                     // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by,
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
                     // Calculate the distances (dist) between the
                     // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist2(
-                        ngridx, ngridy, csize, coorx, coory,
-                        indx, indy, dist);
+                    calc_dist2(ngridx, ngridy, csize, coorx, coory, indx, indy,
+                               dist);
 
                     // Calculate simdata
-                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indx, indy, dist, vx, vy, recon1, recon2, recon3, axis2,
-                        simdata); // Output: simdata
+                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx, csize, indx,
+                                  indy, dist, vx, vy, recon1, recon2, recon3,
+                                  axis2,
+                                  simdata);  // Output: simdata
 
                     // Calculate dist*dist
                     sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++)
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
-                        sum_dist[indy[n] + indx[n]*ngridy] += dist[n];
+                        sum_dist2 += dist[n] * dist[n];
+                        sum_dist[indy[n] + indx[n] * ngridy] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0)
+                    if(sum_dist2 != 0.0)
                     {
-                        ind_data = d + p*dx + s*dt*dx;
-                        upd = (data2[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data2[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update1[indy[n] + indx[n]*ngridy] += upd*dist[n]*vx;
-                            update2[indy[n] + indx[n]*ngridy] += upd*dist[n]*vy;
+                            update1[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vx;
+                            update2[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vy;
                         }
                     }
                 }
             }
 
-            for (m = 0; m < ngridx; m++) {
-                for (n = 0; n < ngridy; n++) {
-                    if (sum_dist[n + m*ngridy] != 0.0)
+            for(m = 0; m < ngridx; m++)
+            {
+                for(n = 0; n < ngridy; n++)
+                {
+                    if(sum_dist[n + m * ngridy] != 0.0)
                     {
-                        recon1[m + s*ngridy + n*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
-                        recon3[m + s*ngridy + n*ngridx*ngridy] += update2[n + m*ngridy]/sum_dist[n + m*ngridy];
+                        recon1[m + s * ngridy + n * ngridx * ngridy] +=
+                            update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                        recon3[m + s * ngridy + n * ngridx * ngridy] +=
+                            update2[n + m * ngridy] / sum_dist[n + m * ngridy];
                     }
                 }
             }
@@ -479,147 +482,148 @@ vector2(
     free(indy);
 }
 
-
 void
-vector3(
-    const float *data1, const float *data2, const float *data3, int dy, int dt, int dx,
-    const float *center1, const float *center2, const float *center3, const float *theta1, const float *theta2, const float *theta3,
-    float *recon1, float *recon2, float *recon3, int ngridx, int ngridy, int num_iter, int axis1, int axis2, int axis3)
+vector3(const float* data1, const float* data2, const float* data3, int dy,
+        int dt, int dx, const float* center1, const float* center2,
+        const float* center3, const float* theta1, const float* theta2,
+        const float* theta3, float* recon1, float* recon2, float* recon3,
+        int ngridx, int ngridy, int num_iter, int axis1, int axis2, int axis3)
 {
-    float *gridx = (float *)malloc((ngridx+1)*sizeof(float));
-    float *gridy = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordx = (float *)malloc((ngridy+1)*sizeof(float));
-    float *coordy = (float *)malloc((ngridx+1)*sizeof(float));
-    float *ax = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *ay = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *bx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *by = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coorx = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *coory = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    float *dist = (float *)malloc((ngridx+ngridy)*sizeof(float));
-    int *indx = (int *)malloc((ngridx+ngridy+1)*sizeof(int));
-    int *indy = (int *)malloc((ngridx+ngridy+1)*sizeof(int));
+    float* gridx  = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* gridy  = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordx = (float*) malloc((ngridy + 1) * sizeof(float));
+    float* coordy = (float*) malloc((ngridx + 1) * sizeof(float));
+    float* ax     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* ay     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* bx     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* by     = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coorx  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* coory  = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    float* dist   = (float*) malloc((ngridx + ngridy) * sizeof(float));
+    int*   indx   = (int*) malloc((ngridx + ngridy + 1) * sizeof(int));
+    int*   indy   = (int*) malloc((ngridx + ngridy + 1) * sizeof(int));
 
-    assert(gridx != NULL && gridy != NULL &&
-        coordx != NULL && coordy != NULL &&
-        ax != NULL && ay != NULL && by != NULL && bx != NULL &&
-        coorx != NULL && coory != NULL && dist != NULL &&
-        indx != NULL && indy != NULL);
+    assert(gridx != NULL && gridy != NULL && coordx != NULL && coordy != NULL &&
+           ax != NULL && ay != NULL && by != NULL && bx != NULL &&
+           coorx != NULL && coory != NULL && dist != NULL && indx != NULL &&
+           indy != NULL);
 
-    int s, p, d, i, n, m;
-    int quadrant;
-    float theta_p, sin_p, cos_p;
-    float mov, xi, yi;
-    int asize, bsize, csize;
-    float *simdata;
-    float upd;
-    int ind_data;
-    float srcx, srcy, detx, dety, dv, vx, vy;
-    float *sum_dist;
-    float sum_dist2;
+    int    s, p, d, i, n, m;
+    int    quadrant;
+    float  theta_p, sin_p, cos_p;
+    float  mov, xi, yi;
+    int    asize, bsize, csize;
+    float* simdata;
+    float  upd;
+    int    ind_data;
+    float  srcx, srcy, detx, dety, dv, vx, vy;
+    float* sum_dist;
+    float  sum_dist2;
     float *update1, *update2;
 
-    for (i=0; i<num_iter; i++)
+    for(i = 0; i < num_iter; i++)
     {
-        printf ("iter=%d\n", i);
+        printf("iter=%d\n", i);
 
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center1[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center1[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update1 = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update2 = (float *)calloc((ngridx*ngridy), sizeof(float));
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update1  = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update2  = (float*) calloc((ngridx * ngridy), sizeof(float));
 
             // For each projection angle
-            for (p=0; p<dt; p++)
+            for(p = 0; p < dt; p++)
             {
                 // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta1[p], 2*M_PI);
+                theta_p  = fmod(theta1[p], 2 * M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
                 // For each detector pixel
-                for (d=0; d<dx; d++)
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
+                    xi = -ngridx - ngridy;
+                    yi = (1 - dx) / 2.0 + d + mov;
 
-                    srcx = xi*cos_p-yi*sin_p;
-                    srcy = xi*sin_p+yi*cos_p;
-                    detx = -xi*cos_p-yi*sin_p;
-                    dety = -xi*sin_p+yi*cos_p;
+                    srcx = xi * cos_p - yi * sin_p;
+                    srcy = xi * sin_p + yi * cos_p;
+                    detx = -xi * cos_p - yi * sin_p;
+                    dety = -xi * sin_p + yi * cos_p;
 
-                    dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-                    vx = (srcx-detx)/dv;
-                    vy = (srcy-dety)/dv;
+                    dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+                    vx = (srcx - detx) / dv;
+                    vy = (srcy - dety) / dv;
 
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
-                        coordx, coordy);
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy,
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
                     // (bx, by). The new sorted intersection points are
                     // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by,
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
                     // Calculate the distances (dist) between the
                     // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist2(
-                        ngridx, ngridy, csize, coorx, coory,
-                        indx, indy, dist);
+                    calc_dist2(ngridx, ngridy, csize, coorx, coory, indx, indy,
+                               dist);
 
                     // Calculate simdata
-                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indx, indy, dist, vx, vy, recon1, recon2, recon3, axis1,
-                        simdata); // Output: simdata
+                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx, csize, indx,
+                                  indy, dist, vx, vy, recon1, recon2, recon3,
+                                  axis1,
+                                  simdata);  // Output: simdata
 
                     // Calculate dist*dist
                     sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++)
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
-                        sum_dist[indy[n] + indx[n]*ngridy] += dist[n];
+                        sum_dist2 += dist[n] * dist[n];
+                        sum_dist[indy[n] + indx[n] * ngridy] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0)
+                    if(sum_dist2 != 0.0)
                     {
-                        ind_data = d + p*dx + s*dt*dx;
-                        upd = (data1[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data1[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update1[indy[n] + indx[n]*ngridy] += upd*dist[n]*vx;
-                            update2[indy[n] + indx[n]*ngridy] += upd*dist[n]*vy;
-
+                            update1[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vx;
+                            update2[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vy;
                         }
                     }
                 }
             }
 
-            for (m = 0; m < ngridx; m++) {
-                for (n = 0; n < ngridy; n++) {
-                    if (sum_dist[n + m*ngridy] != 0.0)
+            for(m = 0; m < ngridx; m++)
+            {
+                for(n = 0; n < ngridy; n++)
+                {
+                    if(sum_dist[n + m * ngridy] != 0.0)
                     {
-                        recon1[n + m*ngridy + s*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
-                        recon2[n + m*ngridy + s*ngridx*ngridy] += update2[n + m*ngridy]/sum_dist[n + m*ngridy];
+                        recon1[n + m * ngridy + s * ngridx * ngridy] +=
+                            update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                        recon2[n + m * ngridy + s * ngridx * ngridy] +=
+                            update2[n + m * ngridy] / sum_dist[n + m * ngridy];
                     }
                 }
             }
@@ -631,102 +635,105 @@ vector3(
 
         free(simdata);
 
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center1[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center1[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update1 = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update2 = (float *)calloc((ngridx*ngridy), sizeof(float));
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update1  = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update2  = (float*) calloc((ngridx * ngridy), sizeof(float));
 
             // For each projection angle
-            for (p=0; p<dt; p++)
+            for(p = 0; p < dt; p++)
             {
                 // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta1[p], 2*M_PI);
+                theta_p  = fmod(theta1[p], 2 * M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
                 // For each detector pixel
-                for (d=0; d<dx; d++)
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
+                    xi = -ngridx - ngridy;
+                    yi = (1 - dx) / 2.0 + d + mov;
 
-                    srcx = xi*cos_p-yi*sin_p;
-                    srcy = xi*sin_p+yi*cos_p;
-                    detx = -xi*cos_p-yi*sin_p;
-                    dety = -xi*sin_p+yi*cos_p;
+                    srcx = xi * cos_p - yi * sin_p;
+                    srcy = xi * sin_p + yi * cos_p;
+                    detx = -xi * cos_p - yi * sin_p;
+                    dety = -xi * sin_p + yi * cos_p;
 
-                    dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-                    vx = (srcx-detx)/dv;
-                    vy = (srcy-dety)/dv;
+                    dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+                    vx = (srcx - detx) / dv;
+                    vy = (srcy - dety) / dv;
 
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
-                        coordx, coordy);
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy,
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
                     // (bx, by). The new sorted intersection points are
                     // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by,
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
                     // Calculate the distances (dist) between the
                     // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist2(
-                        ngridx, ngridy, csize, coorx, coory,
-                        indx, indy, dist);
+                    calc_dist2(ngridx, ngridy, csize, coorx, coory, indx, indy,
+                               dist);
 
                     // Calculate simdata
-                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indx, indy, dist, vx, vy, recon1, recon2, recon3, axis2,
-                        simdata); // Output: simdata
+                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx, csize, indx,
+                                  indy, dist, vx, vy, recon1, recon2, recon3,
+                                  axis2,
+                                  simdata);  // Output: simdata
 
                     // Calculate dist*dist
                     sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++)
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
-                        sum_dist[indy[n] + indx[n]*ngridy] += dist[n];
+                        sum_dist2 += dist[n] * dist[n];
+                        sum_dist[indy[n] + indx[n] * ngridy] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0)
+                    if(sum_dist2 != 0.0)
                     {
-                        ind_data = d + p*dx + s*dt*dx;
-                        upd = (data2[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data2[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update1[indy[n] + indx[n]*ngridy] += upd*dist[n]*vx;
-                            update2[indy[n] + indx[n]*ngridy] += upd*dist[n]*vy;
+                            update1[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vx;
+                            update2[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vy;
                         }
                     }
                 }
             }
 
-            for (m = 0; m < ngridx; m++) {
-                for (n = 0; n < ngridy; n++) {
-                    if (sum_dist[n + m*ngridy] != 0.0)
+            for(m = 0; m < ngridx; m++)
+            {
+                for(n = 0; n < ngridy; n++)
+                {
+                    if(sum_dist[n + m * ngridy] != 0.0)
                     {
-                        recon2[s + m*ngridy + n*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
-                        recon3[s + m*ngridy + n*ngridx*ngridy] += update2[n + m*ngridy]/sum_dist[n + m*ngridy];
+                        recon2[s + m * ngridy + n * ngridx * ngridy] +=
+                            update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                        recon3[s + m * ngridy + n * ngridx * ngridy] +=
+                            update2[n + m * ngridy] / sum_dist[n + m * ngridy];
                     }
                 }
             }
@@ -738,102 +745,105 @@ vector3(
 
         free(simdata);
 
-        simdata = (float *)calloc((dt*dy*dx), sizeof(float));
+        simdata = (float*) calloc((dt * dy * dx), sizeof(float));
 
         // For each slice
-        for (s=0; s<dy; s++)
+        for(s = 0; s < dy; s++)
         {
-            preprocessing(ngridx, ngridy, dx, center1[s],
-                &mov, gridx, gridy); // Outputs: mov, gridx, gridy
+            preprocessing(ngridx, ngridy, dx, center1[s], &mov, gridx,
+                          gridy);  // Outputs: mov, gridx, gridy
 
-            sum_dist = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update1 = (float *)calloc((ngridx*ngridy), sizeof(float));
-            update2 = (float *)calloc((ngridx*ngridy), sizeof(float));
+            sum_dist = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update1  = (float*) calloc((ngridx * ngridy), sizeof(float));
+            update2  = (float*) calloc((ngridx * ngridy), sizeof(float));
 
             // For each projection angle
-            for (p=0; p<dt; p++)
+            for(p = 0; p < dt; p++)
             {
                 // Calculate the sin and cos values
                 // of the projection angle and find
                 // at which quadrant on the cartesian grid.
-                theta_p = fmod(theta1[p], 2*M_PI);
+                theta_p  = fmod(theta1[p], 2 * M_PI);
                 quadrant = calc_quadrant(theta_p);
-                sin_p = sinf(theta_p);
-                cos_p = cosf(theta_p);
+                sin_p    = sinf(theta_p);
+                cos_p    = cosf(theta_p);
 
                 // For each detector pixel
-                for (d=0; d<dx; d++)
+                for(d = 0; d < dx; d++)
                 {
                     // Calculate coordinates
-                    xi = -ngridx-ngridy;
-                    yi = (1-dx)/2.0+d+mov;
+                    xi = -ngridx - ngridy;
+                    yi = (1 - dx) / 2.0 + d + mov;
 
-                    srcx = xi*cos_p-yi*sin_p;
-                    srcy = xi*sin_p+yi*cos_p;
-                    detx = -xi*cos_p-yi*sin_p;
-                    dety = -xi*sin_p+yi*cos_p;
+                    srcx = xi * cos_p - yi * sin_p;
+                    srcy = xi * sin_p + yi * cos_p;
+                    detx = -xi * cos_p - yi * sin_p;
+                    dety = -xi * sin_p + yi * cos_p;
 
-                    dv = sqrt(pow(srcx-detx, 2)+pow(srcy-dety, 2));
-                    vx = (srcx-detx)/dv;
-                    vy = (srcy-dety)/dv;
+                    dv = sqrt(pow(srcx - detx, 2) + pow(srcy - dety, 2));
+                    vx = (srcx - detx) / dv;
+                    vy = (srcy - dety) / dv;
 
-                    calc_coords(
-                        ngridx, ngridy, xi, yi, sin_p, cos_p, gridx, gridy,
-                        coordx, coordy);
+                    calc_coords(ngridx, ngridy, xi, yi, sin_p, cos_p, gridx,
+                                gridy, coordx, coordy);
 
                     // Merge the (coordx, gridy) and (gridx, coordy)
-                    trim_coords(
-                        ngridx, ngridy, coordx, coordy, gridx, gridy,
-                        &asize, ax, ay, &bsize, bx, by);
+                    trim_coords(ngridx, ngridy, coordx, coordy, gridx, gridy,
+                                &asize, ax, ay, &bsize, bx, by);
 
                     // Sort the array of intersection points (ax, ay) and
                     // (bx, by). The new sorted intersection points are
                     // stored in (coorx, coory). Total number of points
                     // are csize.
-                    sort_intersections(
-                        quadrant, asize, ax, ay, bsize, bx, by,
-                        &csize, coorx, coory);
+                    sort_intersections(quadrant, asize, ax, ay, bsize, bx, by,
+                                       &csize, coorx, coory);
 
                     // Calculate the distances (dist) between the
                     // intersection points (coorx, coory). Find the
                     // indices of the pixels on the reconstruction grid.
-                    calc_dist2(
-                        ngridx, ngridy, csize, coorx, coory,
-                        indx, indy, dist);
+                    calc_dist2(ngridx, ngridy, csize, coorx, coory, indx, indy,
+                               dist);
 
                     // Calculate simdata
-                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx,
-                        csize, indx, indy, dist, vx, vy, recon1, recon2, recon3, axis3,
-                        simdata); // Output: simdata
+                    calc_simdata3(s, p, d, ngridx, ngridy, dt, dx, csize, indx,
+                                  indy, dist, vx, vy, recon1, recon2, recon3,
+                                  axis3,
+                                  simdata);  // Output: simdata
 
                     // Calculate dist*dist
                     sum_dist2 = 0.0;
-                    for (n=0; n<csize-1; n++)
+                    for(n = 0; n < csize - 1; n++)
                     {
-                        sum_dist2 += dist[n]*dist[n];
-                        sum_dist[indy[n] + indx[n]*ngridy] += dist[n];
+                        sum_dist2 += dist[n] * dist[n];
+                        sum_dist[indy[n] + indx[n] * ngridy] += dist[n];
                     }
 
                     // Update
-                    if (sum_dist2 != 0.0)
+                    if(sum_dist2 != 0.0)
                     {
-                        ind_data = d + p*dx + s*dt*dx;
-                        upd = (data3[ind_data]-simdata[ind_data])/sum_dist2;
-                        for (n=0; n<csize-1; n++)
+                        ind_data = d + p * dx + s * dt * dx;
+                        upd = (data3[ind_data] - simdata[ind_data]) / sum_dist2;
+                        for(n = 0; n < csize - 1; n++)
                         {
-                            update1[indy[n] + indx[n]*ngridy] += upd*dist[n]*vx;
-                            update2[indy[n] + indx[n]*ngridy] += upd*dist[n]*vy;
+                            update1[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vx;
+                            update2[indy[n] + indx[n] * ngridy] +=
+                                upd * dist[n] * vy;
                         }
                     }
                 }
             }
 
-            for (m = 0; m < ngridx; m++) {
-                for (n = 0; n < ngridy; n++) {
-                    if (sum_dist[n + m*ngridy] != 0.0)
+            for(m = 0; m < ngridx; m++)
+            {
+                for(n = 0; n < ngridy; n++)
+                {
+                    if(sum_dist[n + m * ngridy] != 0.0)
                     {
-                        recon1[m + s*ngridy + n*ngridx*ngridy] += update1[n + m*ngridy]/sum_dist[n + m*ngridy];
-                        recon3[m + s*ngridy + n*ngridx*ngridy] += update2[n + m*ngridy]/sum_dist[n + m*ngridy];
+                        recon1[m + s * ngridy + n * ngridx * ngridy] +=
+                            update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                        recon3[m + s * ngridy + n * ngridx * ngridy] +=
+                            update2[n + m * ngridy] / sum_dist[n + m * ngridy];
                     }
                 }
             }

--- a/tomopy/misc/benchmark.py
+++ b/tomopy/misc/benchmark.py
@@ -1,19 +1,10 @@
 
 import os
-import sys
-import signal
-import argparse
-
-import tornado
-import matplotlib
 import pylab
 import numpy as np
 import scipy.ndimage as ndimage
-import matplotlib.pyplot as plt
 import numpy.linalg as LA
-
 import timemory
-import timemory.options as options
 
 
 algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
@@ -36,9 +27,7 @@ def output_image(image, fname):
 
     pylab.imsave(fname, image, cmap='gray')
 
-    if os.path.exists(fname):
-        print("  --> Image file found @ '{}'...".format(fname))
-    else:
+    if not os.path.exists(fname):
         print("  ##################### WARNING #####################")
         print("  --> No image file at @ '{}' (expected) ...".format(fname))
 

--- a/tomopy/recon/algorithm.py
+++ b/tomopy/recon/algorithm.py
@@ -362,6 +362,7 @@ def _get_func(algorithm):
 def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
     axis_size = recon.shape[0]
     ncore, slcs = mproc.get_ncore_slices(axis_size, ncore, nchunk)
+
     if ncore == 1:
         for slc in slcs:
             # run in this thread (useful for debugging)

--- a/tomopy/recon/rotation.py
+++ b/tomopy/recon/rotation.py
@@ -191,7 +191,7 @@ def _find_center_cost(
     center = np.array(center, dtype='float32')
     rec = recon(
         tomo_ind, theta, center,
-        sinogram_order=sinogram_order, 
+        sinogram_order=sinogram_order,
         algorithm='gridrec')
 
     if mask is True:
@@ -453,7 +453,7 @@ def write_center(
             :cite:`Chambolle:11`.
         'grad'
             Gradient descent method with a constant step size
-    
+
     filter_name : str, optional
         Name of the filter for analytic reconstruction.
 


### PR DESCRIPTION
- Warning fixes
    - Fixed sign comparison warnings in src/morph.c
- Optimizations in src/utils.c via SIMD instructions
    - enable with `export CFLAGS="-fopenmp"` before build
        - this compiler flags will eventually be tested for availability and automatically applied when CMake build system is implemented
    - recorded speed-up on Cori-KNL, Cori-Haswell, Edison: ~1.25x
    - Optimized functions
        - calc_quadrant
        - calc_coords
        - trim_coords
        - sort_intersections
        - calc_dist
- floating-point consistency
    - replaced div by 2 with multiply by 0.5f (faster)
    - replaced double constants with float constants
    - replaced fmod with fmodf
- clang-format
    - created .clang-format file (requires clang-format v6.0+)
        - run: `clang-format -i $(find . -type f | egrep '\.h$|\.c$')` to apply formatting in-place
