### PR TITLE
Remove extraneous definitions from C extension headers

### DIFF
--- a/source/include/misc/morph.h
+++ b/source/include/misc/morph.h
@@ -45,9 +45,6 @@
 
 #pragma once
 
-#include <math.h>
-#include <stdio.h>
-
 #ifdef WIN32
 #    define DLL __declspec(dllexport)
 #else

--- a/source/include/misc/remove_ring.h
+++ b/source/include/misc/remove_ring.h
@@ -45,71 +45,13 @@
 
 #pragma once
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-
 #ifdef WIN32
 #    define DLL __declspec(dllexport)
 #else
 #    define DLL
 #endif
 
-#define PI 3.14159265359
-
 DLL void
 remove_ring(float* data, float center_x, float center_y, int dx, int dy, int dz,
             float thresh_max, float thresh_min, float threshold, int angular_min,
             int ring_width, int int_mode, int istart, int iend);
-
-int
-min_distance_to_edge(float center_x, float center_y, int width, int height);
-
-int
-iroundf(float x);
-
-float**
-polar_transform(float** image, float center_x, float center_y, int width, int height,
-                int* p_pol_width, int* p_pol_height, float thresh_max, float thresh_min,
-                int r_scale, int ang_scale, int overhang);
-
-float**
-inverse_polar_transform(float** polar_image, float center_x, float center_y,
-                        int pol_width, int pol_height, int width, int height, int r_scale,
-                        int over_hang);
-
-void
-swap_float(float* arr, int index1, int index2);
-
-void
-swap_integer(int* arr, int index1, int index2);
-
-int
-partition(float* median_array, int left, int right, int pivot_index);
-
-int
-partition_2_arrays(float* median_array, int* position_array, int left, int right,
-                   int pivot_index);
-
-void
-quick_sort(float* median_array, int left, int right);
-
-void
-quick_sort_2_arrays(float* median_array, int* position_array, int left, int right);
-
-void
-bubble_2_arrays(float* median_array, int* position_array, int index, int length);
-
-void
-median_filter_fast_1D(float*** filtered_image, float*** image, int start_row,
-                      int start_col, int end_row, int end_col, char axis, int kernel_rad,
-                      int filter_width, int width, int height);
-
-void
-mean_filter_fast_1D(float*** filtered_image, float*** image, int start_row, int start_col,
-                    int end_row, int end_col, int int_mode, int kernel_rad, int width,
-                    int height);
-
-void
-ring_filter(float*** polar_image, int pol_height, int pol_width, float threshold,
-            int m_rad, int m_azi, int ring_width, int int_mode);

--- a/source/include/prep/prep.h
+++ b/source/include/prep/prep.h
@@ -45,8 +45,6 @@
 
 #pragma once
 
-#include <stdio.h>
-
 #ifdef WIN32
 #    define DLL __declspec(dllexport)
 #else

--- a/source/include/prep/stripe.h
+++ b/source/include/prep/stripe.h
@@ -45,9 +45,6 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #ifdef WIN32
 #    define DLL __declspec(dllexport)
 #else

--- a/source/include/recon/project.h
+++ b/source/include/recon/project.h
@@ -43,10 +43,6 @@
 
 #pragma once
 
-#include <assert.h>
-#include <math.h>
-#include <stdlib.h>
-
 #ifdef WIN32
 #    define DLL __declspec(dllexport)
 #else
@@ -54,46 +50,14 @@
 #endif
 
 void DLL
-     preprocessing(int ngridx, int ngridy, int dz, float center, float* mov, float* gridx,
-                   float* gridy);
-
-int DLL
-    calc_quadrant(float theta_p);
+     project(const float* obj, int oy, int ox, int oz, float* data, int dy, int dt, int dx,
+             const float* center, const float* theta);
 
 void DLL
-     calc_coords(int ngridx, int ngridy, float xi, float yi, float sin_p, float cos_p,
-                 const float* gridx, const float* gridy, float* coordx, float* coordy);
+     project2(const float* objx, const float* objy, int oy, int ox, int oz, float* data,
+              int dy, int dt, int dx, const float* center, const float* theta);
 
 void DLL
