### PR TITLE
Fixing align_joint for gridrec

### DIFF
--- a/source/tomopy/prep/alignment.py
+++ b/source/tomopy/prep/alignment.py
@@ -303,8 +303,11 @@ def align_joint(
             _rec = rec
 
         # Reconstruct image.
+        extra_kwargs = {}
+        if algorithm != 'gridrec':
+            extra_kwargs['num_iter'] = 1
         rec = recon(prj, ang, center=center, algorithm=algorithm,
-                    num_iter=1, init_recon=_rec)
+                    init_recon=_rec, **extra_kwargs)
 
         # Re-project data and obtain simulated data.
         sim = project(rec, ang, center=center, pad=False)

--- a/source/tomopy/prep/alignment.py
+++ b/source/tomopy/prep/alignment.py
@@ -296,6 +296,10 @@ def align_joint(
     # Initialization of reconstruction.
     rec = 1e-12 * np.ones((prj.shape[1], prj.shape[2], prj.shape[2]))
 
+    extra_kwargs = {}
+    if algorithm != 'gridrec':
+        extra_kwargs['num_iter'] = 1
+
     # Register each image frame-by-frame.
     for n in range(iters):
 
@@ -303,9 +307,6 @@ def align_joint(
             _rec = rec
 
         # Reconstruct image.
-        extra_kwargs = {}
-        if algorithm != 'gridrec':
-            extra_kwargs['num_iter'] = 1
         rec = recon(prj, ang, center=center, algorithm=algorithm,
                     init_recon=_rec, **extra_kwargs)
 


### PR DESCRIPTION
The existing call to `recon` in `align_joint` contains a hard-coded `num_iter` arguments which triggers `ValueError` when `algorithm == 'gridrec'`. 
The PR fixes it by only passing `num_iter=1` to the function when `algorithm != 'gridrec'`.