### PR TITLE
Fix link in example

### DIFF
--- a/doc/source/ipynb/tomopy.ipynb
+++ b/doc/source/ipynb/tomopy.ipynb
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This [data set](../../../source/tomopy/data/tooth.h5) file format follows the [APS](http://www.aps.anl.gov) beamline [2-BM and 32-ID](https://www1.aps.anl.gov/Imaging) [data-exchange](https://dxfile.readthedocs.io) definition. Other file format readers for other synchrotrons are also available with [DXchange](https://dxchange.readthedocs.io/en/latest/source/api/dxchange.exchange.html)."
+    "This [data set](https://github.com/tomopy/tomopy/blob/master/source/tomopy/data/tooth.h5) file format follows the [APS](http://www.aps.anl.gov) beamline [2-BM and 32-ID](https://www1.aps.anl.gov/Imaging) [data-exchange](https://dxfile.readthedocs.io) definition. Other file format readers for other synchrotrons are also available with [DXchange](https://dxchange.readthedocs.io/en/latest/source/api/dxchange.exchange.html)."
    ]
   },
   {


### PR DESCRIPTION
Here:
https://tomopy.readthedocs.io/en/latest/ipynb/tomopy.html#Reconstruction-with-TomoPy
Is currently a broken link to the tomo data, that is fixed by this pr.