### PR TITLE
Added interp_nan function

### DIFF
--- a/source/tomopy/misc/corr.py
+++ b/source/tomopy/misc/corr.py
@@ -353,16 +353,22 @@ def remove_neg(arr, val=0., ncore=None):
     return arr
 
 
-def interp_nan(arr, size=3, ncore=None):
-    """
-    Replace NaN values in array by interpolation of neighboring data. 
+def interp_nan(arr, size=(1, 3, 3), ncore=None):
+    """Replace NaN values in array with median of neighboring data.
+
+    The value for *kernel* can be either a scalar, or a tuple with
+    length matching *arr.ndim*. If a scalar is given it will be
+    broadcast to the appropriate shape. Ex: *size=5* with a
+    3-dimensional *arr* is equivalent to *size=(5, 5, 5)*
+
+    If the output still contains NaN's, try a bigger kernel.
 
     Parameters
     ----------
     arr : ndarray
         Input array.
-    size : int, optional
-        Size of kernel to use for interpolation.
+    size : int or tuple, optional
+        Size of kernel to use for median filtering.
     ncore : int, optional
         Number of cores that will be assigned to jobs (coming soon).
 
@@ -370,61 +376,12 @@ def interp_nan(arr, size=3, ncore=None):
     -------
     ndarray
        Corrected array.
