### PR TITLE
ENH: Tune use of CUDA NPP for multiple-GPUs

### DIFF
--- a/benchmarking/phantom.py
+++ b/benchmarking/phantom.py
@@ -223,28 +223,6 @@ def main(args):
     timemory.options.set_serial("run_tomopy.json")
     manager.report()
 
-    # provide timing plots
-    try:
-        timemory.plotting.plot(files=[timemory.options.serial_filename],
-                               echo_dart=True,
-                               output_dir=timemory.options.output_dir)
-    except Exception as e:
-        print("Exception - {}".format(e))
-
-    # provide results to dashboard
-    try:
-        for i in range(0, len(imgs)):
-            img_base = "{}_{}_stack_{}".format(args.phantom, algorithm, i)
-            img_name = os.path.basename(imgs[i]).replace(
-                ".{}".format(args.format), "").replace(
-                "stack_{}_".format(algorithm), img_base)
-            img_type = args.format
-            img_path = imgs[i]
-            img_path = os.path.abspath(img_path)
-            timemory.plotting.echo_dart_tag(img_name, img_path, img_type)
-    except Exception as e:
-        print("Exception - {}".format(e))
-
     # provide ASCII results
     try:
         notes = manager.write_ctest_notes(

--- a/benchmarking/rec.py
+++ b/benchmarking/rec.py
@@ -302,25 +302,7 @@ def output_analysis(manager, args, imgs):
     timemory.options.set_report("run_tomopy.out")
     timemory.options.set_serial("run_tomopy.json")
     manager.report()
-    # provide timing plots
-    try:
-        print("\nPlotting TiMemory results...\n")
-        timemory.plotting.plot(files=[timemory.options.serial_filename],
-                               echo_dart=True,
-                               output_dir=timemory.options.output_dir)
-    except Exception as e:
-        print("Exception [timemory.plotting] - {}".format(e))
-    # provide results to dashboard
-    try:
-        print("\nEchoing dart tags...\n")
-        for i in range(0, len(imgs)):
-            img_type = args.format
-            img_name = os.path.basename(imgs[i]).replace(
-                ".{}".format(args.format), "")
-            img_path = imgs[i]
-            timemory.plotting.echo_dart_tag(img_name, img_path, img_type)
-    except Exception as e:
-        print("Exception [echo_dart_tag] - {}".format(e))
+
     # provide ASCII results
     try:
         print("\nWriting notes...\n")

--- a/benchmarking/rec.py
+++ b/benchmarking/rec.py
@@ -80,6 +80,10 @@ def read_rot_centers(fname):
 @timemory.util.auto_timer()
 def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
 
+    # not setting this will cause issues on supercomputers
+    # allow user to override though
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+
     # Read APS 32-BM raw data.
     proj, flat, dark, theta = dxchange.read_aps_32id(h5fname, sino=sino)
 

--- a/source/libtomo/accel/gpu/common.cu
+++ b/source/libtomo/accel/gpu/common.cu
@@ -38,9 +38,9 @@
 //   TOMOPY CUDA implementation
 
 #include "common.hh"
+#include "cuda.h"
 #include "macros.hh"
 #include "utils.hh"
-#include "cuda.h"
 
 //======================================================================================//
 
@@ -284,8 +284,15 @@ cuda_device_query()
     else
         printf("Detected %d CUDA capable devices\n", deviceCount);
 
+    int specific_device = GetEnv("TOMOPY_DEVICE_NUM", -1);
+
     for(int dev = 0; dev < deviceCount; ++dev)
     {
+        // if the process set a specific device, only print out info for that device
+        if(specific_device >= 0 && specific_device < deviceCount &&
+           dev != specific_device)
+            continue;
+
         cudaSetDevice(dev);
         cudaDeviceProp deviceProp;
         cudaGetDeviceProperties(&deviceProp, dev);

--- a/source/libtomo/accel/gpu/mlem.cu
+++ b/source/libtomo/accel/gpu/mlem.cu
@@ -175,6 +175,7 @@ mlem_cuda(const float* cpu_data, int dy, int dt, int dx, const float*, const flo
     // compute some properties (expected python threads, max threads, device assignment)
     int pythread_num = ntid++;
     int device       = pythread_num % cuda_device_count();  // assign to device
+    device           = GetEnv("TOMOPY_DEVICE_NUM", device);
 
     TIMEMORY_AUTO_TIMER("");
 

--- a/source/libtomo/accel/gpu/mlem.cu
+++ b/source/libtomo/accel/gpu/mlem.cu
@@ -124,6 +124,7 @@ mlem_gpu_compute_projection(data_array_t& gpu_data, int p, int dy, int dt, int d
 
     // synchronize the stream (do this frequently to avoid backlog)
     stream_sync(stream);
+    CUDA_FAST_CHECK_LAST_ERROR();
 
     // reset destination arrays (NECESSARY! or will cause NaNs)
     // only do once bc for same theta, same pixels get overwritten
@@ -156,7 +157,7 @@ mlem_gpu_compute_projection(data_array_t& gpu_data, int p, int dy, int dt, int d
         CUDA_CHECK_LAST_STREAM_ERROR(stream);
 
         // synchronize the stream (do this frequently to avoid backlog)
-        stream_sync(stream);
+        // stream_sync(stream);
     }
 }
 
@@ -175,7 +176,7 @@ mlem_cuda(const float* cpu_data, int dy, int dt, int dx, const float*, const flo
     // compute some properties (expected python threads, max threads, device assignment)
     int pythread_num = ntid++;
     int device       = pythread_num % cuda_device_count();  // assign to device
-    device           = GetEnv("TOMOPY_DEVICE_NUM", device);
+    device           = GetEnv("TOMOPY_DEVICE_NUM", device) % cuda_device_count();
 
     TIMEMORY_AUTO_TIMER("");
 

--- a/source/libtomo/accel/gpu/sirt.cu
+++ b/source/libtomo/accel/gpu/sirt.cu
@@ -120,6 +120,7 @@ sirt_gpu_compute_projection(data_array_t& gpu_data, int p, int dy, int dt, int d
 
     // synchronize the stream (do this frequently to avoid backlog)
     stream_sync(stream);
+    CUDA_FAST_CHECK_LAST_ERROR();
 
     // reset destination arrays (NECESSARY! or will cause NaNs)
     // only do once bc for same theta, same pixels get overwritten
@@ -152,7 +153,7 @@ sirt_gpu_compute_projection(data_array_t& gpu_data, int p, int dy, int dt, int d
         CUDA_CHECK_LAST_STREAM_ERROR(stream);
 
         // synchronize the stream (do this frequently to avoid backlog)
-        stream_sync(stream);
+        // stream_sync(stream);
     }
 }
 
@@ -172,7 +173,7 @@ sirt_cuda(const float* cpu_data, int dy, int dt, int dx, const float* center,
     // compute some properties (expected python threads, max threads, device assignment)
     int pythread_num = ntid++;
     int device       = pythread_num % cuda_device_count();  // assign to device
-    device           = GetEnv("TOMOPY_DEVICE_NUM", device);
+    device           = GetEnv("TOMOPY_DEVICE_NUM", device) % cuda_device_count();
 
     TIMEMORY_AUTO_TIMER("");
 

--- a/source/libtomo/accel/gpu/sirt.cu
+++ b/source/libtomo/accel/gpu/sirt.cu
@@ -172,6 +172,7 @@ sirt_cuda(const float* cpu_data, int dy, int dt, int dx, const float* center,
     // compute some properties (expected python threads, max threads, device assignment)
     int pythread_num = ntid++;
     int device       = pythread_num % cuda_device_count();  // assign to device
+    device           = GetEnv("TOMOPY_DEVICE_NUM", device);
 
     TIMEMORY_AUTO_TIMER("");
 

--- a/source/libtomo/accel/gpu/utils.cu
+++ b/source/libtomo/accel/gpu/utils.cu
@@ -216,7 +216,7 @@ cuda_rotate_kernel(int32_t* dst, const int32_t* src, const float theta_rad,
 
     if(ret != NPP_SUCCESS)
         fprintf(stderr, "[%lu] %s returned non-zero NPP status: %i @ %s:%i. src = %p\n",
-                GetThisThreadID(), __FUNCTION__, ret, __FILE__, __LINE__, (void*) src);
+                GetMessageID(), __FUNCTION__, ret, __FILE__, __LINE__, (void*) src);
 
     NVTX_RANGE_POP(stream);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);
@@ -279,7 +279,7 @@ cuda_rotate_kernel(float* dst, const float* src, const float theta_rad,
 
     if(ret != NPP_SUCCESS)
         fprintf(stderr, "[%lu] %s returned non-zero NPP status: %i @ %s:%i. src = %p\n",
-                GetThisThreadID(), __FUNCTION__, ret, __FILE__, __LINE__, (void*) src);
+                GetMessageID(), __FUNCTION__, ret, __FILE__, __LINE__, (void*) src);
 
     NVTX_RANGE_POP(stream);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);

--- a/source/libtomo/accel/gpu/utils.cu
+++ b/source/libtomo/accel/gpu/utils.cu
@@ -207,8 +207,6 @@ cuda_rotate_kernel(int32_t* dst, const int32_t* src, const float theta_rad,
 
     if(nppGetStream() != stream)
         throw std::runtime_error("Error! Wrong stream!");
-    // stream_sync(stream);
-    // nppSetStream(stream);
     NVTX_RANGE_PUSH(&nvtx_rotate);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);
 

--- a/source/libtomo/accel/gpu/utils.cu
+++ b/source/libtomo/accel/gpu/utils.cu
@@ -43,6 +43,8 @@
 #include "data.hh"
 #include "utils.hh"
 
+#include <atomic>
+
 //======================================================================================//
 
 #if defined(TOMOPY_USE_NVTX)
@@ -53,6 +55,11 @@ extern nvtxEventAttributes_t nvtx_projection;
 extern nvtxEventAttributes_t nvtx_update;
 extern nvtxEventAttributes_t nvtx_rotate;
 #endif
+
+namespace
+{
+std::atomic<int> _npp_stream_sync{ 0 };
+}
 
 //======================================================================================//
 
@@ -176,8 +183,32 @@ cuda_rotate_kernel(int32_t* dst, const int32_t* src, const float theta_rad,
                    const float theta_deg, const int nx, const int ny,
                    int eInterp = GPU_NN, cudaStream_t stream = 0)
 {
-    stream_sync(stream);
-    nppSetStream(stream);
+    // use static + comma operator to set the stream the first time
+    static bool _first = (nppSetStream(stream), false);
+    (void) _first;
+
+    bool _decrement = false;
+    // if stream is current stream continue
+    while(nppGetStream() != stream ||
+          _npp_stream_sync.load(std::memory_order_relaxed) == 0)
+    {
+        // when this hits zero we update stream
+        if(++_npp_stream_sync == 1)
+        {
+            _decrement = true;
+            nppSetStream(stream);
+            break;
+        }
+        else
+        {
+            --_npp_stream_sync;
+        }
+    }
+
+    if(nppGetStream() != stream)
+        throw std::runtime_error("Error! Wrong stream!");
+    // stream_sync(stream);
+    // nppSetStream(stream);
     NVTX_RANGE_PUSH(&nvtx_rotate);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);
 
@@ -220,6 +251,9 @@ cuda_rotate_kernel(int32_t* dst, const int32_t* src, const float theta_rad,
 
     NVTX_RANGE_POP(stream);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);
+
+    if(_decrement)
+        --_npp_stream_sync;
 }
 
 //======================================================================================//
@@ -233,8 +267,32 @@ cuda_rotate_kernel(float* dst, const float* src, const float theta_rad,
                    const float theta_deg, const int nx, const int ny,
                    int eInterp = GPU_CUBIC, cudaStream_t stream = 0)
 {
-    stream_sync(stream);
-    nppSetStream(stream);
+    // use static + comma operator to set the stream the first time
+    static bool _first = (nppSetStream(stream), false);
+    (void) _first;
+
+    bool _decrement = false;
+    // if stream is current stream continue
+    while(nppGetStream() != stream ||
+          _npp_stream_sync.load(std::memory_order_relaxed) == 0)
+    {
+        // when this hits zero we update stream
+        if(++_npp_stream_sync == 1)
+        {
+            _decrement = true;
+            nppSetStream(stream);
+            break;
+        }
+        else
+        {
+            --_npp_stream_sync;
+        }
+    }
+
+    if(nppGetStream() != stream)
+        throw std::runtime_error("Error! Wrong stream!");
+    // stream_sync(stream);
+    // nppSetStream(stream);
     NVTX_RANGE_PUSH(&nvtx_rotate);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);
 
@@ -283,6 +341,9 @@ cuda_rotate_kernel(float* dst, const float* src, const float theta_rad,
 
     NVTX_RANGE_POP(stream);
     CUDA_CHECK_LAST_STREAM_ERROR(stream);
+
+    if(_decrement)
+        --_npp_stream_sync;
 }
 
 //======================================================================================//

--- a/source/libtomo/accel/macros.hh
+++ b/source/libtomo/accel/macros.hh
@@ -142,10 +142,10 @@ extern "C"
 // relevant OpenCV headers
 //
 #if defined(TOMOPY_USE_OPENCV)
-    #include <opencv2/core.hpp>
-    #include <opencv2/imgproc.hpp>
-    #include <opencv2/imgproc/imgproc.hpp>
-    #include <opencv2/imgproc/types_c.h>
+#    include <opencv2/core.hpp>
+#    include <opencv2/imgproc.hpp>
+#    include <opencv2/imgproc/imgproc.hpp>
+#    include <opencv2/imgproc/types_c.h>
 #endif
 
 //======================================================================================//
@@ -298,10 +298,28 @@ init_nvtx();
             }
 #    endif
 
+// always
+#    if !defined(CUDA_FAST_CHECK_LAST_ERROR)
+#        define CUDA_FAST_CHECK_LAST_ERROR()                                             \
+            {                                                                            \
+                cudaError err = cudaGetLastError();                                      \
+                if(cudaSuccess != err)                                                   \
+                {                                                                        \
+                    fprintf(stderr, "cudaCheckError() failed at %s@'%s':%i : %s\n",      \
+                            __FUNCTION__, __FILE__, __LINE__, cudaGetErrorString(err));  \
+                    std::stringstream ss;                                                \
+                    ss << "cudaCheckError() failed at " << __FUNCTION__ << "@'"          \
+                       << __FILE__ << "':" << __LINE__ << " : "                          \
+                       << cudaGetErrorString(err);                                       \
+                    throw std::runtime_error(ss.str());                                  \
+                }                                                                        \
+            }
+#    endif
+
 // this is only defined in debug mode
 
 #    if !defined(CUDA_CHECK_LAST_ERROR)
-#        if defined(DEBUG)
+#        if defined(DEBUG) && !defined(NDEBUG)
 #            define CUDA_CHECK_LAST_ERROR()                                              \
                 {                                                                        \
                     cudaStreamSynchronize(0);                                            \
@@ -329,7 +347,7 @@ init_nvtx();
 // this is only defined in debug mode
 
 #    if !defined(CUDA_CHECK_LAST_STREAM_ERROR)
-#        if defined(DEBUG)
+#        if defined(DEBUG) && !defined(NDEBUG)
 #            define CUDA_CHECK_LAST_STREAM_ERROR(stream)                                 \
                 {                                                                        \
                     cudaStreamSynchronize(stream);                                       \

--- a/source/libtomo/accel/macros.hh
+++ b/source/libtomo/accel/macros.hh
@@ -163,6 +163,20 @@ GetThisThreadID()
 }
 
 //======================================================================================//
+// this function returns the thread-id on the CPU and the device ID on the GPU
+inline uintmax_t
+GetMessageID()
+{
+#if defined(__CUDACC__)
+    int device = 0;
+    cudaGetDevice(&device);
+    return device;
+#else
+    return GetThisThreadID();
+#endif
+}
+
+//======================================================================================//
 // short hand for static_cast
 #if !defined(scast)
 #    define scast static_cast
@@ -178,7 +192,7 @@ GetThisThreadID()
 // debugging
 #if !defined(PRINT_HERE)
 #    define PRINT_HERE(extra)                                                            \
-        printf("[%lu]> %s@'%s':%i %s\n", GetThisThreadID(), __FUNCTION__, __FILE__,      \
+        printf("[%lu]> %s@'%s':%i %s\n", GetMessageID(), __FUNCTION__, __FILE__,         \
                __LINE__, extra)
 #endif
 
@@ -186,7 +200,7 @@ GetThisThreadID()
 // debugging
 #if !defined(PRINT_ERROR_HERE)
 #    define PRINT_ERROR_HERE(extra)                                                      \
-        fprintf(stderr, "[%lu]> %s@'%s':%i %s\n", GetThisThreadID(), __FUNCTION__,       \
+        fprintf(stderr, "[%lu]> %s@'%s':%i %s\n", GetMessageID(), __FUNCTION__,          \
                 __FILE__, __LINE__, extra)
 #endif
 
@@ -204,7 +218,7 @@ GetThisThreadID()
             auto                          end_time = std::chrono::system_clock::now();   \
             std::chrono::duration<double> elapsed_seconds = end_time - start_time;       \
             printf("[%lu]> %-16s :: %3i of %3i... %5.2f seconds\n",                      \
-                   scast<unsigned long>(GetThisThreadID()), note, counter, total_count,  \
+                   scast<unsigned long>(GetMessageID()), note, counter, total_count,     \
                    elapsed_seconds.count());                                             \
         }
 #endif

--- a/source/tomopy/recon/algorithm.py
+++ b/source/tomopy/recon/algorithm.py
@@ -398,10 +398,9 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
     # check if ncore is limited by env variable
     pythreads = os.environ.get("TOMOPY_PYTHON_THREADS")
     if pythreads is not None and ncore > int(pythreads):
-        print(
-            "Warning! 'TOMOPY_PYTHON_THREADS' has been set to '{0}', which is less than"
-            " specified ncore={1}. Limiting ncore to {0}...".format(
-                pythreads, ncore))
+        print("Warning! 'TOMOPY_PYTHON_THREADS' has been set to '{0}', "
+              "which is less than specified ncore={1}. "
+              "Limiting ncore to {0}...".format(pythreads, ncore))
         ncore = int(pythreads)
 
     print("Reconstructing {} slice groups with {} master threads...".format(
@@ -415,9 +414,9 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
             # run in this thread (useful for debugging)
             algorithm(tomo[slc], center[slc], recon[slc], *args, **kwargs)
     else:
-        # execute recon on ncore processes. Accelerated methods have internal thread-pool
-        # and NVIDIA NPP library does not support simulatenously leveraging multiple devices
-        # within the same process
+        # execute recon on ncore processes. Accelerated methods have internal
+        # thread-pool and NVIDIA NPP library does not support simulatenously
+        # leveraging multiple devices within the same process
         if "accelerated" in kwargs and kwargs["accelerated"]:
             futures = []
             with cf.ProcessPoolExecutor(ncore) as e:
@@ -435,8 +434,8 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
             # execute recon on ncore threads
             with cf.ThreadPoolExecutor(ncore) as e:
                 for slc in use_slcs:
-                    e.submit(algorithm, tomo[slc], center[slc],
-                             recon[slc], *args, **kwargs)
+                    e.submit(algorithm, tomo[slc], center[slc], recon[slc],
+                             *args, **kwargs)
 
     if pythreads is not None:
         # reset to default
@@ -464,18 +463,17 @@ def _get_algorithm_kwargs(shape):
         'reg_par': np.ones(10, dtype='float32'),
         'reg_data': np.zeros([dy, dx, dx], dtype='float32'),
         'num_block': dtype.as_int32(1),
-        'ind_block':
-        np.arange(0, dt, dtype=np.float32),  # TODO: I think this should be int
+        # TODO: I think ind_block should be int
+        'ind_block': np.arange(0, dt, dtype=np.float32),
         'options': {},
         'accelerated': False,
-        'pool_size':
-        0,  # if zero, calculate based on threads started at Python level
-        'interpolation':
-        'NN',  # interpolation method (NN = nearest-neighbor, LINEAR, CUBIC)
+        # if zero, calculate based on threads started at Python level
+        'pool_size': 0,
+        # interpolation method (NN = nearest-neighbor, LINEAR, CUBIC)
+        'interpolation': 'NN',
         'device': 'gpu',
-        'grid_size': np.array(
-            [0, 0, 0],
-            dtype='int32'),  # CUDA grid size. If zero, dynamically computed
-        'block_size': np.array([32, 32, 1],
-                               dtype='int32'),  # CUDA threads per block
+        # CUDA grid size. If zero, dynamically computed
+        'grid_size': np.array([0, 0, 0], dtype='int32'),
+        # CUDA threads per block
+        'block_size': np.array([32, 32, 1], dtype='int32'),
     }

--- a/source/tomopy/recon/algorithm.py
+++ b/source/tomopy/recon/algorithm.py
@@ -435,7 +435,7 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
             # execute recon on ncore threads
             with cf.ThreadPoolExecutor(ncore) as e:
                 for slc in use_slcs:
-                    e.submit(algorithm, tomo[slc], tomo[slc], center[slc],
+                    e.submit(algorithm, tomo[slc], center[slc],
                              recon[slc], *args, **kwargs)
 
     if pythreads is not None:

--- a/source/tomopy/recon/algorithm.py
+++ b/source/tomopy/recon/algorithm.py
@@ -418,8 +418,7 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
         # execute recon on ncore processes. Accelerated methods have internal thread-pool
         # and NVIDIA NPP library does not support simulatenously leveraging multiple devices
         # within the same process
-        if "accelerated" in kwargs and (kwargs["accelerated"] is True
-                                        or kwargs["accelerated"]):
+        if "accelerated" in kwargs and kwargs["accelerated"]:
             futures = []
             with cf.ProcessPoolExecutor(ncore) as e:
                 for idx, slc in enumerate(use_slcs):

--- a/source/tomopy/recon/algorithm.py
+++ b/source/tomopy/recon/algorithm.py
@@ -45,7 +45,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
-
 """
 Module for reconstruction algorithms.
 """
@@ -67,30 +66,37 @@ import tomopy.util.dtype as dtype
 
 logger = logging.getLogger(__name__)
 
-
 __author__ = "Doga Gursoy"
 __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 __all__ = ['recon', 'init_tomo']
 
 allowed_accelerated_kwargs = {
-    'mlem': ['accelerated', 'pool_size', 'interpolation', 'device', 'grid_size', 'block_size'],
-    'sirt': ['accelerated', 'pool_size', 'interpolation', 'device', 'grid_size', 'block_size'],
+    'mlem': [
+        'accelerated', 'pool_size', 'interpolation', 'device', 'grid_size',
+        'block_size'
+    ],
+    'sirt': [
+        'accelerated', 'pool_size', 'interpolation', 'device', 'grid_size',
+        'block_size'
+    ],
 }
 
 allowed_recon_kwargs = {
     'art': ['num_gridx', 'num_gridy', 'num_iter'],
-    'bart': ['num_gridx', 'num_gridy', 'num_iter',
-             'num_block', 'ind_block'],
+    'bart': ['num_gridx', 'num_gridy', 'num_iter', 'num_block', 'ind_block'],
     'fbp': ['num_gridx', 'num_gridy', 'filter_name', 'filter_par'],
     'gridrec': ['num_gridx', 'num_gridy', 'filter_name', 'filter_par'],
     'mlem': ['num_gridx', 'num_gridy', 'num_iter'],
-    'osem': ['num_gridx', 'num_gridy', 'num_iter',
-             'num_block', 'ind_block'],
-    'ospml_hybrid': ['num_gridx', 'num_gridy', 'num_iter',
-                     'reg_par', 'num_block', 'ind_block'],
-    'ospml_quad': ['num_gridx', 'num_gridy', 'num_iter',
-                   'reg_par', 'num_block', 'ind_block'],
+    'osem': ['num_gridx', 'num_gridy', 'num_iter', 'num_block', 'ind_block'],
+    'ospml_hybrid': [
+        'num_gridx', 'num_gridy', 'num_iter', 'reg_par', 'num_block',
+        'ind_block'
+    ],
+    'ospml_quad': [
+        'num_gridx', 'num_gridy', 'num_iter', 'reg_par', 'num_block',
+        'ind_block'
+    ],
     'pml_hybrid': ['num_gridx', 'num_gridy', 'num_iter', 'reg_par'],
     'pml_quad': ['num_gridx', 'num_gridy', 'num_iter', 'reg_par'],
     'sirt': ['num_gridx', 'num_gridy', 'num_iter'],
@@ -100,9 +106,15 @@ allowed_recon_kwargs = {
 }
 
 
-def recon(
-        tomo, theta, center=None, sinogram_order=False, algorithm=None,
-        init_recon=None, ncore=None, nchunk=None, **kwargs):
+def recon(tomo,
+          theta,
+          center=None,
+          sinogram_order=False,
+          algorithm=None,
+          init_recon=None,
+          ncore=None,
+          nchunk=None,
+          **kwargs):
     """
     Reconstruct object from projection data.
 
@@ -268,14 +280,13 @@ def recon(
         if algorithm not in allowed_kwargs:
             raise ValueError(
                 'Keyword "algorithm" must be one of %s, or a Python method.' %
-                (list(allowed_kwargs.keys()),))
+                (list(allowed_kwargs.keys()), ))
 
         # Make sure have allowed kwargs appropriate for algorithm.
         for key, value in list(kwargs.items()):
             if key not in allowed_kwargs[algorithm]:
-                raise ValueError(
-                    '%s keyword not in allowed keywords %s' %
-                    (key, allowed_kwargs[algorithm]))
+                raise ValueError('%s keyword not in allowed keywords %s' %
+                                 (key, allowed_kwargs[algorithm]))
             else:
                 # Make sure they are numpy arrays.
                 if (not isinstance(kwargs[key], (np.ndarray, np.generic))
@@ -298,7 +309,7 @@ def recon(
     else:
         raise ValueError(
             'Keyword "algorithm" must be one of %s, or a Python method.' %
-            (list(allowed_recon_kwargs.keys()),))
+            (list(allowed_recon_kwargs.keys()), ))
 
     # Generate args for the algorithm.
     center_arr = get_center(tomo.shape, center)
@@ -307,8 +318,8 @@ def recon(
     # Initialize reconstruction.
     recon_shape = (tomo.shape[0], kwargs['num_gridx'], kwargs['num_gridy'])
     recon = _init_recon(recon_shape, init_recon, sharedmem=False)
-    return _dist_recon(
-        tomo, center_arr, recon, _get_func(algorithm), args, kwargs, ncore, nchunk)
+    return _dist_recon(tomo, center_arr, recon, _get_func(algorithm), args,
+                       kwargs, ncore, nchunk)
 
 
 # Convert data to sinogram order
@@ -357,8 +368,6 @@ def _get_func(algorithm):
 def _run_accel_algorithm(idx, _func, tomo, center, recon, *_args, **_kwargs):
     # set the device to the specified index within the new process
     os.environ["TOMOPY_DEVICE_NUM"] = "{}".format(idx)
-    # set the "python threads" to one since this was launched via ProcessPool
-    os.environ["TOMOPY_PYTHON_THREADS"] = "1"
     # execute the accelerated algorithm
     _func(tomo, center, recon, *_args, **_kwargs)
     # recon is the only important modified data
@@ -389,11 +398,14 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
     # check if ncore is limited by env variable
     pythreads = os.environ.get("TOMOPY_PYTHON_THREADS")
     if pythreads is not None and ncore > int(pythreads):
-        print("Warning! 'TOMOPY_PYTHON_THREADS' has been set to '{0}', which is less than"
-              " specified ncore={1}. Limiting ncore to {0}...".format(pythreads, ncore))
+        print(
+            "Warning! 'TOMOPY_PYTHON_THREADS' has been set to '{0}', which is less than"
+            " specified ncore={1}. Limiting ncore to {0}...".format(
+                pythreads, ncore))
         ncore = int(pythreads)
 
-    print("Reconstructing {} slice groups with {} master threads...".format(len(slcs), ncore))
+    print("Reconstructing {} slice groups with {} master threads...".format(
+        len(slcs), ncore))
 
     # this is used internally to prevent oversubscription
     os.environ["TOMOPY_PYTHON_THREADS"] = "{}".format(ncore)
@@ -406,11 +418,15 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
         # execute recon on ncore processes. Accelerated methods have internal thread-pool
         # and NVIDIA NPP library does not support simulatenously leveraging multiple devices
         # within the same process
-        if "accelerated" in kwargs and (kwargs["accelerated"] is True or kwargs["accelerated"]):
+        if "accelerated" in kwargs and (kwargs["accelerated"] is True
+                                        or kwargs["accelerated"]):
             futures = []
             with cf.ProcessPoolExecutor(ncore) as e:
                 for idx, slc in enumerate(use_slcs):
-                    futures.append(e.submit(_run_accel_algorithm, idx, algorithm, tomo[slc], center[slc], recon[slc], *args, **kwargs))
+                    futures.append(
+                        e.submit(_run_accel_algorithm, idx, algorithm,
+                                 tomo[slc], center[slc], recon[slc], *args,
+                                 **kwargs))
 
             for f, slc in zip(futures, use_slcs):
                 if f.exception() is not None:
@@ -420,7 +436,8 @@ def _dist_recon(tomo, center, recon, algorithm, args, kwargs, ncore, nchunk):
             # execute recon on ncore threads
             with cf.ThreadPoolExecutor(ncore) as e:
                 for slc in use_slcs:
-                    e.submit(algorithm, tomo[slc], tomo[slc], center[slc], recon[slc], *args, **kwargs)
+                    e.submit(algorithm, tomo[slc], tomo[slc], center[slc],
+                             recon[slc], *args, **kwargs)
 
     if pythreads is not None:
         # reset to default
@@ -446,14 +463,20 @@ def _get_algorithm_kwargs(shape):
         'filter_par': np.array([0.5, 8], dtype='float32'),
         'num_iter': dtype.as_int32(1),
         'reg_par': np.ones(10, dtype='float32'),
-        'reg_data': np.zeros([dy,dx,dx], dtype='float32'),
+        'reg_data': np.zeros([dy, dx, dx], dtype='float32'),
         'num_block': dtype.as_int32(1),
-        'ind_block': np.arange(0, dt, dtype=np.float32),  # TODO: I think this should be int
+        'ind_block':
+        np.arange(0, dt, dtype=np.float32),  # TODO: I think this should be int
         'options': {},
         'accelerated': False,
-        'pool_size': 0, # if zero, calculate based on threads started at Python level
-        'interpolation': 'NN', # interpolation method (NN = nearest-neighbor, LINEAR, CUBIC)
+        'pool_size':
+        0,  # if zero, calculate based on threads started at Python level
+        'interpolation':
+        'NN',  # interpolation method (NN = nearest-neighbor, LINEAR, CUBIC)
         'device': 'gpu',
-        'grid_size': np.array([0, 0, 0], dtype='int32'), # CUDA grid size. If zero, dynamically computed
-        'block_size': np.array([32, 32, 1], dtype='int32'), # CUDA threads per block
+        'grid_size': np.array(
+            [0, 0, 0],
+            dtype='int32'),  # CUDA grid size. If zero, dynamically computed
+        'block_size': np.array([32, 32, 1],
+                               dtype='int32'),  # CUDA threads per block
     }


### PR DESCRIPTION
@dgursoy @carterbox I getting [NESAP](https://www.nersc.gov/research-and-development/nesap/) benchmarking number for our test-bed that resembles Perlmutter and encountered this issue with tomopy not effectively using multiple GPUs. I feel like we uncovered this a long time ago but resolving it got lost when I was transitioning to my new position.

Here is the FOM values I have:

|   | Algorithm | Filename | Cores | Iterations | # Slices | Dimensions | Time to Solution (sec) |
|--| ---------- | --------- | ----- | ---------- | ------- | ------------ | ---------------------- | 
| Edison | sirt | tomo_0001 | 48 | 100 | 24 | 2048 x 2048 | 28069 |
| Edison | mlem | | | | |  | 28733 |
| Perlmutter | sirt (NN) | | 32 | | |  | 569 |
| Perlmutter | mlem (NN) | | | | |  | 566 |

I only used 32 threads (4 threads per GPU) of the 256 available bc you get pretty much the same performance anywhere for 2+ threads per-GPU (there is a slight boost for 2 threads vs. 1 thread) -- it appears NPP holds a lot of state internally and thus isn't great for parallel execution with multiple streams/threads. If one slice is reconstructed at a time, instead of 3 like in this test, the reconstruction time drops down to < 1.5 seconds, however with 3 slices the reconstruction time is ~5.5 seconds instead of 1.5 * 3 = 4.5 seconds. Thus, there appears to be some speed-up missing.