### PR TITLE
Add 3D median filter from Larix

### DIFF
--- a/doc/source/api/tomopy.misc.corr.rst
+++ b/doc/source/api/tomopy.misc.corr.rst
@@ -16,6 +16,7 @@
       median_filter
       median_filter_cuda
       median_filter_nonfinite
+      median_filter_3d
       sobel_filter
       remove_nan
       remove_neg

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -161,4 +161,5 @@ autodoc_mock_imports = [
     'scipy',
     'skimage',
     'tifffile',
+    'larix',
 ]

--- a/envs/linux-37.yml
+++ b/envs/linux-37.yml
@@ -1,6 +1,7 @@
 name: tomopy
 channels:
   - conda-forge
+  - savu-dep
 dependencies:
   - cmake
   - cxx-compiler
@@ -27,3 +28,4 @@ dependencies:
   - mkl_fft
   - opencv>=3.4
   - pytest
+  - larix

--- a/source/tomopy/misc/corr.py
+++ b/source/tomopy/misc/corr.py
@@ -348,7 +348,7 @@ def median_filter_nonfinite(arr, size=3, callback=None):
     return arr
 
 
-def median_filter_3d(arr: np.ndarray, radius_kernel: int = 1,
+def median_filter_3d(arr: np.ndarray, radius_kernel: int = 3,
                      ncore: int = 1) -> np.ndarray:
     """
     Apply 3D median filter from the Larix toolbox.
@@ -359,7 +359,7 @@ def median_filter_3d(arr: np.ndarray, radius_kernel: int = 1,
         Input array.
     radius_kernel : int, optional
         The radius of the median kernel (e.g., the full size 3D kernel is
-        (2*radius_kernel+1)^3).
+        (2*radius_kernel+1)^3). Accepted kernel sizes are 3, 5, 7, 9 and 11.
     ncore : int, optional
         Number of cores that will be assigned to jobs.
 

--- a/source/tomopy/misc/corr.py
+++ b/source/tomopy/misc/corr.py
@@ -62,6 +62,7 @@ import warnings
 import numexpr as ne
 import concurrent.futures as cf
 from scipy.signal import medfilt2d
+from larix.methods.misc import MEDIAN_FILT as median_filter_3d_larix
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ __all__ = [
     'median_filter',
     'median_filter_cuda',
     'median_filter_nonfinite',
+    'median_filter_3d',
     'sobel_filter',
     'remove_nan',
     'remove_neg',
@@ -344,6 +346,30 @@ def median_filter_nonfinite(arr, size=3, callback=None):
         callback(arr.shape[0], 'Nonfinite median filter', ' prjs')
 
     return arr
+
+
+def median_filter_3d(arr: np.ndarray, radius_kernel: int = 1,
+                     ncore: int = 1) -> np.ndarray:
+    """
+    Apply 3D median filter from the Larix toolbox.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input array.
+    radius_kernel : int, optional
+        The radius of the median kernel (e.g., the full size 3D kernel is
+        (2*radius_kernel+1)^3).
+    ncore : int, optional
+        Number of cores that will be assigned to jobs.
+
+    Returns
+    -------
+    np.ndarray
+        Median filtered 3D array.
+    """
+
+    return median_filter_3d_larix(arr, radius_kernel, ncore)
 
 
 def sobel_filter(arr, axis=0, ncore=None):

--- a/test/test_tomopy/test_misc/test_corr.py
+++ b/test/test_tomopy/test_misc/test_corr.py
@@ -53,6 +53,7 @@ from tomopy.misc.corr import (
     gaussian_filter,
     median_filter,
     median_filter_nonfinite,
+    median_filter_3d,
     remove_neg,
     remove_nan,
     remove_outlier,
@@ -109,6 +110,10 @@ class ImageFilterTestCase(unittest.TestCase):
                     size=3,
                     callback=None,
                 )
+
+    def test_median_filter_3d(self):
+        data = np.ones(shape=(100, 100, 100), dtype=np.float32) + 100.0
+        assert np.all(median_filter_3d(data) == 101.)
 
     def test_remove_neg(self):
         assert_allclose(remove_neg([-2, -1, 0, 1, 2]), [0, 0, 0, 1, 2])


### PR DESCRIPTION
As suggested by @dkazanc in previous correspondence regarding developers at DLS potentially collaborating on TomoPy, this PR is testing the waters by attempting to integrate the (CPU) 3D median filter from Larix https://github.com/dkazanc/larix.

The main changes are:
- Add Larix as a dependency
- Add a wrapper function for the 3D median filter in Larix
- Add a unit test for the wrapper function
- Include the newly added median filter in the documentation

It's still a work in progress of course, so please feel free to let us know how else we can add to/improve this!