### PR TITLE
BUG: Don't set default cuda arch in two places

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,6 @@ add_bool_opt("TOMOPY_USE_PTL", args.enable_tasking, args.disable_tasking)
 add_bool_opt("TOMOPY_USE_MKL", args.enable_mkl, args.disable_mkl)
 add_bool_opt("TOMOPY_USE_OPENCV", args.enable_opencv, args.disable_opencv)
 
-if args.enable_cuda:
-    cmake_args.append("-DCUDA_ARCH={}".format(args.cuda_arch))
-
 if args.enable_sanitizer:
     cmake_args.append("-DSANITIZER_TYPE:STRING={}".format(args.sanitizer_type))
 


### PR DESCRIPTION
CMake already sets a default arch if the user doesn't set the
arch. We don't need to set a default also in the setup.py