### PR TITLE
specify Python 3.6 for binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,5 +4,7 @@ channels:
   - defaults
   - astra-toolbox
 dependencies:
+  # astra-toolbox has not released stable builds with Python >3.6
+  - python=3.6
   - tomopy
   - astra-toolbox


### PR DESCRIPTION
astra-toolbox hasn't made stable builds with Python >3.6 and 3.7 is the default on Binder.

the alternative is to allow dev versions by adding `astra-toolbox/label/dev` channel instead, which does have 3.7 builds.