-     trim_coords(int ngridx, int ngridy, const float* coordx, const float* coordy,
-                 const float* gridx, const float* gridy, int* asize, float* ax, float* ay,
-                 int* bsize, float* bx, float* by);
-
-void DLL
-     sort_intersections(int ind_condition, int asize, const float* ax, const float* ay,
-                        int bsize, const float* bx, const float* by, int* csize, float* coorx,
-                        float* coory);
-
-void DLL
-     calc_dist(int ngridx, int ngridy, int csize, const float* coorx, const float* coory,
-               int* indi, float* dist);
-
-void DLL
-     calc_dist2(int ngridx, int ngridy, int csize, const float* coorx, const float* coory,
-                int* indx, int* indy, float* dist);
-
-void DLL
-     calc_simdata(int s, int p, int d, int ngridx, int ngridy, int dt, int dx, int csize,
-                  const int* indi, const float* dist, const float* model, float* simdata);
-
-void DLL
-     calc_simdata2(int s, int p, int d, int ngridx, int ngridy, int dt, int dx, int csize,
-                   const int* indx, const int* indy, const float* dist, float vx, float vy,
-                   const float* modelx, const float* modely, float* simdata);
-
-void DLL
-     calc_simdata3(int s, int p, int d, int ngridx, int ngridy, int dt, int dx, int csize,
-                   const int* indx, const int* indy, const float* dist, float vx, float vy,
-                   const float* modelx, const float* modely, const float* modelz, int axis,
-                   float* simdata);
-
+     project3(const float* objx, const float* objy, const float* objz, int oy, int ox, int oz,
+              float* data, int dy, int dt, int dx, const float* center, const float* theta,
+              int axis);

--- a/source/include/recon/recon.h
+++ b/source/include/recon/recon.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.
+
+// Copyright 2015. UChicago Argonne, LLC. This software was produced
+// under U.S. Government contract DE-AC02-06CH11357 for Argonne National
+// Laboratory (ANL), which is operated by UChicago Argonne, LLC for the
+// U.S. Department of Energy. The U.S. Government has rights to use,
+// reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR
+// UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+// ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+// modified to produce derivative works, such modified software should
+// be clearly marked, so as not to confuse it with the version available
+// from ANL.
+
+// Additionally, redistribution and use in source and binary forms, with
+// or without modification, are permitted provided that the following
+// conditions are met:
+
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+
+//     * Neither the name of UChicago Argonne, LLC, Argonne National
+//       Laboratory, ANL, the U.S. Government, nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago
+// Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#ifdef WIN32
+#    define DLL __declspec(dllexport)
+#else
+#    define DLL
+#endif
+
+void DLL
+     art(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+         float* recon, int ngridx, int ngridy, int num_iter);
+
+void DLL
+     bart(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+          float* recon, int ngridx, int ngridy, int num_iter, int num_block,
+          const float* ind_block);  // TODO: I think this should be int *
+
+void DLL
+     fbp(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+         float* recon, int ngridx, int ngridy, const char name[16], const float* filter_par);
+
+void DLL
+     grad(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+          float* recon, int ngridx, int ngridy, int num_iter, const float* reg_pars);
+
+void DLL
+     mlem(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+          float* recon, int ngridx, int ngridy, int num_iter);
+
+void DLL
+     osem(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+          float* recon, int ngridx, int ngridy, int num_iter, int num_block,
+          const float* ind_block);
+
+void DLL
+     ospml_hybrid(const float* data, int dy, int dt, int dx, const float* center,
+                  const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+                  const float* reg_pars, int num_block, const float* ind_block);
+
+void DLL
+     ospml_quad(const float* data, int dy, int dt, int dx, const float* center,
+                const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+                const float* reg_pars, int num_block, const float* ind_block);
+
+void DLL
+     pml_hybrid(const float* data, int dy, int dt, int dx, const float* center,
+                const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+                const float* reg_pars);
+
+void DLL
+     pml_quad(const float* data, int dy, int dt, int dx, const float* center,
+              const float* theta, float* recon, int ngridx, int ngridy, int num_iter,
+              const float* reg_pars);
+
+void DLL
+     sirt(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+          float* recon, int ngridx, int ngridy, int num_iter);
+
+void DLL
+     tv(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+        float* recon, int ngridx, int ngridy, int num_iter, const float* reg_pars);
+
+void DLL
+     tikh(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+          float* recon, int ngridx, int ngridy, int num_iter, const float* reg_data, const float* reg_pars);
+
+void DLL
+     vector(const float* data, int dy, int dt, int dx, const float* center, const float* theta,
+            float* recon1, float* recon2, int ngridx, int ngridy, int num_iter);
+
+void DLL
+     vector2(const float* data1, const float* data2, int dy, int dt, int dx,
+             const float* center1, const float* center2, const float* theta1,
+             const float* theta2, float* recon1, float* recon2, float* recon3, int ngridx,
+             int ngridy, int num_iter, int axis1, int axis2);
+
+void DLL
+     vector3(const float* data1, const float* data2, const float* data3, int dy, int dt,
+             int dx, const float* center1, const float* center2, const float* center3,
+             const float* theta1, const float* theta2, const float* theta3, float* recon1,
+             float* recon2, float* recon3, int ngridx, int ngridy, int num_iter, int axis1,
+             int axis2, int axis3);

