### PR TITLE
BUG: Don't require absolute path for shared libraries

### DIFF
--- a/envs/win-37.yml
+++ b/envs/win-37.yml
@@ -22,5 +22,5 @@ dependencies:
   - mkl
   - mkl-devel
   - mkl_fft
-  - opencv>=3.4
+  - opencv>=3.4,<4.2
   - pytest

--- a/source/tomopy/util/extern/__init__.py
+++ b/source/tomopy/util/extern/__init__.py
@@ -58,16 +58,21 @@ def c_shared_lib(lib_name, error=True):
 
     The ctypes.util.find_library function preprends "lib" to the name.
     """
-    load_dll = ctypes.cdll.LoadLibrary
-    ext = '.so'
-    if sys.platform == 'darwin':
-        ext = '.dylib'
     if os.name == 'nt':
-        ext = '.dll'
         load_dll = ctypes.windll.LoadLibrary
+    else:
+        load_dll = ctypes.cdll.LoadLibrary
+
+    # Returns None or a library name
     sharedlib = ctypes.util.find_library(lib_name)
-    if sharedlib and os.path.exists(sharedlib):
-        return load_dll(sharedlib)
+
+    if sharedlib is not None:
+        try:
+            # No error if sharedlib is None; error if library name wrong
+            return load_dll(sharedlib)
+        except OSError:
+            pass
+
     explanation = (
         'TomoPy links to compiled components which are installed separately'
         ' and loaded using ctypes.util.find_library().'
@@ -79,7 +84,8 @@ def c_shared_lib(lib_name, error=True):
     warnings.warn(
         explanation +
         'Some functionality is unavailable because an optional shared'
-        f' library, {sharedlib}, is missing.', ImportWarning)
+        f' library, {lib_name}, is missing.', ImportWarning)
+    return None
 
 
 def _missing_library(function):

--- a/source/tomopy/util/mproc.py
+++ b/source/tomopy/util/mproc.py
@@ -87,7 +87,7 @@ def get_rank():
         from mpi4py import MPI
         comm_w = MPI.COMM_WORLD
         return comm_w.Get_rank()
-    except:
+    except ModuleNotFoundError:
         return 0
 
 
@@ -97,7 +97,7 @@ def get_nproc():
         from mpi4py import MPI
         comm_w = MPI.COMM_WORLD
         return comm_w.Get_size()
-    except:
+    except ModuleNotFoundError:
         return 1
 
 def barrier():
@@ -106,7 +106,7 @@ def barrier():
         from mpi4py import MPI
         comm_w = MPI.COMM_WORLD
         comm_w.Barrier()
-    except:
+    except ModuleNotFoundError:
         pass
 
 


### PR DESCRIPTION
The purpose of this PR is to refactor `c_shared_lib()`, so it doesn't require that ctypes `find_library()` return an absolute path. Apparently on arch linux, ctypes `LoadLibrary` can still sometimes find the library with just the filename if it is on the path.

An exception is now raised only if `LoadLibrary` cannot find the library OR `find_library()` returns `None`.

Additional bug fixes include removing some bare exceptions and checking the ThreadPool for exception.

@falkmielke, please try this patch to see if it works for you.

Closes #590