### PR TITLE
BLD: Remove license and readme from MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,2 @@
-include README.rst
-include LICENSE.txt
 graft source/tomopy
 global-exclude *.py[co]

--- a/envs/linux-36.yml
+++ b/envs/linux-36.yml
@@ -25,7 +25,7 @@ dependencies:
   - pywavelets
   - scikit-build
   - scikit-image
-  - scipy<1.3
+  - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
   - six

--- a/envs/linux-37.yml
+++ b/envs/linux-37.yml
@@ -24,7 +24,7 @@ dependencies:
   - pywavelets
   - scikit-build
   - scikit-image
-  - scipy<1.3
+  - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
   - six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file=README.rst
+long_description=file: README.rst, LICENSE.txt
 
 [nosetests]
 verbosity=2

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,6 @@ if platform.system() == "Darwin":
     version = ".".join([version[0], version[1]])
     cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET={}".format(version)]
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
 # suppress:
 #  "setuptools_scm/git.py:68: UserWarning: "/.../tomopy" is shallow and may cause errors"
 # since 'error' in output causes CDash to interpret warning as error
@@ -103,7 +100,6 @@ with warnings.catch_warnings():
         author='Doga Gursoy',
         author_email='dgursoy@aps.anl.gov',
         description='Tomographic Reconstruction in Python.',
-        long_description=read('README.rst'),
         long_description_content_type='text/x-rst',
         keywords=['tomography', 'reconstruction', 'imaging'],
         url='http://tomopy.readthedocs.org',

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,9 @@ if platform.system() == "Darwin":
     version = ".".join([version[0], version[1]])
     cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET={}".format(version)]
 
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 # suppress:
 #  "setuptools_scm/git.py:68: UserWarning: "/.../tomopy" is shallow and may cause errors"
 # since 'error' in output causes CDash to interpret warning as error
@@ -100,6 +103,8 @@ with warnings.catch_warnings():
         author='Doga Gursoy',
         author_email='dgursoy@aps.anl.gov',
         description='Tomographic Reconstruction in Python.',
+        long_description=read('README.rst'),
+        long_description_content_type='text/x-rst',
         keywords=['tomography', 'reconstruction', 'imaging'],
         url='http://tomopy.readthedocs.org',
         download_url='http://github.com/tomopy/tomopy.git',


### PR DESCRIPTION
These files, if included in the MANIFEST, are placed in the root
directory of the python installation instead of with the source. This
can cause problems with packaging because files are placed outside the
tomopy directory. Also, they are not necessary because wheels will
automatically include files named LICENSE* in the dist-info and the
README text can be included with the setup metadata.

Resolves #434