### PR TITLE
normalize accepts 2D tiffs.

### DIFF
--- a/source/tomopy/prep/normalize.py
+++ b/source/tomopy/prep/normalize.py
@@ -109,9 +109,9 @@ def normalize(arr, flat, dark, cutoff=None, ncore=None, out=None):
     arr : ndarray
         3D stack of projections.
     flat : ndarray
-        3D flat field data.
+        2D or 3D flat field data.
     dark : ndarray
-        3D dark field data.
+        2D or 3D dark field data.
     cutoff : float, optional
         Permitted maximum vaue for the normalized data.
     ncore : int, optional
@@ -127,7 +127,11 @@ def normalize(arr, flat, dark, cutoff=None, ncore=None, out=None):
     """
     arr = dtype.as_float32(arr)
     l = np.float32(1e-6)
+    if len(flat.shape) == 2:
+      flat = flat[np.newaxis;:,:]
     flat = np.mean(flat, axis=0, dtype=np.float32)
+    if len(dark.shape) == 2:
+      dark = dark[np.newaxis;:,:]
     dark = np.mean(dark, axis=0, dtype=np.float32)
 
     with mproc.set_numexpr_threads(ncore):

--- a/source/tomopy/prep/normalize.py
+++ b/source/tomopy/prep/normalize.py
@@ -128,10 +128,10 @@ def normalize(arr, flat, dark, cutoff=None, ncore=None, out=None):
     arr = dtype.as_float32(arr)
     l = np.float32(1e-6)
     if len(flat.shape) == 2:
-      flat = flat[np.newaxis;:,:]
+      flat = flat[np.newaxis,:,:]
     flat = np.mean(flat, axis=0, dtype=np.float32)
     if len(dark.shape) == 2:
-      dark = dark[np.newaxis;:,:]
+      dark = dark[np.newaxis,:,:]
     dark = np.mean(dark, axis=0, dtype=np.float32)
 
     with mproc.set_numexpr_threads(ncore):


### PR DESCRIPTION
Users may have one flat/dark image for their entire dataset.

dxchange.reader.import_tiff will pull these single image tiffs in, but they will only be in 2D format.

The user should be able to normalize this 2D data as they do with 3D data. If the user does not read that 3D data is required from documentation (or misses it), they will not know why their background is not subtracted.