### PR TITLE
DOC: Add Python 2 deprecation warning to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ then open a terminal or a command prompt window and run:
   conda install -c conda-forge tomopy
 
 
-.. warning:: TomoPy will drop support for Python 2 no later than 1 January 2020. For more information, visit https://python3statement.org/.
+.. warning:: TomoPy will drop support for Python 2 before 1 January 2020. For more information, visit https://python3statement.org/.
 
 Try Now
 =======

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ TomoPy
 .. image:: https://travis-ci.org/tomopy/tomopy.svg?branch=master
    :target: https://travis-ci.org/tomopy/tomopy
    :alt: Travis CI
-  
+
 .. image:: https://ci.appveyor.com/api/projects/status/t2ty4k5snkv9od0r/branch/master?svg=true
    :target: https://ci.appveyor.com/project/tomopy/tomopy
    :alt: Appyveyor
@@ -25,11 +25,11 @@ TomoPy
    :target: https://anaconda.org/conda-forge/tomopy
    :alt: Anaconda downloads
 
-.. image:: https://mybinder.org/badge.svg 
+.. image:: https://mybinder.org/badge.svg
    :target: https://mybinder.org/v2/gh/tomopy/tomopy/master
    :alt: Use on Binder
 
-**TomoPy** is an open-source Python package for tomographic data 
+**TomoPy** is an open-source Python package for tomographic data
 processing and image reconstruction.
 
 Features
@@ -42,11 +42,13 @@ Features
 Installation
 ============
 
-Have `Conda <http://continuum.io/downloads>`_ installed first,  
+Have `Conda <http://continuum.io/downloads>`_ installed first,
 then open a terminal or a command prompt window and run:
 
     conda install -c conda-forge tomopy
-    
+
+.. warning:: TomoPy will drop support for Python 2 no later than 1 January 2020. For more information, visit https://python3statement.org/.
+
 Try Now
 =======
 
@@ -66,5 +68,5 @@ Contribute
 License
 =======
 
-The project is licensed under the 
+The project is licensed under the
 `BSD-3 <https://github.com/tomopy/tomopy/blob/master/LICENSE.txt>`_ license.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-TomoPy
-######
+**TomoPy** is an open-source
+Python package for tomographic data processing and image reconstruction.
 
 .. image:: https://readthedocs.org/projects/tomopy/badge/?version=latest
    :target: https://readthedocs.org/projects/tomopy/?badge=latest
@@ -29,8 +29,7 @@ TomoPy
    :target: https://mybinder.org/v2/gh/tomopy/tomopy/master
    :alt: Use on Binder
 
-**TomoPy** is an open-source Python package for tomographic data
-processing and image reconstruction.
+|
 
 Features
 ========
@@ -45,7 +44,10 @@ Installation
 Have `Conda <http://continuum.io/downloads>`_ installed first,
 then open a terminal or a command prompt window and run:
 
-    conda install -c conda-forge tomopy
+.. code-block::
+
+  conda install -c conda-forge tomopy
+
 
 .. warning:: TomoPy will drop support for Python 2 no later than 1 January 2020. For more information, visit https://python3statement.org/.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,31 +1,21 @@
-.. title:: TomoPy
-
 .. image:: img/tomopy-logo.png
    :width: 320px
    :alt: TomoPy
 
-`TomoPy <https://github.com/tomopy/tomopy.git>`_ is an open-source
-Python package for tomographic data processing and image reconstruction.
 
-Features
-========
+.. include:: ../../README.rst
 
-* Image reconstruction algorithms for tomography.
-* Various filters, ring removal algorithms, phase retrieval algorithms.
-* Forward projection operator for absorption and wave propagation.
 
-Contribute
-==========
+Indices and tables
+==================
 
-* Issue Tracker: https://github.com/tomopy/tomopy/issues
-* Documentation: https://github.com/tomopy/tomopy/tree/master/doc
-* Source Code: https://github.com/tomopy/tomopy/tree/master/tomopy
-* Tests: https://github.com/tomopy/tomopy/tree/master/test
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
 
-Table of Contents
-=================
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    about
@@ -38,18 +28,3 @@ Table of Contents
    demo
    faq
    credits
-
-License
-=======
-
-The project is licensed under the
-`BSD-3 <https://github.com/tomopy/tomopy/blob/master/LICENSE.txt>`_ license.
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-

--- a/source/tomopy/__init__.py
+++ b/source/tomopy/__init__.py
@@ -81,7 +81,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 if sys.version_info < (3,):
     warnings.warn(
-        'TomoPy will drop support for Python 2 no later than 1 January 2020.'
+        'TomoPy will drop support for Python 2 before 1 January 2020.'
         ' For more information, visit https://python3statement.org/.',
         UserWarning,
     )

--- a/source/tomopy/__init__.py
+++ b/source/tomopy/__init__.py
@@ -49,6 +49,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
+import warnings
+
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     __version__ = get_distribution(__name__).version
@@ -75,3 +78,10 @@ from tomopy.util.mproc import set_debug
 
 import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+if sys.version_info < (3,):
+    warnings.warn(
+        'TomoPy will drop support for Python 2 no later than 1 January 2020.'
+        ' For more information, visit https://python3statement.org/.',
+        UserWarning,
+    )


### PR DESCRIPTION
We will be discontinuing support for Python 2 no later than 1 January 2020. I've added an annoying warning to the front page of the repo, the front page of the docs, and at runtime when importing TomoPy with Python 2.