### PR TITLE
Demote dxchange to soft dependency

### DIFF
--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,5 +1,5 @@
 ======================
-Tomographic data files
+How to read tomographic data
 ======================
 
 For reading tomography files formatted in different ways, please 

--- a/envs/requirements-all.txt
+++ b/envs/requirements-all.txt
@@ -1,5 +1,3 @@
-dxchange
-h5py
 mkl
 mkl-devel
 mkl_fft
@@ -9,3 +7,4 @@ pywavelets
 scikit-image
 scipy
 six
+tifffile

--- a/meta.yaml
+++ b/meta.yaml
@@ -23,16 +23,17 @@ requirements:
     - python={{ python }}
     - setuptools
   run:
-    - dxchange
     - futures  # [py2k]
-    - numexpr
     - mkl
     - mkl_fft
-    - python={{ python }}
+    - numexpr
     - numpy
+    - python={{ python }}
+    - pywavelets
     - scikit-image
     - scipy
     - six
+    - tifffile
 
 test:
   requires:

--- a/tomopy/misc/npmath.py
+++ b/tomopy/misc/npmath.py
@@ -49,7 +49,6 @@
 import numpy as np
 import scipy
 import logging
-import warnings
 
 logger = logging.getLogger(__name__)
 

--- a/tomopy/prep/alignment.py
+++ b/tomopy/prep/alignment.py
@@ -81,6 +81,38 @@ __all__ = ['align_seq',
            ]
 
 
