### PR TITLE
BLD: Update CMake find_package to CUDAToolkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ env:
       CUDA="--enable-cuda"
   global:
     - CUDA_INSTALLER=cuda_10.1.168_418.67_linux.run
-    - CUDA_TOOLKIT_ROOT_DIR=${HOME}/cuda
-    - CUDA_COMPILER=${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc
-    - LD_LIBRARY_PATH=${HOME}/miniconda/lib:${CUDA_TOOLKIT_ROOT_DIR}/lib64
+    - CUDAToolkit_LIBRARY_ROOT=${HOME}/cuda
+    - CUDA_COMPILER=${CUDAToolkit_LIBRARY_ROOT}/bin/nvcc
+    - LD_LIBRARY_PATH=${HOME}/miniconda/lib:${CUDAToolkit_LIBRARY_ROOT}/lib64
     - PATH=${HOME}/miniconda/bin:${PATH}
     - PYCTEST_ARGS="-SF --pyctest-jobs=1 --pyctest-site=Travis
       --phantoms baboon checkerboard peppers -- -VV --
-      -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}
+      -DCUDAToolkit_LIBRARY_ROOT=${CUDAToolkit_LIBRARY_ROOT}
       -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER}"
     - TOMOPY_USE_C_ALGORITHMS=1
 before_install:
@@ -58,8 +58,8 @@ install:
       wget -q -N https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/${CUDA_INSTALLER};
       chmod u+x ${CUDA_INSTALLER};
       ./${CUDA_INSTALLER} --silent --toolkit
-      --toolkitpath=${CUDA_TOOLKIT_ROOT_DIR}
-      --defaultroot=${CUDA_TOOLKIT_ROOT_DIR}
+      --toolkitpath=${CUDAToolkit_LIBRARY_ROOT}
+      --defaultroot=${CUDAToolkit_LIBRARY_ROOT}
       --no-opengl-libs --no-man-page --no-drm;
     fi
   # Check the compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# need CUDA as a first-class language
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+# need CUDA as a first-class language; use newer FindCUDAToolkit
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     set(MSG "")

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -23,8 +23,8 @@ else()
 endif()
 
 # Check if CUDA can be enabled
-find_package(CUDA)
-if(CUDA_FOUND)
+find_package(CUDAToolkit)
+if(CUDAToolkit_FOUND)
     set(_USE_CUDA ON)
 else()
     set(_USE_CUDA OFF)

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -184,8 +184,8 @@ if(TOMOPY_USE_CUDA)
         set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
     endif()
 
-    if(NOT CMAKE_CUDA_COMPILER)
-        set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc)
+    if(NOT CMAKE_CUDA_COMPILER AND CUDAToolkit_FOUND)
+        set(CMAKE_CUDA_COMPILER ${CUDAToolkit_BIN_DIR}/nvcc)
     endif()
 
     enable_language(CUDA)
@@ -209,10 +209,10 @@ if(TOMOPY_USE_CUDA)
         #   70, 72      + Volta support
         #   75          + Turing support
         if(NOT DEFINED CUDA_ARCH)
-            if(CUDA_VERSION_MAJOR VERSION_LESS 11)
+            if(CUDAToolkit_VERSION_MAJOR VERSION_LESS 11)
                 set(CUDA_ARCH "30;32;35;37;50;52;53;60;61;62;70;72;75")
             else()
-                if(CUDA_VERSION_MINOR VERSION_LESS 1)
+                if(CUDAToolkit_VERSION_MINOR VERSION_LESS 1)
                     set(CUDA_ARCH "35;37;50;52;53;60;61;62;70;72;75;80")
                 else()
                     set(CUDA_ARCH "35;37;50;52;53;60;61;62;70;72;75;80;86")

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -190,7 +190,7 @@ if(TOMOPY_USE_CUDA)
 
     enable_language(CUDA)
 
-    list(APPEND EXTERNAL_LIBRARIES ${CUDA_npp_LIBRARY})
+    list(APPEND EXTERNAL_LIBRARIES "CUDA::nppc_static;CUDA::npps_static;CUDA::nppig_static;CUDA::nppisu_static")
     list(APPEND EXTERNAL_INCLUDE_DIRS ${CUDA_INCLUDE_DIRS}
         ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 


### PR DESCRIPTION
The old find_package(CUDA) is deprecated in favor of this new one
which supposedly does a better job of locating the CUDA compiler
and libraries.

Making these changes because I'm having trouble getting Windows builds to compile on the conda-forge feedstock.