--- a/source/include/recon/utils.h
+++ b/source/include/recon/utils.h
@@ -47,6 +47,11 @@
 #include <math.h>
 #include <stdlib.h>
 
+#define _USE_MATH_DEFINES
+#ifndef M_PI
+#    define M_PI 3.14159265358979323846264338327
+#endif
+
 #ifdef WIN32
 #    define DLL __declspec(dllexport)
 #else

--- a/source/libtomo/misc/morph.c
+++ b/source/libtomo/misc/morph.c
@@ -41,24 +41,11 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "morph.h"
-#include "assert.h"
+#include <assert.h>
 #include <limits.h>
+#include <math.h>
 
-DLL void
-sample(int mode, const float* data, int dx, int dy, int dz, int level, int axis,
-       float* out)
-{
-    if(mode == 0)
-    {
-        downsample(data, dx, dy, dz, level, axis, out);
-    }
-
-    else if(mode == 1)
-    {
-        upsample(data, dx, dy, dz, level, axis, out);
-    }
-}
+#include "morph.h"
 
 DLL void
 downsample(const float* data, int dx, int dy, int dz, int level, int axis, float* out)
@@ -202,5 +189,20 @@ upsample(const float* data, int dx, int dy, int dz, int level, int axis, float* 
                 }
             }
         }
+    }
+}
+
+DLL void
+sample(int mode, const float* data, int dx, int dy, int dz, int level, int axis,
+       float* out)
+{
+    if(mode == 0)
+    {
+        downsample(data, dx, dy, dz, level, axis, out);
+    }
+
+    else if(mode == 1)
+    {
+        upsample(data, dx, dy, dz, level, axis, out);
     }
 }

--- a/source/libtomo/misc/remove_ring.c
+++ b/source/libtomo/misc/remove_ring.c
@@ -43,79 +43,15 @@
 
 // Original author: Justin Blair
 
+#include <stdlib.h>
+#include <math.h>
+
 #include "remove_ring.h"
 
 #define INT_MODE_WRAP 0
 #define INT_MODE_REFLECT 1
 
-void
-remove_ring(float* data, float center_x, float center_y, int dx, int dy, int dz,
-            float thresh_max, float thresh_min, float threshold, int angular_min,
-            int ring_width, int int_mode, int istart, int iend)
-{
-    int     pol_width  = 0;
-    int     pol_height = 0;
-    int     m_rad      = 30;
-    int     r_scale    = 1;
-    int     ang_scale  = 1;
-    int     m_azi;
-    float** polar_image = 0;
-    float** ring_image  = 0;
-    float** image       = (float**) calloc(dy, sizeof(float*));
-
-    // For each reconstructed slice
-    for(int s = istart; s < iend; s++)
-    {
-        // Fill in reconstructed slice data array into reshaped 2D array
-        image[0] = data + s * dy * dx;
-        for(int i = 1; i < dy; i++)
-        {
-            image[i] = image[i - 1] + dx;
-        }
-        // Translate Image to Polar Coordinates
-        polar_image =
-            polar_transform(image, center_x, center_y, dx, dy, &pol_width, &pol_height,
-                            thresh_max, thresh_min, r_scale, ang_scale, ring_width);
-        m_azi = ceil((float) pol_height / 360.0) * angular_min;
-        m_rad = 2 * ring_width + 1;
-
-        // Call Ring Algorithm
-        ring_filter(&polar_image, pol_height, pol_width, threshold, m_rad, m_azi,
-                    ring_width, int_mode);
-
-        // Translate Ring-Image to Cartesian Coordinates
-        ring_image = inverse_polar_transform(polar_image, center_x, center_y, pol_width,
-                                             pol_height, dx, dy, r_scale, ring_width);
-
-        // Subtract Ring-Image from Image
-        for(int row = 0; row < dy; row++)
-        {
-            for(int col = 0; col < dx; col++)
-            {
-                image[row][col] -= ring_image[row][col];
-            }
-        }
-
-        // Flatten 2D filtered array
-        for(int j = 0; j < dy; j++)
-        {
-            for(int i = 0; i < dx; i++)
-            {
-                data[i + (j * dx) + s * dy * dx] = image[j][i];
-            }
-        }
-
-        free(polar_image[0]);
-        free(polar_image);
-
-        free(ring_image[0]);
-        free(ring_image);
-    }
-
-    free(image);
-
-    return;
-}
+#define PI 3.14159265359
 
 int
 min_distance_to_edge(float center_x, float center_y, int width, int height)
