### PR TITLE
BLD: Target all CUDA architectures >= 3.0 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0042 NEW)
 cmake_policy(SET CMP0053 NEW)
+cmake_policy(SET CMP0104 OLD)  # ignore CMAKE_CUDA_ARCHITECTURES
 
 project(tomopy LANGUAGES C CXX)
 

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -209,7 +209,7 @@ if(TOMOPY_USE_CUDA)
         #   70, 72      + Volta support
         #   75          + Turing support
         if(NOT DEFINED CUDA_ARCH)
-            set(CUDA_ARCH "35")
+            set(CUDA_ARCH "30;35;37;50;52;53;60;61;62;70;72;75;80;86")
         endif()
 
         if(TOMOPY_USE_NVTX)
@@ -231,8 +231,12 @@ if(TOMOPY_USE_CUDA)
             endif()
         endif()
 
+        foreach(ARCH IN LISTS ${CUDA_ARCH})
+            list(APPEND ${PROJECT_NAME}_CUDA_FLAGS
+                -arch=sm_${ARCH})
+        endforeach(ARCH)
+
         list(APPEND ${PROJECT_NAME}_CUDA_FLAGS
-            -arch=sm_${CUDA_ARCH}
             --default-stream per-thread)
 
         if(NOT WIN32)

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -209,7 +209,11 @@ if(TOMOPY_USE_CUDA)
         #   70, 72      + Volta support
         #   75          + Turing support
         if(NOT DEFINED CUDA_ARCH)
-            set(CUDA_ARCH "30;35;37;50;52;53;60;61;62;70;72;75;80;86")
+            if(CUDA_VERSION_MAJOR VERSION_LESS 11)
+                set(CUDA_ARCH "30;32;35;37;50;52;53;60;61;62;70;72;75")
+            else()
+                set(CUDA_ARCH "35;37;50;52;53;60;61;62;70;72;75;80;86")
+            endif()
         endif()
 
         if(TOMOPY_USE_NVTX)
@@ -231,9 +235,9 @@ if(TOMOPY_USE_CUDA)
             endif()
         endif()
 
-        foreach(ARCH IN LISTS ${CUDA_ARCH})
+        foreach(ARCH IN ITEMS ${CUDA_ARCH})
             list(APPEND ${PROJECT_NAME}_CUDA_FLAGS
-                -arch=sm_${ARCH})
+                -gencode=arch=compute_${ARCH},code=sm_${ARCH})
         endforeach(ARCH)
 
         list(APPEND ${PROJECT_NAME}_CUDA_FLAGS


### PR DESCRIPTION
The purpose of this PR is to change the default behavior of the build system to target all CUDA architectures from 3.0 to 8.6 inclusive instead of just 3.5. The reason for this change is that we distribute a precompiled binary on conda-forge, so most users aren't compiling for themselves. The consequence is the the binary will become larger, but users with arch=30 will be supported and most should get a performance bump?

My approach is to use the `-gencode=arch=compute_${ARCH},code=sm_${ARCH}` flags for NVCC, and enumerate a list of the compatible architectures for CUDA 11 and 9,10. Online documentation for CUDA <= 8 is no longer available, so I didn't consider that case.