### PR TITLE
DOC: Deduplicate install directions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,8 +1,0 @@
-For Windows, both MinGW-64 and `make` need to be installed and placed in the
-PATH, so that the appropriate 'gcc.exe' (that is, one that supports C99) and
-'make.exe' can be found. For Anaconda Python on Windows, adding the conda
-packages MinGW and make provides these resources.
-
-Then use
-
-    pip install .

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,0 +1,25 @@
+Installing dependencies
+=======================
+To build and run TomoPy, you will need to install at least the dependencies
+listed in ``envs/{platform}-{version}.yml`` plus additional dependencies based
+on your platform. For example, installing requirements for building
+the Python 3.6 version on Linux can be accomplished as follows::
+
+    $ conda env create -f envs/linux-36.yml [-n ENVIRONMENT]
+
+
+Additional Windows Requirements
+-------------------------------
+The Windows VC++2017 compiler cannot be distributed through conda. You must
+install it using the Windows Build Tools installer. The conda package for this
+compiler merely searches for this compiler and links it to the conda
+environment into which it is installed.
+
+
+Building TomoPy
+===============
+
+After navigating to inside the `tomopy` directory, you can install TomoPy by
+running the install script in the typical Python way::
+
+    $ python setup.py install

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -2,19 +2,27 @@ Installing dependencies
 =======================
 To build and run TomoPy, you will need to install at least the dependencies
 listed in ``envs/{platform}-{version}.yml`` plus additional dependencies based
-on your platform. For example, installing requirements for building
+on your platform. For convenience, installing requirements for building
 the Python 3.6 version on Linux can be accomplished as follows::
 
     $ conda env create -f envs/linux-36.yml [-n ENVIRONMENT]
-
+    
+This will create a new conda environment named tomopy with the build
+dependencies. If you already have a conda environment named tomopy. Use the
+`-n` option to name it something else.
 
 Additional Windows Requirements
 -------------------------------
-The Windows VC++2017 compiler cannot be distributed through conda. You must
-install it using the Windows Build Tools installer. The conda package for this
-compiler merely searches for this compiler and links it to the conda
-environment into which it is installed.
+The Windows VC++2017 compiler cannot be distributed through conda. The conda
+package for this compiler creates link from the system provided compiler
+to the conda environment into which it is installed. Install VC++2017 using
+the Windows Build Tools installer; Visual Studio (the IDE) is not required
+to build TomoPy.
 
+Additional CUDA Requirements
+----------------------------
+The CUDA compiler cannot be distributed through conda. Building TomoPy with
+GPU features requires the CUDA Toolkit and NVCC.
 
 Building TomoPy
 ===============

--- a/doc/source/devguide.rst
+++ b/doc/source/devguide.rst
@@ -34,23 +34,7 @@ and ask you where you want to save it. Select a location in your
 computer and feel comfortable with making modifications in the code.
 
 
-Installing dependencies
-=======================
-To build and run TomoPy, you will need to install at least the dependencies
-listed in ``envs/{platform}-{version}.yml`` plus additional dependencies based
-on your build environment. For example, installing requirements for building
-the Python 3.6 version on Linux can be accomplished as follows::
-
-    $ conda env create -f envs/linux-36.yml
-
-
-Building TomoPy
-===============
-
-After navigating to inside the `tomopy` directory, you can install TomoPy by
-running the install script in the typical Python way::
-
-    $ python setup.py install
+.. include:: ../../INSTALL.rst
 
 
 Running the Tests

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -15,8 +15,8 @@ and its dependencies for you.
 First, you must have `Conda <https://docs.conda.io/en/latest/miniconda.html>`_
 installed.
 
-Next, install TomoPy and all its dependencies into a new Conda environment
-called ``tomopy`` by running::
+Next, install TomoPy and all its runtime dependencies into a new Conda
+environment called ``tomopy`` by running::
 
     $ conda create --name tomopy --channel conda-forge tomopy
 
@@ -36,3 +36,10 @@ containing TomoPy and run::
 
 For some more information about using Conda, please refer to the `docs
 <https://conda.io/projects/conda>`__.
+
+
+Build from Source
+-----------------
+
+Please read the development guide for directions on how to build TomoPy from
+the source code.


### PR DESCRIPTION
This pull request updates the documentation by removing old installation directions from INSTALL which were confusing builders.

Closes #489 