### PR TITLE
CI: Use older cuda arch for self-hosted CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
     displayName: Create build environment
   - script: |
       source activate tomopy
-      python setup.py install --enable-cuda
+      python setup.py install --enable-cuda --cuda-arch=30
     displayName: Setup and install
   - script: |
       source activate tomopy


### PR DESCRIPTION
I have old GPUs that I'm using to set up a CI server for TomoPy with CUDA architectures 3.5, 3.5, and 3.0. I observed that building with --cuda-arch=35 breaks the GPU tests on all GPUs while compiling with --cuda-arch=30 allows them all to pass.

Is this the expected behavior? Only one of the GPUs has a 3.0 architecture, so shouldn't the tests pass on two GPUs when --cuda-arch=35?