### PR TITLE
wrappers.py: UFO import requests version "0"

### DIFF
--- a/source/tomopy/recon/wrappers.py
+++ b/source/tomopy/recon/wrappers.py
@@ -291,7 +291,7 @@ def ufo_dfi(tomo, center, recon, theta, **kwargs):
     Reconstruct object using UFO's Direct Fourier pipeline
     """
     import gi
-    gi.require_version('Ufo', '0.0')
+    # gi.require_version('Ufo', '0.0')
     from gi.repository import Ufo
 
     theta = theta[1] - theta[0]


### PR DESCRIPTION
UFO import: a static version 0 of UFO is required which prevents using UFO reconstruction. I suggest to skip this test in order to be able to use UFO from tomopy (else it is useless).