@@ -692,5 +628,74 @@ ring_filter(float*** polar_image, int pol_height, int pol_width, float threshold
 
     free(filtered_image[0]);
     free(filtered_image);
+    return;
+}
+
+void
+remove_ring(float* data, float center_x, float center_y, int dx, int dy, int dz,
+            float thresh_max, float thresh_min, float threshold, int angular_min,
+            int ring_width, int int_mode, int istart, int iend)
+{
+    int     pol_width  = 0;
+    int     pol_height = 0;
+    int     m_rad      = 30;
+    int     r_scale    = 1;
+    int     ang_scale  = 1;
+    int     m_azi;
+    float** polar_image = 0;
+    float** ring_image  = 0;
+    float** image       = (float**) calloc(dy, sizeof(float*));
+
+    // For each reconstructed slice
+    for(int s = istart; s < iend; s++)
+    {
+        // Fill in reconstructed slice data array into reshaped 2D array
+        image[0] = data + s * dy * dx;
+        for(int i = 1; i < dy; i++)
+        {
+            image[i] = image[i - 1] + dx;
+        }
+        // Translate Image to Polar Coordinates
+        polar_image =
+            polar_transform(image, center_x, center_y, dx, dy, &pol_width, &pol_height,
+                            thresh_max, thresh_min, r_scale, ang_scale, ring_width);
+        m_azi = ceil((float) pol_height / 360.0) * angular_min;
+        m_rad = 2 * ring_width + 1;
+
+        // Call Ring Algorithm
+        ring_filter(&polar_image, pol_height, pol_width, threshold, m_rad, m_azi,
+                    ring_width, int_mode);
+
+        // Translate Ring-Image to Cartesian Coordinates
+        ring_image = inverse_polar_transform(polar_image, center_x, center_y, pol_width,
+                                             pol_height, dx, dy, r_scale, ring_width);
+
+        // Subtract Ring-Image from Image
+        for(int row = 0; row < dy; row++)
+        {
+            for(int col = 0; col < dx; col++)
+            {
+                image[row][col] -= ring_image[row][col];
+            }
+        }
+
+        // Flatten 2D filtered array
+        for(int j = 0; j < dy; j++)
+        {
+            for(int i = 0; i < dx; i++)
+            {
+                data[i + (j * dx) + s * dy * dx] = image[j][i];
+            }
+        }
+
+        free(polar_image[0]);
+        free(polar_image);
+
+        free(ring_image[0]);
+        free(ring_image);
+    }
+
+    free(image);
+
     return;
 }

--- a/source/libtomo/misc/remove_ring.c
+++ b/source/libtomo/misc/remove_ring.c
@@ -183,24 +183,6 @@ swap_integer(int* arr, int index1, int index2)
 }
 
 int
