### PR TITLE
Fix to 'python setup.py clean' Mk.config path check

### DIFF
--- a/build.py
+++ b/build.py
@@ -62,7 +62,7 @@ def build_libtomopy():
 
 def clean_libtomopy():
     """Clean libtomopy shared library for the current system."""
-    if os.path.exists(os.path.join(os.getcwd(), "config", "Mk.config")):
+    if os.path.exists(os.path.join(os.getcwd(), "Mk.config")):
         subprocess.check_call(('make', 'clean', '-f', get_makefile()))
     else:
         print("Mk.config does not exist. Assuming nothing to clean...")


### PR DESCRIPTION
- when running `python setup.py clean`, build.py was checking if file `$PWD/config/Mk.config` existed instead of `$PWD/Mk.config`, which is invalid because it is executed from `config` folder