### PR TITLE
Made MKL dependency optional

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,30 @@ jobs:
       nosetests
     displayName: nosetests
 
+- job: Linux_No_MKL
+  pool:
+    vmImage: 'ubuntu-latest'
+  strategy:
+    matrix:
+      Python37:
+        python.version: '37'
+    maxParallel: 4
+  steps:
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+  - script: |
+      conda env create -n tomopy --quiet -f envs/linux-$(python.version).yml
+      conda uninstall mkl mkl-devel mkl_fft
+    displayName: Create build environment
+  - script: |
+      source activate tomopy
+      python setup.py install
+    displayName: Setup and install
+  - script: |
+      source activate tomopy
+      nosetests
+    displayName: nosetests
+
 - job: macOS
   pool:
     vmImage: 'macOS-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,36 +62,14 @@ jobs:
         python.version: '36'
       Python37:
         python.version: '37'
+      Python37-nomkl:
+        python.version: '37-nomkl'
     maxParallel: 4
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
   - script: |
       conda env create -n tomopy --quiet -f envs/linux-$(python.version).yml
-    displayName: Create build environment
-  - script: |
-      source activate tomopy
-      python setup.py install
-    displayName: Setup and install
-  - script: |
-      source activate tomopy
-      nosetests
-    displayName: nosetests
-
-- job: Linux_No_MKL
-  pool:
-    vmImage: 'ubuntu-latest'
-  strategy:
-    matrix:
-      Python37:
-        python.version: '37'
-    maxParallel: 4
-  steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
-  - script: |
-      conda env create -n tomopy --quiet -f envs/linux-$(python.version).yml
-      conda uninstall mkl mkl-devel mkl_fft
     displayName: Create build environment
   - script: |
       source activate tomopy

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -11,6 +11,7 @@ include(Compilers)
 set(_USE_OMP ON)
 set(_USE_CUDA ON)
 set(_USE_CXX_GRIDREC OFF)
+set(_USE_MKL ON)
 
 # if Windows MSVC compiler, use C++ version of gridrec
 if(WIN32)
@@ -34,6 +35,23 @@ if(CUDA_FOUND)
     endif()
 else()
     set(_USE_CUDA OFF)
+endif()
+
+################################################################################
+#
+#        MKL (required for gridrec)
+#
+################################################################################
+
+find_package(MKL QUIET)
+if(MKL_FOUND)
+    list(APPEND EXTERNAL_INCLUDE_DIRS ${MKL_INCLUDE_DIRS})
+    list(APPEND EXTERNAL_LIBRARIES ${MKL_LIBRARIES})
+elseif(TOMOPY_USE_MKL)
+    message(FATAL_ERROR "MKL not found. Aborting build.")
+else() 
+    message(WARNING "MKL not found. Gridrec reconstruction algorithm will not be available.")
+    set(_USE_MKL OFF)
 endif()
 
 # features
@@ -63,6 +81,7 @@ add_option(TOMOPY_USE_PTL "Enable Parallel Tasking Library (PTL)" ON)
 add_option(TOMOPY_USE_CLANG_TIDY "Enable clang-tidy (C++ linter)" OFF)
 add_option(TOMOPY_USE_CUDA "Enable CUDA option for GPU execution" ${_USE_CUDA})
 add_option(TOMOPY_USER_FLAGS "Insert CFLAGS and CXXFLAGS regardless of whether pass check" OFF)
+add_option(TOMOPY_USE_MKL "Enables Intel Math Kernel Library" ${_USE_MKL})
 
 if(TOMOPY_USE_CUDA)
     add_option(TOMOPY_USE_NVTX "Enable NVTX for Nsight" OFF)

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -40,21 +40,6 @@ if(PYTHON_EXECUTABLE)
         ${PYTHON_ROOT_DIR}/include)
 endif()
 
-
-################################################################################
-#
-#        MKL (required)
-#
-################################################################################
-
-find_package(MKL REQUIRED)
-
-if(MKL_FOUND)
-    list(APPEND EXTERNAL_INCLUDE_DIRS ${MKL_INCLUDE_DIRS})
-    list(APPEND EXTERNAL_LIBRARIES ${MKL_LIBRARIES})
-endif()
-
-
 ################################################################################
 #
 #        OpenCV (required)

--- a/envs/linux-37-nomkl.yml
+++ b/envs/linux-37-nomkl.yml
@@ -4,7 +4,6 @@ channels:
   - jrmadsen
   - defaults
 dependencies:
-  - nomkl
   - coverage!=5.0.2
   - dxchange
   - gcc_linux-64
@@ -13,6 +12,7 @@ dependencies:
   - h5py
   - libstdcxx-ng
   - libgcc-ng
+  - nomkl
   - nose
   - numexpr
   - numpy ["blas=*=openblas"]

