### PR TITLE
BUG: distribute_jobs no longer works on Win/MacOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
     vmImage: 'macOS-latest'
   strategy:
     matrix:
-      Python37:
+      Python38:
         python.version: '38'
     maxParallel: 4
   steps:

--- a/envs/osx-38.yml
+++ b/envs/osx-38.yml
@@ -14,7 +14,7 @@ dependencies:
   - mkl_fft
   - nose
   - numexpr
-  - numpy
+  - numpy!=1.22.4
   - opencv
   - pyctest>0.0.10
   - python=3.8

--- a/envs/win-37.yml
+++ b/envs/win-37.yml
@@ -12,7 +12,7 @@ dependencies:
   - mkl-devel
   - mkl_fft
   - numexpr
-  - numpy
+  - numpy!=1.22.4
   - libopencv
   - py-opencv  # only for testing
   - python=3.7

--- a/envs/win-39.yml
+++ b/envs/win-39.yml
@@ -12,7 +12,7 @@ dependencies:
   - mkl-devel
   - mkl_fft
   - numexpr
-  - numpy
+  - numpy!=1.22.4
   - libopencv
   - py-opencv  # only for testing
   - python=3.9

--- a/envs/win-nomkl.yml
+++ b/envs/win-nomkl.yml
@@ -10,7 +10,7 @@ dependencies:
   - h5py
   - nomkl
   - numexpr
-  - numpy
+  - numpy!=1.22.4
   - libopencv
   - pywavelets
   - scikit-build


### PR DESCRIPTION
```
    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       TypeError: cannot pickle 'memoryview' object
```
This error is occuring on the conda-forge feedstock OSX builds. Research tells me that it is caused by trying to pass memory views instead of numpy arrays to the multiprocessing distrbute_jobs function.