### PR TITLE
BUG: Add keyword to suppress skimage API change warning

### DIFF
--- a/tomopy/misc/phantom.py
+++ b/tomopy/misc/phantom.py
@@ -82,7 +82,8 @@ DATA_PATH = os.path.abspath(
 
 try:
     resize_kwargs = {'anti_aliasing': False}
-    ignore = skimage.transform.resize(np.zeros(5), 2, **resize_kwargs)
+    ignore = skimage.transform.resize(np.zeros(5), 2, mode='constant',
+                                      **resize_kwargs)
 except TypeError:
     logger.debug("Determined that the anti_aliasing keyword is not needed.")
     resize_kwargs = dict()


### PR DESCRIPTION
The skimage API is changing in 0.15, so adding this keyword prevents
the behavior of skimage.transform.resize from changing. This warning
is drowning the tests output on Windows.