### PR TITLE
BLD: Use python functions to replace `make install` and `make clean` in build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -12,6 +12,8 @@ from os.path import join as pjoin
 import logging
 import sys
 import subprocess
+import glob
+import shutil
 import time
 import logging
 import argparse
@@ -24,8 +26,6 @@ if 'CONDA_PREFIX' in os.environ:
 else:
     PREFIX = sys.prefix
 
-INSTALL_PREFIX = None
-
 def get_makefile():
     """Get the Makefile for the system"""
     if sys.platform.lower().startswith('win'):
@@ -35,46 +35,60 @@ def get_makefile():
     else:
         return 'Makefile.linux'
 
+def get_config(install_prefix):
+    if sys.platform.lower().startswith('win'):
+        conf = config_windows(install_prefix)
+    elif sys.platform == 'darwin':
+        conf = config_macosx(install_prefix)
+    else:
+        conf = config_linux(install_prefix)
+    return conf
 
-def build_libtomopy():
+
+def build_libtomopy(install_prefix='.'):
     """Build libtomopy shared library for the current system.
 
     This does the following steps:
       1. write `Mk.config` for current os
       2. run `make -j4` for the the current os
     """
-    if sys.platform.lower().startswith('win'):
-        conf = config_windows()
-    elif sys.platform == 'darwin':
-        conf = config_macosx()
-    else:
-        conf = config_linux()
-    logger.info("Config output:\n" + conf)
+    install_prefix = os.path.abspath(install_prefix)
+
+    conf = get_config(install_prefix)
+    logger.info("Config output:\n" + conf.format())
     with open('Mk.config', 'w') as fout:
-        fout.write(conf)
+        fout.write(conf.format())
     cmd = ['make', '-j4', '-f', get_makefile()]
-    _PREFIX_PATH = os.path.abspath(INSTALL_PREFIX)
-    _BINARY_PATH = os.path.abspath(os.path.join(os.getcwd(), ".."))
-    if INSTALL_PREFIX is not None and _PREFIX_PATH != _BINARY_PATH:
-        cmd.append('install')
     subprocess.check_call(tuple(cmd))
-
-
-def clean_libtomopy():
+    
+    src  = os.path.abspath(os.path.join("..", 'tomopy', 'sharedlibs', conf.sharedlib))
+    dest = os.path.join(install_prefix, conf.sharedlib)
+    shutil.copy(src, dest)
+    os.chmod(dest, 493) # chmod 755
+        
+def clean_libtomopy(install_prefix='.'):
     """Clean libtomopy shared library for the current system."""
-    if os.path.exists(os.path.join(os.getcwd(), "Mk.config")):
-        subprocess.check_call(('make', 'clean', '-f', get_makefile()))
-    else:
-        print("Mk.config does not exist. Assuming nothing to clean...")
+    install_prefix = os.path.abspath(install_prefix)
+    conf = get_config(install_prefix)
+    dylib = os.path.abspath(os.path.join("..", 'tomopy', 'sharedlibs', conf.sharedlib))
+    clean_files = [dylib]
+    for pattern in ('*.o', '*.gcda', '*.gcno', '*.gcov'):
+        clean_files.extend(glob.glob(pattern))
 
+    for fname in clean_files:
+        try:
+            os.unlink(fname)
+        except OSError:
+            logger.info("could not clean %s" % fname)
 
 class Config:
     """A string formatter for the Makefile"""
-    def __init__(self):
+    def __init__(self, install_prefix):
         self.compilerdir = 'gcc'
         self.sharedlib = ''
         self.arch_target = ''
         self.conda_compat = ''
+        self.install_prefix = install_prefix
         self.includes = [pjoin(os.path.dirname(os.getcwd()), 'include')]
         self.linklibs = ['%s' % pjoin(PREFIX, 'lib')]
         # anaconda compat?
@@ -109,32 +123,32 @@ class Config:
                 'LINK_LIB       = %s' % linklib,
                 'INCLUDE        = %s' % include,
                 'CONDA_COMPAT   = %s' % self.conda_compat,
-                'INSTALL_PREFIX = %s' % INSTALL_PREFIX,
+                'INSTALL_PREFIX = %s' % self.install_prefix,
                 '####', '']
         return '\n'.join(buff).replace('\\', '/')
 
 
