### PR TITLE
Convert upsample_factor from positional to key argument

### DIFF
--- a/source/tomopy/prep/alignment.py
+++ b/source/tomopy/prep/alignment.py
@@ -190,7 +190,7 @@ def align_seq(
 
             # Register current projection in sub-pixel precision
             shift, error, diffphase = phase_cross_correlation(
-                    _prj[m], _sim[m], upsample_factor)
+                    _prj[m], _sim[m], upsample_factor=upsample_factor)
             err[m] = np.sqrt(shift[0]*shift[0] + shift[1]*shift[1])
             sx[m] += shift[0]
             sy[m] += shift[1]
@@ -329,7 +329,7 @@ def align_joint(
 
             # Register current projection in sub-pixel precision
             shift, error, diffphase = phase_cross_correlation(
-                    _prj[m], _sim[m], upsample_factor)
+                    _prj[m], _sim[m], upsample_factor=upsample_factor)
             err[m] = np.sqrt(shift[0]*shift[0] + shift[1]*shift[1])
             sx[m] += shift[0]
             sy[m] += shift[1]


### PR DESCRIPTION
This is to overcome the error:
TypeError: phase_cross_correlation() takes 2 positional arguments but 3 were given