### PR TITLE
DOC: Make it clearer which shared libraries are optional

### DIFF
--- a/source/tomopy/util/extern/__init__.py
+++ b/source/tomopy/util/extern/__init__.py
@@ -49,12 +49,10 @@
 import ctypes
 import os
 import sys
-import logging
-
-logger = logging.getLogger(__name__)
+import warnings
 
 
-def c_shared_lib(lib_name, do_warn=True):
+def c_shared_lib(lib_name, error=True):
     """Get the path and import the C-shared library."""
     load_dll = ctypes.cdll.LoadLibrary
     ext = '.so'
@@ -67,17 +65,19 @@ def c_shared_lib(lib_name, do_warn=True):
     sharedlib = os.path.join(base_path, '%s%s' % (lib_name, ext))
     if os.path.exists(sharedlib):
         return load_dll(sharedlib)
-    # cannot find shared lib:
-    if do_warn is True:
-        logger.warning(
-            'OSError: ' +
-            'The following shared lib is missing!\n{}'.format(sharedlib))
+    if error:
+        raise ModuleNotFoundError(
+            f'The following shared library is missing:\n{sharedlib}')
+    warnings.warn(
+        'Some compiled functions are unavailable because an optional shared'
+        f' library is missing:\n{sharedlib}', ImportWarning)
 
 
-def MissingLibrary(function):
-    print(f"The {function} algorithm is unavailable."
-          " Check CMake logs to determine if TomoPy was"
-          " built with dependencies required by this algorithm.")
+def _missing_library(function):
+    raise ModuleNotFoundError(
+        f"The {function} algorithm is unavailable because its shared library"
+        " is missing. Check CMake logs to determine if TomoPy was"
+        " built with all dependencies required by this algorithm.")
 
 
 from tomopy.util.extern.recon import *

--- a/source/tomopy/util/extern/accel.py
+++ b/source/tomopy/util/extern/accel.py
@@ -52,7 +52,7 @@ Module for external library wrappers.
 
 import tomopy.util.dtype as dtype
 from . import c_shared_lib
-from . import MissingLibrary
+from . import _missing_library
 
 __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
@@ -60,13 +60,13 @@ __docformat__ = 'restructuredtext en'
 __all__ = ['c_accel_mlem',
            'c_accel_sirt']
 
-LIB_TOMOPY_ACCEL = c_shared_lib("libtomopy-accel")
+LIB_TOMOPY_ACCEL = c_shared_lib("libtomopy-accel", error=False)
 
 
 def c_accel_mlem(tomo, center, recon, theta, **kwargs):
 
     if LIB_TOMOPY_ACCEL is None:
-        MissingLibrary("MLEM ACCEL")
+        _missing_library("MLEM ACCEL")
 
     if len(tomo.shape) == 2:
         # no y-axis (only one slice)
@@ -97,7 +97,7 @@ def c_accel_mlem(tomo, center, recon, theta, **kwargs):
 def c_accel_sirt(tomo, center, recon, theta, **kwargs):
 
     if LIB_TOMOPY_ACCEL is None:
-        return MissingLibrary("SIRT ACCEL")
+        _missing_library("SIRT ACCEL")
 
     if len(tomo.shape) == 2:
         # no y-axis (only one slice)

--- a/source/tomopy/util/extern/gridrec.py
+++ b/source/tomopy/util/extern/gridrec.py
@@ -51,7 +51,7 @@ Module for external library wrappers.
 """
 import tomopy.util.dtype as dtype
 from . import c_shared_lib
-from . import MissingLibrary
+from . import _missing_library
 
 __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
@@ -59,13 +59,13 @@ __docformat__ = 'restructuredtext en'
 __all__ = ['c_gridrec']
 
 
-LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec")
+LIB_TOMOPY_GRIDREC = c_shared_lib("libtomopy-gridrec", error=False)
 
 
 def c_gridrec(tomo, center, recon, theta, **kwargs):
 
     if LIB_TOMOPY_GRIDREC is None:
-        return MissingLibrary("gridrec")
+        _missing_library("gridrec")
 
     if len(tomo.shape) == 2:
         # no y-axis (only one slice)

--- a/test/test_tomopy/test_recon/test_rotation.py
+++ b/test/test_tomopy/test_recon/test_rotation.py
@@ -94,6 +94,7 @@ class CenterFindingTestCase(unittest.TestCase):
                         str('{0:.2f}'.format(cen[m]) + '.tiff'))), True)
         shutil.rmtree(dpath)
 
+    @unittest.skipUnless(found_mkl, "Requires MKL")
     def test_find_center(self):
         sim = read_file('sinogram.npy')
         ang = np.linspace(0, np.pi, sim.shape[0])


### PR DESCRIPTION
Have TomoPy raises errors when loading required components and
only raise warnings when looking for optional components so that it
is clearer to the user which components are considered required
and which are optional.

Regardless, an error is now raised when a user tries to run code
whose shared library is missing instead of just failing silently
and giving bad results.