+
     """
-    ndim = arr.ndim
-    noutdim = 1 # 1 for scalar data, 3 for 3D vector data, etc
-    # Get coordinate positions of data
-    all_points = np.mgrid[tuple(slice(0, d) for d in arr.shape)]
-    # assert all_points.shape == arr.shape, "{} - {}".format(all_points.shape, arr.shape)
-    # Separate into good and bad data
+    median = filters.median_filter(arr, size=size)
     arr_isnan = np.isnan(arr)
-    values = arr[~arr_isnan]
-    values = values[..., np.newaxis]
-    points = all_points[:,~arr_isnan]
-    xi = all_points[:,arr_isnan]
-    # Interpolate the missing values
-    print(f"Points: {points.shape}, Values: {values.shape}, xi: {xi.shape}")
-    interped = interpn(points, arr.flatten(), xi)
-    print("Result:", interped)
-    # nans, x= nan_helper(y)
-    # y[nans]= np.interp(x(nans), x(~nans), y[~nans])
-    
-    # val = np.float32(val)
-
-    # with mproc.set_numexpr_threads(ncore):
-    #     ne.evaluate('where(arr!=arr, val, arr)', out=arr)
-    # import matplotlib.pyplot as plt
-    # fig, (ax0, ax1) = plt.subplots(1, 2)
-    # ax0.imshow(arr[2])
-    # ax1.imshow(points[:,:,-1,2], vmax=48)
-    # plt.show()
-    return arr
-
-
-def remove_neg(arr, val=0., ncore=None):
-    """
-    Replace negative values in array with a given value.
-
-    Parameters
-    ----------
-    arr : ndarray
-        Input array.
-    val : float, optional
-        Values to be replaced with negative values in array.
-    ncore : int, optional
-        Number of cores that will be assigned to jobs.
-
-    Returns
-    -------
-    ndarray
-       Corrected array.
-    """
-    arr = dtype.as_float32(arr)
-    val = np.float32(val)
-
-    with mproc.set_numexpr_threads(ncore):
-        ne.evaluate('where(arr<0, val, arr)', out=arr)
-    return arr
+    median[~arr_isnan] = arr[~arr_isnan]
+    return median
 
 
 def remove_outlier(arr, dif, size=3, axis=0, ncore=None, out=None):

--- a/test/test_tomopy/test_misc/test_corr.py
+++ b/test/test_tomopy/test_misc/test_corr.py
@@ -49,10 +49,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import unittest
-from tomopy.misc.corr import gaussian_filter, median_filter, remove_neg, remove_nan, remove_outlier, circ_mask
+from tomopy.misc.corr import (gaussian_filter, median_filter,
+                              remove_neg, remove_nan, remove_outlier,
+                              circ_mask, interp_nan)
 from ..util import read_file, loop_dim
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
@@ -75,6 +77,33 @@ class ImageFilterTestCase(unittest.TestCase):
         assert_allclose(
             remove_nan(
                 [np.nan, 1.5, 2, np.nan, 1]), [0, 1.5, 2, 0, 1])
+
+    def test_interp_nan(self):
+        use_1d = False
+        if use_1d:
+            in_arr = read_file('proj.npy')[2, 6]
+            nan_idx = 17
+        else:
+            in_arr = read_file('proj.npy')
+            nan_idx = (2, 6, 17) # Which pixel to change
+        # Modify the input array to have a np.nan value
+        in_arr[nan_idx] = np.nan
+        # Create an interpolated result to compare against
+        # expected_arr = np.copy(in_arr)
+        # r = int((kernel_size - 1) / 2)
+        # box = expected_arr[nan_idx[0],
+        #                    nan_idx[1]-r:nan_idx[1]+r+1,
+        #                    nan_idx[2]-r:nan_idx[2]+r+1,]
+        # expected_arr[nan_idx] = np.nanmedian(box)
+        # Run the *interp_nan* function and check the results
+        out_arr = interp_nan(in_arr)
+        # import matplotlib.pyplot as plt
+        # fig, (ax0, ax1) = plt.subplots(1, 2)
+        # ax0.imshow(in_arr[2])
+        # # ax1.imshow(expected_arr[2])
+        # plt.show()
+        print(out_arr)
+        assert_array_equal(out_arr, expected_arr)
 
     def test_remove_outlier(self):
         proj = read_file('proj.npy')

--- a/test/test_tomopy/test_misc/test_corr.py
+++ b/test/test_tomopy/test_misc/test_corr.py
@@ -79,30 +79,20 @@ class ImageFilterTestCase(unittest.TestCase):
                 [np.nan, 1.5, 2, np.nan, 1]), [0, 1.5, 2, 0, 1])
 
     def test_interp_nan(self):
-        use_1d = False
-        if use_1d:
-            in_arr = read_file('proj.npy')[2, 6]
-            nan_idx = 17
-        else:
-            in_arr = read_file('proj.npy')
-            nan_idx = (2, 6, 17) # Which pixel to change
+        in_arr = read_file('proj.npy')
+        nan_idx = (2, 6, 17) # Which pixel to change
+        kernel_size = 3
         # Modify the input array to have a np.nan value
         in_arr[nan_idx] = np.nan
-        # Create an interpolated result to compare against
-        # expected_arr = np.copy(in_arr)
-        # r = int((kernel_size - 1) / 2)
-        # box = expected_arr[nan_idx[0],
-        #                    nan_idx[1]-r:nan_idx[1]+r+1,
-        #                    nan_idx[2]-r:nan_idx[2]+r+1,]
-        # expected_arr[nan_idx] = np.nanmedian(box)
+        # Create an filtered result to compare against
+        expected_arr = np.copy(in_arr)
+        r = int((kernel_size - 1) / 2)
+        box = expected_arr[nan_idx[0],
+                           nan_idx[1]-r:nan_idx[1]+r+1,
+                           nan_idx[2]-r:nan_idx[2]+r+1,]
+        expected_arr[nan_idx] = np.nanmedian(box)
         # Run the *interp_nan* function and check the results
-        out_arr = interp_nan(in_arr)
-        # import matplotlib.pyplot as plt
-        # fig, (ax0, ax1) = plt.subplots(1, 2)
-        # ax0.imshow(in_arr[2])
-        # # ax1.imshow(expected_arr[2])
-        # plt.show()
-        print(out_arr)
+        out_arr = interp_nan(in_arr, size=(1, kernel_size, kernel_size))
         assert_array_equal(out_arr, expected_arr)
 
     def test_remove_outlier(self):


### PR DESCRIPTION
I use *remove_nan* to get rid of some pesky nan's and inf's that come up from dead/hot pixels, etc. However, the downside is that I have to choose a specific value for all bad values. Instead, I want a function that decides a replacement value for each bad value based on neighboring data.

This PR tests and implements a function that replaces bad data with a local median filter of the surrounding data. It achieves the desired result (mostly) but is most likely horribly inefficient since it calculates the entire median_filtered dataset first and so takes a lot of time and memory. I was hoping to use scipy.interpolate.interpn, but it doesn't really allow for interpolation of dense matrices.

Looking at the rest of the misc/corr.py functions they seem to include some parallelization and memory management. **Are there any simple ways that I can improve this code to make use of some of those optimizations?**