-def config_linux():
+def config_linux(install_prefix):
     """config for Linux"""
     logger.info("Config for Linux")
-    config = Config()
+    config = Config(install_prefix)
     config.sharedlib = 'libtomopy.so'
-    return config.format()
+    return config
 
 
-def config_macosx():
+def config_macosx(install_prefix):
     """config for MacOSX"""
     logger.info("Config for MacOS")
-    config = Config()
+    config = Config(install_prefix)
     config.sharedlib = 'libtomopy.dylib'
     config.arch_target = '-arch x86_64'
-    return config.format()
+    return config
 
 
-def config_windows():
+def config_windows(install_prefix):
     """config for Windows"""
     logger.info("Config for Windows")
-    config = Config()
+    config = Config(install_prefix)
     compilerdir = None
     if 'conda' in sys.version:
         # Look for GCC in the conda directory
@@ -161,7 +175,7 @@ def config_windows():
                        os.path.dirname(os.path.dirname(PREFIX)),
                        "C:/Windows/System32",
                        ]
-    return config.format()
+    return config
 
 
 if __name__ == '__main__':
@@ -177,11 +191,11 @@ if __name__ == '__main__':
 
     curpath = os.getcwd()
     os.chdir('config')
-    if args.prefix is not None:
-        INSTALL_PREFIX = args.prefix
+    if args.prefix is None:
+        args.prefix = '.'
 
     if args.clean:
-        clean_libtomopy()
+        clean_libtomopy(install_prefix=args.prefix)
     else:
-        build_libtomopy()
+        build_libtomopy(install_prefix=args.prefix)
     os.chdir(curpath)

--- a/build.py
+++ b/build.py
@@ -60,12 +60,12 @@ def build_libtomopy(install_prefix='.'):
         fout.write(conf.format())
     cmd = ['make', '-j4', '-f', get_makefile()]
     subprocess.check_call(tuple(cmd))
-    
+
     src  = os.path.abspath(os.path.join("..", 'tomopy', 'sharedlibs', conf.sharedlib))
-    dest = os.path.join(install_prefix, conf.sharedlib)
+    dest = os.path.join(install_prefix, 'tomopy', 'sharedlibs', conf.sharedlib)
     shutil.copy(src, dest)
     os.chmod(dest, 493) # chmod 755
-        
+
 def clean_libtomopy(install_prefix='.'):
     """Clean libtomopy shared library for the current system."""
     install_prefix = os.path.abspath(install_prefix)