-partition(float* median_array, int left, int right, int pivot_index)
-{
-    float pivot_value = median_array[pivot_index];
-    swap_float(median_array, pivot_index, right);
-    int store_index = left;
-    for(int i = left; i < right; i++)
-    {
-        if(median_array[i] <= pivot_value)
-        {
-            swap_float(median_array, i, store_index);
-            store_index += 1;
-        }
-    }
-    swap_float(median_array, store_index, right);
-    return store_index;
-}
-
-int
 partition_2_arrays(float* median_array, int* position_array, int left, int right,
                    int pivot_index)
 {
@@ -220,18 +202,6 @@ partition_2_arrays(float* median_array, int* position_array, int left, int right
     swap_float(median_array, store_index, right);
     swap_integer(position_array, store_index, right);
     return store_index;
-}
-
-void
-quick_sort(float* median_array, int left, int right)
-{
-    if(left < right)
-    {
-        int pivot_index     = (int) ((left + right) / 2);
-        int new_pivot_index = partition(median_array, left, right, pivot_index);
-        quick_sort(median_array, left, new_pivot_index - 1);
-        quick_sort(median_array, new_pivot_index + 1, right);
-    }
 }
 
 void

--- a/source/libtomo/prep/stripe.c
+++ b/source/libtomo/prep/stripe.c
@@ -41,6 +41,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <stdlib.h>
+
 #include "stripe.h"
 
 void

--- a/source/libtomo/recon/art.c
+++ b/source/libtomo/recon/art.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "profiler.h"
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/bart.c
+++ b/source/libtomo/recon/bart.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/fbp.c
+++ b/source/libtomo/recon/fbp.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/grad.c
+++ b/source/libtomo/recon/grad.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/mlem.c
+++ b/source/libtomo/recon/mlem.c
@@ -41,8 +41,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-// #include "cxx_extern.h"
 #include "profiler.h"
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/osem.c
+++ b/source/libtomo/recon/osem.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/ospml_hybrid.c
+++ b/source/libtomo/recon/ospml_hybrid.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/ospml_quad.c
+++ b/source/libtomo/recon/ospml_quad.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/pml_hybrid.c
+++ b/source/libtomo/recon/pml_hybrid.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/pml_quad.c
+++ b/source/libtomo/recon/pml_quad.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/project.c
+++ b/source/libtomo/recon/project.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "profiler.h"
+#include "project.h"
 #include "utils.h"
 
 volatile unsigned long counter;

--- a/source/libtomo/recon/sirt.c
+++ b/source/libtomo/recon/sirt.c
@@ -41,8 +41,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-// #include "cxx_extern.h"
 #include "profiler.h"
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/tikh.c
+++ b/source/libtomo/recon/tikh.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void
@@ -180,7 +181,7 @@ tikh(const float* data, int dy, int dt, int dx, const float* center, const float
                             grad[ind_recon + indi[n]] +=
                                 2 * r * prox1[ind_data] * dist[n];
                 }
-            }                      
+            }
         }
 
         // add to the gradient 2*reg_par[1]*(recon-reg_data)

--- a/source/libtomo/recon/tv.c
+++ b/source/libtomo/recon/tv.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void

--- a/source/libtomo/recon/utils.c
+++ b/source/libtomo/recon/utils.c
@@ -41,10 +41,10 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "utils.h"
-
 #include <float.h>
 #include <stdint.h>
+
+#include "utils.h"
 
 // for windows build
 #ifdef WIN32

--- a/source/libtomo/recon/utils.c
+++ b/source/libtomo/recon/utils.c
@@ -42,8 +42,14 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+
 #include <float.h>
 #include <stdint.h>
+
+#define _USE_MATH_DEFINES
+#ifndef M_PI
+#    define M_PI 3.14159265358979323846264338327
+#endif
 
 // for windows build
 #ifdef WIN32

--- a/source/libtomo/recon/utils.c
+++ b/source/libtomo/recon/utils.c
@@ -46,11 +46,6 @@
 #include <float.h>
 #include <stdint.h>
 
-#define _USE_MATH_DEFINES
-#ifndef M_PI
-#    define M_PI 3.14159265358979323846264338327
-#endif
-
 // for windows build
 #ifdef WIN32
 #    ifdef PY3K

--- a/source/libtomo/recon/vector.c
+++ b/source/libtomo/recon/vector.c
@@ -41,6 +41,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "recon.h"
 #include "utils.h"
 
 void


### PR DESCRIPTION
In this PR, I have refactored the headers for the misc, prep, and recon modules so they do not contain functions which are not intended to be used externally. Additionally, I broke the recon module header into smaller chunks.