### PR TITLE
DOC: Add tomopy.util.extern to mock modules

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -145,6 +145,7 @@ autodoc_mock_imports = [
     'concurrent',
     'DM3lib',
     'libtomopy',
+    'tomopy.util.extern',
     'matplotlib',
     'numexpr',
     'numpy',


### PR DESCRIPTION
Because:
- A recent change causing a new error to be raised when shared
  libraries are missing causes the docs to fail