### PR TITLE
Fix warnings caused by missing libraries

### DIFF
--- a/source/include/gridrec/gridrec.h
+++ b/source/include/gridrec/gridrec.h
@@ -45,7 +45,6 @@
 
 #include <complex.h>
 #include <stdlib.h>
-// #include "filters.h"
 
 #ifdef WIN32
 #    define DLL __declspec(dllexport)

--- a/source/libtomo/recon/bart.c
+++ b/source/libtomo/recon/bart.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include "string.h"
 
 void
 bart(const float* data, int dy, int dt, int dx, const float* center, const float* theta,

--- a/source/libtomo/recon/grad.c
+++ b/source/libtomo/recon/grad.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include "string.h"
 
 void
 grad(const float* data, int dy, int dt, int dx, const float* center, const float* theta,

--- a/source/libtomo/recon/osem.c
+++ b/source/libtomo/recon/osem.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include "string.h"
 
 void
 osem(const float* data, int dy, int dt, int dx, const float* center, const float* theta,

--- a/source/libtomo/recon/tikh.c
+++ b/source/libtomo/recon/tikh.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include "string.h"
 
 void
 tikh(const float* data, int dy, int dt, int dx, const float* center, const float* theta,

--- a/source/libtomo/recon/tv.c
+++ b/source/libtomo/recon/tv.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include "string.h"
 
 void
 tv(const float* data, int dy, int dt, int dx, const float* center, const float* theta,

--- a/source/libtomo/recon/vector.c
+++ b/source/libtomo/recon/vector.c
@@ -42,6 +42,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
+#include "stdio.h"
 
 void
 vector(const float* data, int dy, int dt, int dx, const float* center, const float* theta,


### PR DESCRIPTION
This PR addresses some of the warnings produced by building TomoPy by including the necessary libraries. This also removes the no-mkl Windows environment.