--- a/envs/linux-37-nomkl.yml
+++ b/envs/linux-37-nomkl.yml
@@ -1,0 +1,29 @@
+name: tomopy
+channels:
+  - conda-forge
+  - jrmadsen
+  - defaults
+dependencies:
+  - nomkl
+  - coverage!=5.0.2
+  - dxchange
+  - gcc_linux-64
+  - git
+  - gxx_linux-64
+  - h5py
+  - libstdcxx-ng
+  - libgcc-ng
+  - nose
+  - numexpr
+  - numpy ["blas=*=openblas"]
+  - opencv>=3.4 ["blas=*=openblas"]
+  - pyctest>0.0.10
+  - python=3.7
+  - pywavelets
+  - scikit-build
+  - scikit-image
+  - scipy
+  - setuptools_scm
+  - setuptools_scm_git_archive
+  - six
+  - timemory

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ add_option("gperf", "gperftools")
 add_option("timemory", "TiMemory")
 add_option("sanitizer", "Enable sanitizer (default=leak)")
 add_option("tasking", "Tasking library (PTL)")
+add_option("mkl", "Intel MKL")
 
 parser.add_argument("--sanitizer-type", default="leak",
                     help="Set the sanitizer type",
@@ -68,6 +69,7 @@ add_bool_opt("TOMOPY_USE_GPERF", args.enable_gperf, args.disable_gperf)
 add_bool_opt("TOMOPY_USE_TIMEMORY", args.enable_timemory, args.disable_timemory)
 add_bool_opt("TOMOPY_USE_SANITIZER", args.enable_sanitizer, args.disable_sanitizer)
 add_bool_opt("TOMOPY_USE_PTL", args.enable_tasking, args.disable_tasking)
+add_bool_opt("TOMOPY_USE_MKL", args.enable_mkl, args.disable_mkl)
 
 if args.enable_cuda:
     cmake_args.append("-DCUDA_ARCH={}".format(args.cuda_arch))

--- a/source/libtomo/CMakeLists.txt
+++ b/source/libtomo/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/misc)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/prep)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/recon)
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/gridrec)
+if(TOMOPY_USE_MKL)
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/gridrec)
+endif()
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/accel)

--- a/source/tomopy/util/extern.py
+++ b/source/tomopy/util/extern.py
@@ -127,7 +127,7 @@ LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec")
 
 
 def MissingLibrary(function):
-    print(f"The {function} algorithm is unavailable".
+    print(f"The {function} algorithm is unavailable"
           + "Check CMake logs to determine if TomoPy was"
           + "built with dependencies required by this algorithm.")
 

--- a/source/tomopy/util/extern.py
+++ b/source/tomopy/util/extern.py
@@ -128,8 +128,8 @@ LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec")
 
 def MissingLibrary(function):
     print(f"The {function} algorithm is unavailable"
-          + "Check CMake logs to determine if TomoPy was"
-          + "built with dependencies required by this algorithm.")
+          " Check CMake logs to determine if TomoPy was"
+          " built with dependencies required by this algorithm.")
 
 
 def c_normalize_bg(tomo, air):

--- a/source/tomopy/util/extern.py
+++ b/source/tomopy/util/extern.py
@@ -126,6 +126,10 @@ LIB_TOMOPY_ACCEL = c_shared_lib("libtomopy-accel")
 LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec")
 
 
+def MissingLibrary(function):
+    print(f"The {function} algorithm is unavailable. Check CMake logs to determine if TomoPy was built with dependencies required by this algorithm.")
+
+
 def c_normalize_bg(tomo, air):
     dt, dy, dx = tomo.shape
 
@@ -349,6 +353,10 @@ def c_fbp(tomo, center, recon, theta, **kwargs):
 
 
 def c_gridrec(tomo, center, recon, theta, **kwargs):
+
+    if LIB_TOMOPY_GRIDREC is None:
+        return
+
     if len(tomo.shape) == 2:
         # no y-axis (only one slice)
         dy = 1
@@ -576,6 +584,7 @@ def c_sirt(tomo, center, recon, theta, **kwargs):
             dtype.as_c_int(kwargs['num_gridx']),
             dtype.as_c_int(kwargs['num_gridy']),
             dtype.as_c_int(kwargs['num_iter']))
+
 
 def c_tv(tomo, center, recon, theta, **kwargs):
     if len(tomo.shape) == 2:

--- a/source/tomopy/util/extern.py
+++ b/source/tomopy/util/extern.py
@@ -127,7 +127,7 @@ LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec")
 
 
 def MissingLibrary(function):