--- a/config/Makefile.darwin
+++ b/config/Makefile.darwin
@@ -8,7 +8,4 @@ CC           = $(COMPILER_DIR) $(CC_OPTIMIZE) $(CC_WARNINGS) $(ARCH_TARGET) $(IN
                 -DUSE_MKL -std=c99 $(CFLAGS)
 LINK         = $(COMPILER_DIR) -bundle -undefined dynamic_lookup $(ARCH_TARGS) $(LINK_LIB) $(LDFLAGS)
 
-INSTALL      = install -m 755
-REMOVE       = rm -f
-
 include Mk.base

--- a/config/Makefile.darwin
+++ b/config/Makefile.darwin
@@ -8,4 +8,7 @@ CC           = $(COMPILER_DIR) $(CC_OPTIMIZE) $(CC_WARNINGS) $(ARCH_TARGET) $(IN
                 -DUSE_MKL -std=c99 $(CFLAGS)
 LINK         = $(COMPILER_DIR) -bundle -undefined dynamic_lookup $(ARCH_TARGS) $(LINK_LIB) $(LDFLAGS)
 
+INSTALL      = install -m 755
+REMOVE       = rm -f
+
 include Mk.base

--- a/config/Makefile.linux
+++ b/config/Makefile.linux
@@ -8,8 +8,4 @@ CC           = $(COMPILER_DIR) -pthread $(CONDA_COMPAT) $(CC_OPTIMIZE) \
                $(CC_WARNINGS) $(ARCH_TARGET) $(INCLUDE) -DUSE_MKL -std=c99 $(CFLAGS)
 LINK         = $(COMPILER_DIR) -pthread -shared $(CONDA_COMPAT) $(LINK_LIB) $(LDFLAGS) \
                -Wl,-rpath=$(LINK_LIB),--no-as-needed
-
-INSTALL      = install -m 755
-REMOVE       = rm -f
-
 include Mk.base

--- a/config/Makefile.linux
+++ b/config/Makefile.linux
@@ -9,4 +9,7 @@ CC           = $(COMPILER_DIR) -pthread $(CONDA_COMPAT) $(CC_OPTIMIZE) \
 LINK         = $(COMPILER_DIR) -pthread -shared $(CONDA_COMPAT) $(LINK_LIB) $(LDFLAGS) \
                -Wl,-rpath=$(LINK_LIB),--no-as-needed
 
+INSTALL      = install -m 755
+REMOVE       = rm -f
+
 include Mk.base

--- a/config/Makefile.windows
+++ b/config/Makefile.windows
@@ -8,4 +8,7 @@ CC           = $(COMPILER_DIR)/gcc.exe $(CC_OPTIMIZE) $(CC_WARNINGS) $(INCLUDE) 
 LINK_LIBWIN  = $(LINK_LIB)/Library $(LINK_LIB)/Library/bin $(LINK_LIB)/libs $(LINK_LIB)/PCBuild/amd64
 LINK         = $(COMPILER_DIR)/gcc.exe -shared -s $(LINK_LIBWIN) -lvcruntime140
 
+INSTALL      = copy
+REMOVE       = del /q
+
 include Mk.base

--- a/config/Makefile.windows
+++ b/config/Makefile.windows
@@ -1,3 +1,4 @@
+
 # tomopy makefile for Windows
 
 include Mk.config
@@ -7,8 +8,5 @@ CC_OPTIMIZE  = -mdll -O -DMS_WIN64 -DUSE_MKL
 CC           = $(COMPILER_DIR)/gcc.exe $(CC_OPTIMIZE) $(CC_WARNINGS) $(INCLUDE)  -DPY3K -DWIN32 -std=c99
 LINK_LIBWIN  = $(LINK_LIB)/Library $(LINK_LIB)/Library/bin $(LINK_LIB)/libs $(LINK_LIB)/PCBuild/amd64
 LINK         = $(COMPILER_DIR)/gcc.exe -shared -s $(LINK_LIBWIN) -lvcruntime140
-
-INSTALL      = copy
-REMOVE       = del /q
 
 include Mk.base

--- a/config/Mk.base
+++ b/config/Mk.base
@@ -27,8 +27,3 @@ pml_quad.o project.o sirt.o tv.o utils.o vector.o: utils.h
 $(INSTALLDIR)/$(SHAREDLIB): $(OBJ)
 	$(LINK) -o $(INSTALLDIR)/$(SHAREDLIB) $(OBJ) $(LINK_CFLAGS)
 
-install: $(INSTALLDIR)/$(SHAREDLIB)
-	$(INSTALL) $(INSTALLDIR)/$(SHAREDLIB) $(INSTALL_PREFIX)/tomopy/sharedlibs/
-
-clean:
-	$(REMOVE) $(OBJ) $(INSTALLDIR)/$(SHAREDLIB) *.gcda *.gcno *.gcov

--- a/config/Mk.base
+++ b/config/Mk.base
@@ -28,7 +28,7 @@ $(INSTALLDIR)/$(SHAREDLIB): $(OBJ)
 	$(LINK) -o $(INSTALLDIR)/$(SHAREDLIB) $(OBJ) $(LINK_CFLAGS)
 
 install: $(INSTALLDIR)/$(SHAREDLIB)
-	install -m 755 $(INSTALLDIR)/$(SHAREDLIB) $(INSTALL_PREFIX)/tomopy/sharedlibs/
+	$(INSTALL) $(INSTALLDIR)/$(SHAREDLIB) $(INSTALL_PREFIX)/tomopy/sharedlibs/
 
 clean:
-	rm -f $(OBJ) $(INSTALLDIR)/$(SHAREDLIB) *.gcda *.gcno *.gcov
+	$(REMOVE) $(OBJ) $(INSTALLDIR)/$(SHAREDLIB) *.gcda *.gcno *.gcov


### PR DESCRIPTION
This addresses #371  by using `shutil.copy()`, `os.chmod()`, and `os.unlink()` instead of relying on `make install` to run an external `install` program (and `make clean` to run an external `rm` program).   These external programs may not be available on all platforms and environments.