+def write_tiff(data, fname='tmp/data', digit=None, ext='tiff'):
+    """
+    Write image data to a tiff file.
+
+    Overwrite existing data and infer data-type from the data.
+
+    Parameters
+    ----------
+    data : ndarray
+        Array data to be saved.
+    fname : str
+        File name to which the data is saved. ``.tiff`` extension
+        will be appended even if it already has one.
+    digit : int
+        Append this number to fname using a dash. e.g. {fname}-{digit}.{ext}
+    """
+    # Add the extension and digit.
+    if digit is None:
+        fname = '{}.{}'.format(fname, ext)
+    else:
+        fname = '{}-{:d}.{}'.format(fname, digit, ext)
+    # Convert to absolute path.
+    fname = os.path.abspath(fname)
+    # Create the directory if it doesn't exist.
+    dname = os.path.dirname(os.path.abspath(fname))
+    if not os.path.exists(dname):
+        os.makedirs(dname)
+    # Save the file.
+    import tifffile
+    tifffile.imsave(fname, data)
+
+
 def align_seq(
         prj, ang, fdir='.', iters=10, pad=(0, 0),
         blur=True, center=None, algorithm='sirt',
@@ -136,7 +168,7 @@ def align_seq(
         rout is set to zero.
     save : bool, optional
         Saves projections and corresponding reconstruction
-        for each algorithm iteration. Requires the dxchange package.
+        for each algorithm iteration.
     debug : book, optional
         Provides debugging info such as iterations and error.
 
@@ -199,10 +231,9 @@ def align_seq(
             conv[n] = np.linalg.norm(err)
 
         if save:
-            import dxchange
-            dxchange.write_tiff(prj, fdir + '/tmp/iters/prj/prj')
-            dxchange.write_tiff(sim, fdir + '/tmp/iters/sim/sim')
-            dxchange.write_tiff(rec, fdir + '/tmp/iters/rec/rec')
+            write_tiff(prj, fdir + '/tmp/iters/prj/prj', n)
+            write_tiff(sim, fdir + '/tmp/iters/sim/sim', n)
+            write_tiff(rec, fdir + '/tmp/iters/rec/rec', n)
 
     # Re-normalize data
     prj *= scl
@@ -264,7 +295,7 @@ def align_joint(
         rout is set to zero.
     save : bool, optional
         Saves projections and corresponding reconstruction
-        for each algorithm iteration. Requires the dxchange package.
+        for each algorithm iteration.
     debug : book, optional
         Provides debugging info such as iterations and error.
 
@@ -335,10 +366,9 @@ def align_joint(
             conv[n] = np.linalg.norm(err)
 
         if save:
-            import dxchange
-            dxchange.write_tiff(prj, 'tmp/iters/prj/prj')
-            dxchange.write_tiff(sim, 'tmp/iters/sim/sim')
-            dxchange.write_tiff(rec, 'tmp/iters/rec/rec')
+            write_tiff(prj, 'tmp/iters/prj/prj', n)
+            write_tiff(sim, 'tmp/iters/sim/sim', n)
+            write_tiff(rec, 'tmp/iters/rec/rec', n)
 
     # Re-normalize data
     prj *= scl

--- a/tomopy/prep/alignment.py
+++ b/tomopy/prep/alignment.py
@@ -50,7 +50,6 @@ import numpy as np
 import concurrent.futures as cf
 import tomopy.util.mproc as mproc
 import logging
-import dxchange
 
 from skimage import transform as tf
 from skimage.feature import register_translation
@@ -61,8 +60,6 @@ from scipy.signal import medfilt, medfilt2d
 from scipy.optimize import curve_fit
 from scipy.ndimage import affine_transform
 from collections import namedtuple
-
-import dxchange
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +127,7 @@ def align_seq(
 
     upsample_factor : integer, optional
         The upsampling factor. Registration accuracy is
-        inversely propotional to upsample_factor. 
+        inversely propotional to upsample_factor.
     rin : scalar, optional
         The inner radius of blur function. Pixels inside
         rin is set to one.
@@ -139,7 +136,7 @@ def align_seq(
         rout is set to zero.
     save : bool, optional
         Saves projections and corresponding reconstruction
-        for each algorithm iteration.
+        for each algorithm iteration. Requires the dxchange package.
     debug : book, optional
         Provides debugging info such as iterations and error.
 
@@ -202,6 +199,7 @@ def align_seq(
             conv[n] = np.linalg.norm(err)
 
         if save:
+            import dxchange
             dxchange.write_tiff(prj, fdir + '/tmp/iters/prj/prj')
             dxchange.write_tiff(sim, fdir + '/tmp/iters/sim/sim')
             dxchange.write_tiff(rec, fdir + '/tmp/iters/rec/rec')
@@ -266,7 +264,7 @@ def align_joint(
         rout is set to zero.
     save : bool, optional
         Saves projections and corresponding reconstruction
-        for each algorithm iteration.
+        for each algorithm iteration. Requires the dxchange package.
     debug : book, optional
         Provides debugging info such as iterations and error.
 
@@ -337,6 +335,7 @@ def align_joint(
             conv[n] = np.linalg.norm(err)
 
         if save:
+            import dxchange
             dxchange.write_tiff(prj, 'tmp/iters/prj/prj')
             dxchange.write_tiff(sim, 'tmp/iters/sim/sim')
             dxchange.write_tiff(rec, 'tmp/iters/rec/rec')
@@ -532,13 +531,13 @@ def find_slits_corners_aps_1id(img,
     Automatically locate the slit box location by its four corners.
 
     NOTE:
-    The four slits that form a binding box is the current setup at aps_1id, 
-    which reduce the illuminated region on the detector. Since the slits are 
-    stationary, they can serve as a reference to check detector drifting 
-    during the scan. Technically, the four slits should be used to find 
-    the transformation matrix (not necessarily affine) to correct the image. 
-    However, since we are dealing with 2D images with very little distortion, 
-    affine transformation matrices were used for approximation. Therefore 
+    The four slits that form a binding box is the current setup at aps_1id,
+    which reduce the illuminated region on the detector. Since the slits are
+    stationary, they can serve as a reference to check detector drifting
+    during the scan. Technically, the four slits should be used to find
+    the transformation matrix (not necessarily affine) to correct the image.
+    However, since we are dealing with 2D images with very little distortion,
+    affine transformation matrices were used for approximation. Therefore
     the "four corners" are used instead of all four slits.
 
     Parameters
@@ -549,10 +548,10 @@ def find_slits_corners_aps_1id(img,
         method for auto detecting slit corners
             - simple    :: assume a rectange slit box, fast but less accurate
                            (1 pixel precision)
-            - quadrant  :: subdivide the image into four quandrant, then use 
+            - quadrant  :: subdivide the image into four quandrant, then use
                            an explicit method to find the corner
                            (1 pixel precision)
-            - quadrant+ :: similar to quadrant, but use curve_fit (gauss1d) to 
+            - quadrant+ :: similar to quadrant, but use curve_fit (gauss1d) to
                            find the corner
                            (0.1 pixel precision)
     medfilt2_kernel_size : int, optional

--- a/tomopy/prep/alignment.py
+++ b/tomopy/prep/alignment.py
@@ -200,9 +200,9 @@ def align_seq(
             conv[n] = np.linalg.norm(err)
 
         if save:
-            write_tiff(prj, fdir + '/tmp/iters/prj/prj', n)
-            write_tiff(sim, fdir + '/tmp/iters/sim/sim', n)
-            write_tiff(rec, fdir + '/tmp/iters/rec/rec', n)
+            write_tiff(prj, fdir + '/tmp/iters/prj', n)
+            write_tiff(sim, fdir + '/tmp/iters/sim', n)
+            write_tiff(rec, fdir + '/tmp/iters/rec', n)
 
     # Re-normalize data
     prj *= scl
@@ -335,9 +335,9 @@ def align_joint(
             conv[n] = np.linalg.norm(err)
 
         if save:
-            write_tiff(prj, 'tmp/iters/prj/prj', n)
-            write_tiff(sim, 'tmp/iters/sim/sim', n)
-            write_tiff(rec, 'tmp/iters/rec/rec', n)
+            write_tiff(prj, 'tmp/iters/prj', n)
+            write_tiff(sim, 'tmp/iters/sim', n)
+            write_tiff(rec, 'tmp/iters/rec', n)
 
     # Re-normalize data
     prj *= scl

--- a/tomopy/prep/alignment.py
+++ b/tomopy/prep/alignment.py
@@ -50,8 +50,6 @@ import numpy as np
 import concurrent.futures as cf
 import tomopy.util.mproc as mproc
 import logging
-import warnings
-import os
 import dxchange
 
 from skimage import transform as tf
@@ -61,7 +59,7 @@ from tomopy.sim.project import project
 from tomopy.misc.npmath import gauss1d, calc_affine_transform
 from scipy.signal import medfilt, medfilt2d
 from scipy.optimize import curve_fit
-from scipy.ndimage import affine_transform, shift
+from scipy.ndimage import affine_transform
 from collections import namedtuple
 
 import dxchange
@@ -510,7 +508,6 @@ def shift_images(prj, sx, sy):
     """
 
     from skimage import transform as tf
-    from skimage.feature import register_translation
 
     # Needs scaling for skimage float operations.
     prj, scl = scale(prj)

--- a/tomopy/prep/alignment.py
+++ b/tomopy/prep/alignment.py
@@ -56,6 +56,7 @@ from skimage.feature import register_translation
 from tomopy.recon.algorithm import recon
 from tomopy.sim.project import project
 from tomopy.misc.npmath import gauss1d, calc_affine_transform
+from tomopy.util.misc import write_tiff
 from scipy.signal import medfilt, medfilt2d
 from scipy.optimize import curve_fit
 from scipy.ndimage import affine_transform
@@ -79,38 +80,6 @@ __all__ = ['align_seq',
            'calc_slit_box_aps_1id',
            'remove_slits_aps_1id',
            ]
-
-
-def write_tiff(data, fname='tmp/data', digit=None, ext='tiff'):
-    """
-    Write image data to a tiff file.
-
-    Overwrite existing data and infer data-type from the data.
-
-    Parameters
-    ----------
-    data : ndarray
-        Array data to be saved.
-    fname : str
-        File name to which the data is saved. ``.tiff`` extension
-        will be appended even if it already has one.
-    digit : int
-        Append this number to fname using a dash. e.g. {fname}-{digit}.{ext}
-    """
-    # Add the extension and digit.
-    if digit is None:
-        fname = '{}.{}'.format(fname, ext)
-    else:
-        fname = '{}-{:d}.{}'.format(fname, digit, ext)
-    # Convert to absolute path.
-    fname = os.path.abspath(fname)
-    # Create the directory if it doesn't exist.
-    dname = os.path.dirname(os.path.abspath(fname))
-    if not os.path.exists(dname):
-        os.makedirs(dname)
-    # Save the file.
-    import tifffile
-    tifffile.imsave(fname, data)
 
 
 def align_seq(

--- a/tomopy/recon/rotation.py
+++ b/tomopy/recon/rotation.py
@@ -55,7 +55,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from scipy import ndimage
-from tomopy.util.misc import fft2
+from tomopy.util.misc import fft2, write_tiff
 from scipy.optimize import minimize
 from skimage.feature import register_translation
 from tomopy.misc.corr import circ_mask

--- a/tomopy/recon/rotation.py
+++ b/tomopy/recon/rotation.py
@@ -55,8 +55,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from scipy import ndimage
+import tifffile
 from tomopy.util.misc import fft2
-import dxchange
 from scipy.optimize import minimize
 from skimage.feature import register_translation
 from tomopy.misc.corr import circ_mask
@@ -347,7 +347,7 @@ def _create_mask(nrow, ncol, radius, drop):
         Image height.
     ncol : int
         Image width.
-    radius: int 
+    radius: int
         Radius of an object, in pixel unit.
     drop : int
         Drop lines around vertical center of the mask.
@@ -392,7 +392,7 @@ def find_center_pc(proj1, proj2, tol=0.5, rotc_guess=None):
     tol : scalar, optional
         Subpixel accuracy
 
-    rotc_guess : float, optional 
+    rotc_guess : float, optional
         Initual guess value for the rotation center
 
     Returns
@@ -552,10 +552,13 @@ def write_center(
         rec = circ_mask(rec, axis=0)
 
     # Save images to a temporary folder.
+    dpath = os.path.abspath(dpath)
+    if not os.path.exists(dpath):
+        os.makedirs(dpath)
     for m in range(len(center)):
         fname = os.path.join(
             dpath, str('{0:.2f}'.format(center[m]) + '.tiff'))
-        dxchange.write_tiff(rec[m], fname=fname, overwrite=True)
+        tifffile.imsave(file=fname, data=rec[m])
 
 
 def mask_empty_slice(tomo, threshold=0.25):

--- a/tomopy/recon/rotation.py
+++ b/tomopy/recon/rotation.py
@@ -55,7 +55,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from scipy import ndimage
-import tifffile
 from tomopy.util.misc import fft2
 from scipy.optimize import minimize
 from skimage.feature import register_translation
@@ -552,13 +551,8 @@ def write_center(
         rec = circ_mask(rec, axis=0)
 
     # Save images to a temporary folder.
-    dpath = os.path.abspath(dpath)
-    if not os.path.exists(dpath):
-        os.makedirs(dpath)
     for m in range(len(center)):
-        fname = os.path.join(
-            dpath, str('{0:.2f}'.format(center[m]) + '.tiff'))
-        tifffile.imsave(file=fname, data=rec[m])
+        write_tiff(data=rec[m], fname=dpath, digit='{0:.2f}'.format(center[m]))
 
 
 def mask_empty_slice(tomo, threshold=0.25):

--- a/tomopy/util/misc.py
+++ b/tomopy/util/misc.py
@@ -55,8 +55,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import logging
 import warnings
+import tifffile
 from .. import fft_impl
-
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2016, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
-__all__ = ['deprecated', 'fft2', 'ifft2', 'fft', 'ifft']
+__all__ = ['deprecated', 'write_tiff', 'fft2', 'ifft2', 'fft', 'ifft']
 
 
 def deprecated(func, msg=None):
@@ -84,6 +84,37 @@ def deprecated(func, msg=None):
     new_func.__doc__ = func.__doc__
     new_func.__dict__.update(func.__dict__)
     return new_func
+
+
+def write_tiff(data, fname='tmp/data', digit=None, ext='tiff'):
+    """
+    Write image data to a tiff file.
+
+    Overwrite existing data and infer data-type from the data.
+
+    Parameters
+    ----------
+    data : ndarray
+        Array data to be saved.
+    fname : str
+        File name to which the data is saved. ``.tiff`` extension
+        will be appended even if it already has one.
+    digit : int
+        Append this number to fname using a dash. e.g. {fname}-{digit}.{ext}
+    """
+    # Add the extension and digit.
+    if digit is None:
+        fname = '{}.{}'.format(fname, ext)
+    else:
+        fname = '{}-{}.{}'.format(fname, digit, ext)
+    # Convert to absolute path.
+    fname = os.path.abspath(fname)
+    # Create the directory if it doesn't exist.
+    dname = os.path.dirname(os.path.abspath(fname))
+    if not os.path.exists(dname):
+        os.makedirs(dname)
+    # Save the file.
+    tifffile.imsave(fname, data)
 
 
 if fft_impl == 'mkl_fft':
@@ -117,7 +148,7 @@ elif fft_impl == 'pyfftw':
         return pyfftw.interfaces.numpy_fft.fft(x, n=n, axis=axis,
                                                overwrite_input=overwrite_input,
                                                planner_effort=_plan_effort(extra_info))
-    
+
 
     def ifft(x, n=None, axis=-1, overwrite_input=False, extra_info=None):
         return pyfftw.interfaces.numpy_fft.ifft(x, n=n, axis=axis,
@@ -129,7 +160,7 @@ elif fft_impl == 'pyfftw':
         return pyfftw.interfaces.numpy_fft.fft2(x, s=s, axes=axes,
                                                 overwrite_input=overwrite_input,
                                                 planner_effort=_plan_effort(extra_info))
-    
+
 
     def ifft2(x, s=None, axes=(-2,-1), overwrite_input=False, extra_info=None):
         return pyfftw.interfaces.numpy_fft.ifft2(x, s=s, axes=axes,

--- a/tomopy/util/misc.py
+++ b/tomopy/util/misc.py
@@ -56,6 +56,7 @@ from __future__ import (absolute_import, division, print_function,
 import logging
 import warnings
 import tifffile
+import os
 from .. import fft_impl
 
 
@@ -100,13 +101,13 @@ def write_tiff(data, fname='tmp/data', digit=None, ext='tiff'):
         File name to which the data is saved. ``.tiff`` extension
         will be appended even if it already has one.
     digit : int
-        Append this number to fname using a dash. e.g. {fname}-{digit}.{ext}
+        Append this number to fname using a folder e.g. {fname}/{digit}.{ext}
     """
     # Add the extension and digit.
     if digit is None:
         fname = '{}.{}'.format(fname, ext)
     else:
-        fname = '{}-{}.{}'.format(fname, digit, ext)
+        fname = os.path.join(fname, '{}.{}'.format(digit, ext))
     # Convert to absolute path.
     fname = os.path.abspath(fname)
     # Create the directory if it doesn't exist.

--- a/tomopy/util/misc.py
+++ b/tomopy/util/misc.py
@@ -99,15 +99,15 @@ def write_tiff(data, fname='tmp/data', digit=None, ext='tiff'):
         Array data to be saved.
     fname : str
         File name to which the data is saved. ``.tiff`` extension
-        will be appended even if it already has one.
+        will be appended if it doesn't already have one.
     digit : int
         Append this number to fname using a folder e.g. {fname}/{digit}.{ext}
     """
     # Add the extension and digit.
-    if digit is None:
-        fname = '{}.{}'.format(fname, ext)
-    else:
-        fname = os.path.join(fname, '{}.{}'.format(digit, ext))
+    if digit is not None:
+        fname = os.path.join(fname, str(digit))
+    if not str(fname).endswith(ext):
+        fname = ".".join([fname, ext])
     # Convert to absolute path.
     fname = os.path.abspath(fname)
     # Create the directory if it doesn't exist.


### PR DESCRIPTION
The main contribution of this pull is to move `dxchange` from required dependency to soft dependency. It also removes some unused import statements and corrects the runtime requirements in meta.yaml and requirements.txt

Addresses some of #377.

This pull does not remove `pyfftw` related code. However, `pyfftw` is not required dependency.