### PR TITLE
API: Remove dependency on six

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -40,7 +40,7 @@ $ export PYTHON_VERSION=3.6
 
 $ export CONDA_ENV="tomopy-pyctest"
 
-$ conda install -n ${CONDA_ENV} -c conda-forge -c jrmadsen python=${PYTHON_VERSION} nose six numpy h5py scipy scikit-image pywavelets mkl-devel mkl_fft python-coveralls dxchange numexpr coverage timemory pyctest
+$ conda install -n ${CONDA_ENV} -c conda-forge -c jrmadsen python=${PYTHON_VERSION} nose numpy h5py scipy scikit-image pywavelets mkl-devel mkl_fft python-coveralls dxchange numexpr coverage timemory pyctest
 
 $ source activate ${CONDA_ENV}
 

--- a/envs/linux-36.yml
+++ b/envs/linux-36.yml
@@ -28,5 +28,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory

--- a/envs/linux-37.yml
+++ b/envs/linux-37.yml
@@ -27,5 +27,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory

--- a/envs/linux-38.yml
+++ b/envs/linux-38.yml
@@ -27,5 +27,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory

--- a/envs/linux-nomkl.yml
+++ b/envs/linux-nomkl.yml
@@ -24,5 +24,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory

--- a/envs/osx-36.yml
+++ b/envs/osx-36.yml
@@ -25,5 +25,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory

--- a/envs/osx-37.yml
+++ b/envs/osx-37.yml
@@ -24,5 +24,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory

--- a/envs/win-36.yml
+++ b/envs/win-36.yml
@@ -23,6 +23,5 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - timemory
   - vs2017_win-64

--- a/envs/win-37.yml
+++ b/envs/win-37.yml
@@ -22,5 +22,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - vs2017_win-64

--- a/envs/win-nomkl.yml
+++ b/envs/win-nomkl.yml
@@ -19,5 +19,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - setuptools_scm_git_archive
-  - six
   - vs2017_win-64

--- a/source/tomopy/recon/algorithm.py
+++ b/source/tomopy/recon/algorithm.py
@@ -53,16 +53,17 @@ Module for reconstruction algorithms.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
-import six
+import concurrent.futures as cf
 import copy
+import logging
+import os
+
 import numpy as np
+
+from tomopy.sim.project import get_center
 import tomopy.util.mproc as mproc
 import tomopy.util.extern as extern
 import tomopy.util.dtype as dtype
-from tomopy.sim.project import get_center
-import logging
-import concurrent.futures as cf
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +152,7 @@ def recon(
             Total Variation reconstruction technique
             :cite:`Chambolle:11`.
         'grad'
-            Gradient descent method. 
+            Gradient descent method.
         'tikh'
             Tikhonov regularization with identity Tikhonov matrix.
 
@@ -257,7 +258,7 @@ def recon(
     # Generate kwargs for the algorithm.
     kwargs_defaults = _get_algorithm_kwargs(tomo.shape)
 
-    if isinstance(algorithm, six.string_types):
+    if isinstance(algorithm, str):
 
         allowed_kwargs = copy.copy(allowed_recon_kwargs)
         if algorithm in allowed_accelerated_kwargs:
@@ -277,7 +278,7 @@ def recon(
                     (key, allowed_kwargs[algorithm]))
             else:
                 # Make sure they are numpy arrays.
-                if not isinstance(kwargs[key], (np.ndarray, np.generic)) and not isinstance(kwargs[key], six.string_types):
+                if not isinstance(kwargs[key], (np.ndarray, np.generic)) and not isinstance(kwargs[key], str):
                     kwargs[key] = np.array(value)
 
                 # Make sure reg_par and filter_par is float32.

--- a/source/tomopy/recon/algorithm.py
+++ b/source/tomopy/recon/algorithm.py
@@ -278,7 +278,8 @@ def recon(
                     (key, allowed_kwargs[algorithm]))
             else:
                 # Make sure they are numpy arrays.
-                if not isinstance(kwargs[key], (np.ndarray, np.generic)) and not isinstance(kwargs[key], str):
+                if (not isinstance(kwargs[key], (np.ndarray, np.generic))
+                        and not isinstance(kwargs[key], str)):
                     kwargs[key] = np.array(value)
 
                 # Make sure reg_par and filter_par is float32.

--- a/source/tomopy/util/dtype.py
+++ b/source/tomopy/util/dtype.py
@@ -54,10 +54,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import ctypes
-import numpy as np
-import multiprocessing as mp
 import logging
-import six
+import multiprocessing as mp
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ def as_c_float(arr):
 
 
 def as_c_char_p(arr):
-    return ctypes.c_char_p(six.b(arr))
+    return ctypes.c_char_p(arr.encode())
 
 
 def as_c_void_p():


### PR DESCRIPTION
Because we do not support Python 2.x anymore. We do not need the six package anymore. Having extra packages makes dependency resolution more difficult.