-    print(f"The {function} algorithm is unavailable"
+    print(f"The {function} algorithm is unavailable."
           " Check CMake logs to determine if TomoPy was"
           " built with dependencies required by this algorithm.")
 

--- a/source/tomopy/util/extern.py
+++ b/source/tomopy/util/extern.py
@@ -127,7 +127,9 @@ LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec")
 
 
 def MissingLibrary(function):
-    print(f"The {function} algorithm is unavailable. Check CMake logs to determine if TomoPy was built with dependencies required by this algorithm.")
+    print(f"The {function} algorithm is unavailable".
+          + "Check CMake logs to determine if TomoPy was"
+          + "built with dependencies required by this algorithm.")
 
 
 def c_normalize_bg(tomo, air):
@@ -355,7 +357,7 @@ def c_fbp(tomo, center, recon, theta, **kwargs):
 def c_gridrec(tomo, center, recon, theta, **kwargs):
 
     if LIB_TOMOPY_GRIDREC is None:
-        return
+        return MissingLibrary("gridrec")
 
     if len(tomo.shape) == 2:
         # no y-axis (only one slice)

--- a/test/test_tomopy/test_recon/test_algorithm.py
+++ b/test/test_tomopy/test_recon/test_algorithm.py
@@ -60,11 +60,12 @@ __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
-try: 
-    import mkl 
+try:
+    import mkl
     found_mkl = True
 except ImportError:
     found_mkl = False
+
 
 class ReconstructionAlgorithmTestCase(unittest.TestCase):
     def setUp(self):

--- a/test/test_tomopy/test_recon/test_algorithm.py
+++ b/test/test_tomopy/test_recon/test_algorithm.py
@@ -60,6 +60,11 @@ __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
+try: 
+    import mkl 
+    found_mkl = True
+except ImportError:
+    found_mkl = False
 
 class ReconstructionAlgorithmTestCase(unittest.TestCase):
     def setUp(self):
@@ -82,6 +87,7 @@ class ReconstructionAlgorithmTestCase(unittest.TestCase):
             recon(self.prj, self.ang, algorithm='fbp'),
             read_file('fbp.npy'), rtol=1e-2)
 
+    @unittest.skipUnless(found_mkl, "Requires MKL")
     def test_gridrec_custom(self):
         assert_allclose(
             recon(self.prj, self.ang, algorithm='gridrec', filter_name='none'),
@@ -89,6 +95,7 @@ class ReconstructionAlgorithmTestCase(unittest.TestCase):
                 self.prj, self.ang, algorithm='gridrec', filter_name='custom',
                 filter_par=np.ones(self.prj.shape[-1], dtype=np.float32)))
 
+    @unittest.skipUnless(found_mkl, "Requires MKL")
     def test_gridrec(self):
         assert_allclose(
             recon(self.prj, self.ang, algorithm='gridrec', filter_name='none'),

--- a/test/test_tomopy/test_recon/test_algorithm.py
+++ b/test/test_tomopy/test_recon/test_algorithm.py
@@ -88,7 +88,7 @@ class ReconstructionAlgorithmTestCase(unittest.TestCase):
             recon(self.prj, self.ang, algorithm='fbp'),
             read_file('fbp.npy'), rtol=1e-2)
 
-    @unittest.skipUnless(found_mkl, "Requires MKL")
+    @unittest.skipUnless(found_mkl, "Gridrec requires MKL.")
     def test_gridrec_custom(self):
         assert_allclose(
             recon(self.prj, self.ang, algorithm='gridrec', filter_name='none'),
@@ -96,7 +96,7 @@ class ReconstructionAlgorithmTestCase(unittest.TestCase):
                 self.prj, self.ang, algorithm='gridrec', filter_name='custom',
                 filter_par=np.ones(self.prj.shape[-1], dtype=np.float32)))
 
-    @unittest.skipUnless(found_mkl, "Requires MKL")
+    @unittest.skipUnless(found_mkl, "Gridrec requires MKL.")
     def test_gridrec(self):
         assert_allclose(
             recon(self.prj, self.ang, algorithm='gridrec', filter_name='none'),

--- a/test/test_tomopy/test_recon/test_rotation.py
+++ b/test/test_tomopy/test_recon/test_rotation.py
@@ -65,18 +65,19 @@ __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
-try: 
-    import mkl 
+try:
+    import mkl
     found_mkl = True
 except ImportError:
     found_mkl = False
+
 
 class CenterFindingTestCase(unittest.TestCase):
 
     @unittest.skipUnless(found_mkl, "Requires MKL")
     def test_write_center(self):
         dpath = os.path.join('test', 'tmp')
-        #if get_nproc() > 1 and get_rank() > 0:
+        # if get_nproc() > 1 and get_rank() > 0:
         #    dpath += "_{}".format(get_rank())
         cen_range = (5, 7, 0.5)
         cen = np.arange(*cen_range)

--- a/test/test_tomopy/test_recon/test_rotation.py
+++ b/test/test_tomopy/test_recon/test_rotation.py
@@ -65,8 +65,15 @@ __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
+try: 
+    import mkl 
+    found_mkl = True
+except ImportError:
+    found_mkl = False
 
 class CenterFindingTestCase(unittest.TestCase):
+
+    @unittest.skipUnless(found_mkl, "Requires MKL")
     def test_write_center(self):
         dpath = os.path.join('test', 'tmp')
         #if get_nproc() > 1 and get_rank() > 0:


### PR DESCRIPTION
This makes it that Intel MKL is optional during the build process. By default, MKL will be enabled, but if it is not found, it will be disabled, a warning message will be provided, and the gridrec reconstruction algorithm will be disabled. If the user specifies for MKL to be installed and it is not found, CMake will return an error and the build process will stop.