### PR TITLE
BLD: fixing a tiny typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def add_option(lc_name, disp_name):
                         help="Explicitly enable {} build".format(disp_name))
     # disable option
     parser.add_argument("--disable-{}".format(lc_name), action='store_true',
-                        help="Explicitly disnable {} build".format(disp_name))
+                        help="Explicitly disable {} build".format(disp_name))
 
 add_option("cuda", "CUDA")
 add_option("nvtx", "NVTX (NVIDIA Nsight)")


### PR DESCRIPTION
The `setup.py` looks really re-worked since I saw it last time (triggered by @carterbox's https://github.com/data-exchange/dxchange/issues/81#issuecomment-498422461), and they are great changes based on scikit-build. I noticed a minor typo in a help message, which is fixed here.