### PR TITLE
scikit-image API update

### DIFF
--- a/envs/linux-36.yml
+++ b/envs/linux-36.yml
@@ -24,7 +24,7 @@ dependencies:
   - python-coveralls
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/linux-37.yml
+++ b/envs/linux-37.yml
@@ -23,7 +23,7 @@ dependencies:
   - python=3.7
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/linux-38.yml
+++ b/envs/linux-38.yml
@@ -23,7 +23,7 @@ dependencies:
   - python=3.8
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/linux-nomkl.yml
+++ b/envs/linux-nomkl.yml
@@ -20,7 +20,7 @@ dependencies:
   - pyctest>0.0.10
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/osx-36.yml
+++ b/envs/osx-36.yml
@@ -21,7 +21,7 @@ dependencies:
   - python-coveralls
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/osx-37.yml
+++ b/envs/osx-37.yml
@@ -20,7 +20,7 @@ dependencies:
   - python=3.7
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/win-36.yml
+++ b/envs/win-36.yml
@@ -19,7 +19,7 @@ dependencies:
   - python-coveralls
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/win-37.yml
+++ b/envs/win-37.yml
@@ -18,7 +18,7 @@ dependencies:
   - python=3.7
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/envs/win-nomkl.yml
+++ b/envs/win-nomkl.yml
@@ -15,7 +15,7 @@ dependencies:
   - libopencv
   - pywavelets
   - scikit-build
-  - scikit-image
+  - scikit-image>=0.17
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive

--- a/source/tomopy/prep/alignment.py
+++ b/source/tomopy/prep/alignment.py
@@ -52,7 +52,7 @@ import tomopy.util.mproc as mproc
 import logging
 
 from skimage import transform as tf
-from skimage.feature import register_translation
+from skimage.registration import phase_cross_correlation
 from tomopy.recon.algorithm import recon
 from tomopy.sim.project import project
 from tomopy.misc.npmath import gauss1d, calc_affine_transform
@@ -189,8 +189,8 @@ def align_seq(
         for m in range(prj.shape[0]):
 
             # Register current projection in sub-pixel precision
-            shift, error, diffphase = register_translation(
-                _prj[m], _sim[m], upsample_factor)
+            shift, error, diffphase = phase_cross_correlation(
+                    _prj[m], _sim[m], upsample_factor)
             err[m] = np.sqrt(shift[0]*shift[0] + shift[1]*shift[1])
             sx[m] += shift[0]
             sy[m] += shift[1]
@@ -328,8 +328,8 @@ def align_joint(
         for m in range(prj.shape[0]):
 
             # Register current projection in sub-pixel precision
-            shift, error, diffphase = register_translation(
-                _prj[m], _sim[m], upsample_factor)
+            shift, error, diffphase = phase_cross_correlation(
+                    _prj[m], _sim[m], upsample_factor)
             err[m] = np.sqrt(shift[0]*shift[0] + shift[1]*shift[1])
             sx[m] += shift[0]
             sy[m] += shift[1]

--- a/source/tomopy/recon/rotation.py
+++ b/source/tomopy/recon/rotation.py
@@ -57,7 +57,7 @@ import numpy as np
 from scipy import ndimage
 from tomopy.util.misc import fft2, write_tiff
 from scipy.optimize import minimize
-from skimage.feature import register_translation
+from skimage.registration import phase_cross_correlation
 from tomopy.misc.corr import circ_mask
 from tomopy.misc.morph import downsample
 from tomopy.recon.algorithm import recon
@@ -376,7 +376,7 @@ def find_center_pc(proj1, proj2, tol=0.5, rotc_guess=None):
     Find rotation axis location by finding the offset between the first
     projection and a mirrored projection 180 degrees apart using
     phase correlation in Fourier space.
-    The ``register_translation`` function uses cross-correlation in Fourier
+    The ``phase_cross_correlation`` function uses cross-correlation in Fourier
     space, optionally employing an upsampled matrix-multiplication DFT to
     achieve arbitrary subpixel precision. :cite:`Guizar:08`.
 
@@ -409,7 +409,7 @@ def find_center_pc(proj1, proj2, tol=0.5, rotc_guess=None):
     proj2 = np.fliplr(proj2)
 
     # Determine shift between images using scikit-image pcm
-    shift = register_translation(proj1, proj2, upsample_factor=1.0 / tol)
+    shift = phase_cross_correlation(proj1, proj2, upsample_factor=1.0 / tol)
 
     # Compute center of rotation as the center of first image and the
     # registered translation with the second image


### PR DESCRIPTION
The function `feature.register_translation` is deprecated and users are to move to `registration.phase_cross_correlation`. The conda recipe might also need to set `0.17` as the minimum version of `scikit-image` (which it already does).