### PR TITLE
BLD: Update PTL to the latest version remove USE_PTL flag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,11 @@ jobs:
     displayName: List build environment
   - script: |
       source activate tomopy
+      export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${CONDA_PREFIX}"
+      export CC=$(which gcc)
+      export CXX=$(which g++)
+      echo "C compiler is ${CC}"
+      echo "C++ compiler is ${CXX}"
       pip install . --no-deps
       cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
       cmake --build build
@@ -110,6 +115,11 @@ jobs:
     displayName: List build environment
   - script: |
       source activate tomopy
+      export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${CONDA_PREFIX}"
+      export CC=$(which clang)
+      export CXX=$(which clang++)
+      echo "C compiler is ${CC}"
+      echo "C++ compiler is ${CXX}"
       pip install . --no-deps
       cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
       cmake --build build

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -77,7 +77,6 @@ add_option(TOMOPY_USE_SANITIZER "Enable sanitizer" OFF)
 add_option(TOMOPY_CXX_GRIDREC "Enable gridrec with C++ std::complex"
            ${_USE_CXX_GRIDREC})
 add_option(TOMOPY_USE_COVERAGE "Enable code coverage for C/C++" OFF)
-add_option(TOMOPY_USE_PTL "Enable Parallel Tasking Library (PTL)" ON)
 add_option(TOMOPY_USE_CLANG_TIDY "Enable clang-tidy (C++ linter)" OFF)
 add_option(TOMOPY_USE_CUDA "Enable CUDA option for GPU execution" ${_USE_CUDA})
 add_option(TOMOPY_USER_FLAGS

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -20,25 +20,17 @@ set(CMAKE_POSITION_INDEPENDENT_CODE
 # PTL submodule
 #
 # ------------------------------------------------------------------------------#
-checkout_git_submodule(
-  RECURSIVE
-  TEST_FILE
-  CMakeLists.txt
-  RELATIVE_PATH
-  source/PTL
-  WORKING_DIRECTORY
-  ${PROJECT_SOURCE_DIR})
-
-if(TOMOPY_USE_PTL)
-  add_subdirectory(PTL)
-  if(BUILD_STATIC_LIBS)
-    list(APPEND TOMOPY_EXTERNAL_LIBRARIES ptl-static)
-  else()
-    list(APPEND TOMOPY_EXTERNAL_LIBRARIES ptl-shared)
-  endif()
-  list(APPEND ${PROJECT_NAME}_DEFINITIONS TOMOPY_USE_PTL)
+if(TOMOPY_USE_OPENCV OR TOMOPY_USE_CUDA)
+  checkout_git_submodule(
+    RECURSIVE
+    TEST_FILE
+    CMakeLists.txt
+    RELATIVE_PATH
+    source/PTL
+    WORKING_DIRECTORY
+    ${PROJECT_SOURCE_DIR})
+  add_subdirectory(PTL EXCLUDE_FROM_ALL)
 endif()
-
 # ------------------------------------------------------------------------------#
 #
 # TomoPy Python module

--- a/source/libtomo/accel/CMakeLists.txt
+++ b/source/libtomo/accel/CMakeLists.txt
@@ -23,12 +23,6 @@ target_include_directories(
          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
-if(TRUE)
-  # FIXME: Need PTL headers regardless of whether we use PTL
-  target_include_directories(tomo-accel
-                             PRIVATE ${tomopy_SOURCE_DIR}/source/PTL/source)
-endif()
-
 if(TOMOPY_USE_CUDA)
 
   target_sources(tomo-accel PRIVATE gpu/common.cu gpu/mlem.cu gpu/sirt.cu
@@ -54,9 +48,9 @@ if(TOMOPY_USE_CUDA)
 endif(TOMOPY_USE_CUDA)
 
 target_link_libraries(tomo-accel PRIVATE ${TOMOPY_EXTERNAL_LIBRARIES}
-                                         ${TOMOPY_EXTERNAL_PRIVATE_LIBRARIES})
+                                         ${TOMOPY_EXTERNAL_PRIVATE_LIBRARIES} ptl-static)
 
-target_compile_definitions(tomo-accel PRIVATE ${${PROJECT_NAME}_DEFINITIONS})
+target_compile_definitions(tomo-accel PRIVATE ${${PROJECT_NAME}_DEFINITIONS} TOMOPY_USE_PTL)
 
 target_compile_options(
   tomo-accel

--- a/source/libtomo/accel/cxx/mlem.cc
+++ b/source/libtomo/accel/cxx/mlem.cc
@@ -76,7 +76,7 @@ cxx_mlem(const float* data, int dy, int dt, int dx, const float* center,
     // local count for the thread
     int count = registration.initialize();
     // number of threads started at Python level
-    auto tcount = GetEnv("TOMOPY_PYTHON_THREADS", HW_CONCURRENCY);
+    auto tcount = PTL::GetEnv("TOMOPY_PYTHON_THREADS", HW_CONCURRENCY);
 
     // configured runtime options
     RuntimeOptions opts(pool_size, interp, device, grid_size, block_size);
@@ -109,7 +109,7 @@ cxx_mlem(const float* data, int dy, int dt, int dx, const float* center,
     }
     catch(std::exception& e)
     {
-        AutoLock l(TypeMutex<decltype(std::cout)>());
+        PTL::AutoLock l(PTL::TypeMutex<decltype(std::cout)>());
         std::cerr << "[TID: " << tid << "] " << e.what()
                   << "\nFalling back to CPU algorithm..." << std::endl;
         return EXIT_FAILURE;
@@ -129,7 +129,7 @@ void
 mlem_cpu_compute_projection(data_array_t& cpu_data, int p, int dy, int dt, int dx, int nx,
                             int ny, const float* theta)
 {
-    ConsumeParameters(dy);
+    PTL::ConsumeParameters(dy);
     auto cache = cpu_data[GetThisThreadID() % cpu_data.size()];
 
     // calculate some values
@@ -237,4 +237,4 @@ mlem_cpu(const float* data, int dy, int dt, int dx, const float*, const float* t
     printf("\n");
 }
 
-#endif // TOMOPY_USE_OPENCV
+#endif  // TOMOPY_USE_OPENCV

--- a/source/libtomo/accel/cxx/sirt.cc
+++ b/source/libtomo/accel/cxx/sirt.cc
@@ -75,7 +75,7 @@ cxx_sirt(const float* data, int dy, int dt, int dx, const float* center,
     // local count for the thread
     int count = registration.initialize();
     // number of threads started at Python level
-    auto tcount = GetEnv("TOMOPY_PYTHON_THREADS", HW_CONCURRENCY);
+    auto tcount = PTL::GetEnv("TOMOPY_PYTHON_THREADS", HW_CONCURRENCY);
 
     // configured runtime options
     RuntimeOptions opts(pool_size, interp, device, grid_size, block_size);
@@ -108,7 +108,7 @@ cxx_sirt(const float* data, int dy, int dt, int dx, const float* center,
     }
     catch(std::exception& e)
     {
-        AutoLock l(TypeMutex<decltype(std::cout)>());
+        PTL::AutoLock l(PTL::TypeMutex<decltype(std::cout)>());
         std::cerr << "[TID: " << tid << "] " << e.what()
                   << "\nFalling back to CPU algorithm..." << std::endl;
         // return failure code
@@ -130,7 +130,7 @@ void
 sirt_cpu_compute_projection(data_array_t& cpu_data, int p, int dy, int dt, int dx, int nx,
                             int ny, const float* theta)
 {
-    ConsumeParameters(dy);
+    PTL::ConsumeParameters(dy);
     auto cache = cpu_data[GetThisThreadID() % cpu_data.size()];
 
     // calculate some values
@@ -238,4 +238,4 @@ sirt_cpu(const float* data, int dy, int dt, int dx, const float*, const float* t
     printf("\n");
 }
 
-#endif // TOMOPY_USE_OPENCV
+#endif  // TOMOPY_USE_OPENCV

--- a/source/libtomo/accel/data.hh
+++ b/source/libtomo/accel/data.hh
@@ -90,7 +90,7 @@ struct RuntimeOptions
     ~RuntimeOptions() {}
 
     // disable copying and copy assignment
-    RuntimeOptions(const RuntimeOptions&) = delete;
+    RuntimeOptions(const RuntimeOptions&)            = delete;
     RuntimeOptions& operator=(const RuntimeOptions&) = delete;
 
     // create the thread pool -- don't have this in the constructor
@@ -210,7 +210,7 @@ execute(RuntimeOptions* ops, int dt, DataArray& data, Func&& func, Args&&... arg
         std::stringstream ss;
         ss << "\n\nError executing :: " << e.what() << "\n\n";
         {
-            AutoLock l(TypeMutex<decltype(std::cout)>());
+            PTL::AutoLock l(PTL::TypeMutex<decltype(std::cout)>());
             std::cerr << e.what() << std::endl;
         }
         throw std::runtime_error(ss.str().c_str());
@@ -244,7 +244,7 @@ execute(RuntimeOptions* ops, int dt, DataArray& data, Func&& func, Args&&... arg
         std::stringstream ss;
         ss << "\n\nError executing :: " << e.what() << "\n\n";
         {
-            AutoLock l(TypeMutex<decltype(std::cout)>());
+            PTL::AutoLock l(PTL::TypeMutex<decltype(std::cout)>());
             std::cerr << e.what() << std::endl;
         }
         throw std::runtime_error(ss.str().c_str());
@@ -295,9 +295,9 @@ public:
 
     int interpolation() const { return m_interp; }
 
-    Mutex* upd_mutex() const
+    PTL::Mutex* upd_mutex() const
     {
-        static Mutex mtx;
+        static PTL::Mutex mtx;
         return &mtx;
     }
 
@@ -401,7 +401,7 @@ public:
     GpuData(this_type&&)      = default;
 
     this_type& operator=(const this_type&) = delete;
-    this_type& operator=(this_type&&) = default;
+    this_type& operator=(this_type&&)      = default;
 
 public:
     // access functions

--- a/source/libtomo/accel/gpu/common.cu
+++ b/source/libtomo/accel/gpu/common.cu
@@ -238,7 +238,7 @@ cuda_device_count()
 void
 cuda_device_query()
 {
-    auto pythreads = GetEnv("TOMOPY_PYTHON_THREADS", HW_CONCURRENCY);
+    auto pythreads = PTL::GetEnv("TOMOPY_PYTHON_THREADS", HW_CONCURRENCY);
     static std::atomic<int16_t> _once;
     auto                        _count = _once++;
     if(_count + 1 == pythreads)
@@ -277,14 +277,14 @@ cuda_device_query()
         return;
     }
 
-    AutoLock l(TypeMutex<decltype(std::cout)>());
+    PTL::AutoLock l(PTL::TypeMutex<decltype(std::cout)>());
 
     if(deviceCount == 0)
         printf("No available CUDA device(s) detected\n");
     else
         printf("Detected %d CUDA capable devices\n", deviceCount);
 
-    int specific_device = GetEnv("TOMOPY_DEVICE_NUM", -1);
+    int specific_device = PTL::GetEnv("TOMOPY_DEVICE_NUM", -1);
 
     for(int dev = 0; dev < deviceCount; ++dev)
     {

--- a/source/libtomo/accel/gpu/mlem.cu
+++ b/source/libtomo/accel/gpu/mlem.cu
@@ -176,7 +176,7 @@ mlem_cuda(const float* cpu_data, int dy, int dt, int dx, const float*, const flo
     // compute some properties (expected python threads, max threads, device assignment)
     int pythread_num = ntid++;
     int device       = pythread_num % cuda_device_count();  // assign to device
-    device           = GetEnv("TOMOPY_DEVICE_NUM", device) % cuda_device_count();
+    device           = PTL::GetEnv("TOMOPY_DEVICE_NUM", device) % cuda_device_count();
 
     TIMEMORY_AUTO_TIMER("");
 

--- a/source/libtomo/accel/gpu/sirt.cu
+++ b/source/libtomo/accel/gpu/sirt.cu
@@ -173,7 +173,7 @@ sirt_cuda(const float* cpu_data, int dy, int dt, int dx, const float* center,
     // compute some properties (expected python threads, max threads, device assignment)
     int pythread_num = ntid++;
     int device       = pythread_num % cuda_device_count();  // assign to device
-    device           = GetEnv("TOMOPY_DEVICE_NUM", device) % cuda_device_count();
+    device           = PTL::GetEnv("TOMOPY_DEVICE_NUM", device) % cuda_device_count();
 
     TIMEMORY_AUTO_TIMER("");
 

--- a/source/libtomo/accel/macros.hh
+++ b/source/libtomo/accel/macros.hh
@@ -154,7 +154,7 @@ inline uintmax_t
 GetThisThreadID()
 {
 #if defined(TOMOPY_USE_PTL)
-    return ThreadPool::GetThisThreadID();
+    return PTL::ThreadPool::get_this_thread_id();
 #else
     static std::atomic<uintmax_t> tcounter;
     static thread_local auto      tid = tcounter++;
@@ -406,15 +406,15 @@ struct cuda_algorithms
 
 //--------------------------------------------------------------------------------------//
 
-using ThreadPool = ::ThreadPool;
+using ThreadPool = PTL::ThreadPool;
 template <typename _Ret, typename _Arg = _Ret>
-using TaskGroup = ::TaskGroup<_Ret, _Arg>;
+using TaskGroup = PTL::TaskGroup<_Ret, _Arg>;
 
 //--------------------------------------------------------------------------------------//
 
 // when compiled with PTL, mark tomopy::ThreadPool as implemented
 template <>
-struct implementation_available<ThreadPool> : std::true_type
+struct implementation_available<PTL::ThreadPool> : std::true_type
 {
 };
 

--- a/source/libtomo/accel/utils.hh
+++ b/source/libtomo/accel/utils.hh
@@ -54,11 +54,11 @@ END_EXTERN_C
 
 #if defined(TOMOPY_USE_OPENCV)
 
-#define CPU_NN CV_INTER_NN
-#define CPU_LINEAR CV_INTER_LINEAR
-#define CPU_AREA CV_INTER_AREA
-#define CPU_CUBIC CV_INTER_CUBIC
-#define CPU_LANCZOS CV_INTER_LANCZOS4
+#    define CPU_NN CV_INTER_NN
+#    define CPU_LINEAR CV_INTER_LINEAR
+#    define CPU_AREA CV_INTER_AREA
+#    define CPU_CUBIC CV_INTER_CUBIC
+#    define CPU_LANCZOS CV_INTER_LANCZOS4
 
 //--------------------------------------------------------------------------------------//
 
@@ -73,16 +73,16 @@ struct OpenCVDataType
     }
 };
 
-#define DEFINE_OPENCV_DATA_TYPE(pod_type, opencv_type)                                   \
-    template <>                                                                          \
-    struct OpenCVDataType<pod_type>                                                      \
-    {                                                                                    \
-        template <typename _Up = pod_type>                                               \
-        static constexpr int value()                                                     \
+#    define DEFINE_OPENCV_DATA_TYPE(pod_type, opencv_type)                               \
+        template <>                                                                      \
+        struct OpenCVDataType<pod_type>                                                  \
         {                                                                                \
-            return opencv_type;                                                          \
-        }                                                                                \
-    };
+            template <typename _Up = pod_type>                                           \
+            static constexpr int value()                                                 \
+            {                                                                            \
+                return opencv_type;                                                      \
+            }                                                                            \
+        };
 
 // floating point types
 DEFINE_OPENCV_DATA_TYPE(float, CV_32F)
@@ -97,19 +97,19 @@ DEFINE_OPENCV_DATA_TYPE(int32_t, CV_32S)
 DEFINE_OPENCV_DATA_TYPE(uint8_t, CV_8U)
 DEFINE_OPENCV_DATA_TYPE(uint16_t, CV_16U)
 
-#undef DEFINE_OPENCV_DATA_TYPE  // don't pollute
+#    undef DEFINE_OPENCV_DATA_TYPE  // don't pollute
 
 //--------------------------------------------------------------------------------------//
 
 inline int
 GetOpenCVInterpolationMode(const std::string& preferred)
 {
-    EnvChoiceList<int> choices = {
-        EnvChoice<int>(CPU_NN, "NN", "nearest neighbor interpolation"),
-        EnvChoice<int>(CPU_LINEAR, "LINEAR", "bilinear interpolation"),
-        EnvChoice<int>(CPU_CUBIC, "CUBIC", "bicubic interpolation")
+    PTL::EnvChoiceList<int> choices = {
+        PTL::EnvChoice<int>(CPU_NN, "NN", "nearest neighbor interpolation"),
+        PTL::EnvChoice<int>(CPU_LINEAR, "LINEAR", "bilinear interpolation"),
+        PTL::EnvChoice<int>(CPU_CUBIC, "CUBIC", "bicubic interpolation")
     };
-    return GetChoice<int>(choices, preferred);
+    return PTL::GetChoice<int>(choices, preferred);
 }
 
 //--------------------------------------------------------------------------------------//
@@ -158,7 +158,8 @@ cxx_rotate(const _Tp* src, double theta, const intmax_t& nx, const intmax_t& ny,
 inline iarray_t
 cxx_compute_sum_dist(int dy, int dt, int dx, int nx, int ny, const float* theta)
 {
-    auto compute = [&](const iarray_t& ones, iarray_t& sum_dist, int p) {
+    auto compute = [&](const iarray_t& ones, iarray_t& sum_dist, int p)
+    {
         for(int s = 0; s < dy; ++s)
         {
             for(int d = 0; d < dx; ++d)
@@ -186,7 +187,7 @@ cxx_compute_sum_dist(int dy, int dt, int dx, int nx, int ny, const float* theta)
 
     return sum_dist;
 }
-#endif // TOMOPY_USE_OPENCV
+#endif  // TOMOPY_USE_OPENCV
 
 //======================================================================================//
 //
@@ -203,12 +204,12 @@ cxx_compute_sum_dist(int dy, int dt, int dx, int nx, int ny, const float* theta)
 inline int
 GetNppInterpolationMode(const std::string& preferred)
 {
-    EnvChoiceList<int> choices = {
-        EnvChoice<int>(GPU_NN, "NN", "nearest neighbor interpolation"),
-        EnvChoice<int>(GPU_LINEAR, "LINEAR", "bilinear interpolation"),
-        EnvChoice<int>(GPU_CUBIC, "CUBIC", "bicubic interpolation")
+    PTL::EnvChoiceList<int> choices = {
+        PTL::EnvChoice<int>(GPU_NN, "NN", "nearest neighbor interpolation"),
+        PTL::EnvChoice<int>(GPU_LINEAR, "LINEAR", "bilinear interpolation"),
+        PTL::EnvChoice<int>(GPU_CUBIC, "CUBIC", "bicubic interpolation")
     };
-    return GetChoice<int>(choices, preferred);
+    return PTL::GetChoice<int>(choices, preferred);
 }
 
 //======================================================================================//
@@ -220,7 +221,7 @@ GetNppInterpolationMode(const std::string& preferred)
 inline int
 GetBlockSize(const int& init = 32)
 {
-    static thread_local int _instance = GetEnv<int>("TOMOPY_BLOCK_SIZE", init);
+    static thread_local int _instance = PTL::GetEnv<int>("TOMOPY_BLOCK_SIZE", init);
     return _instance;
 }
 
@@ -230,7 +231,7 @@ inline int
 GetGridSize(const int& init = 0)
 {
     // default value of zero == calculated according to block and loop size
-    static thread_local int _instance = GetEnv<int>("TOMOPY_GRID_SIZE", init);
+    static thread_local int _instance = PTL::GetEnv<int>("TOMOPY_GRID_SIZE", init);
     return _instance;
 }
 
@@ -247,9 +248,9 @@ ComputeGridSize(const int& size, const int& block_size = GetBlockSize())
 inline dim3
 GetBlockDims(const dim3& init = dim3(32, 32, 1))
 {
-    int _x = GetEnv<int>("TOMOPY_BLOCK_SIZE_X", init.x);
-    int _y = GetEnv<int>("TOMOPY_BLOCK_SIZE_Y", init.y);
-    int _z = GetEnv<int>("TOMOPY_BLOCK_SIZE_Z", init.z);
+    int _x = PTL::GetEnv<int>("TOMOPY_BLOCK_SIZE_X", init.x);
+    int _y = PTL::GetEnv<int>("TOMOPY_BLOCK_SIZE_Y", init.y);
+    int _z = PTL::GetEnv<int>("TOMOPY_BLOCK_SIZE_Z", init.z);
     return dim3(_x, _y, _z);
 }
 
@@ -259,9 +260,9 @@ inline dim3
 GetGridDims(const dim3& init = dim3(0, 0, 0))
 {
     // default value of zero == calculated according to block and loop size
-    int _x = GetEnv<int>("TOMOPY_GRID_SIZE_X", init.x);
-    int _y = GetEnv<int>("TOMOPY_GRID_SIZE_Y", init.y);
-    int _z = GetEnv<int>("TOMOPY_GRID_SIZE_Z", init.z);
+    int _x = PTL::GetEnv<int>("TOMOPY_GRID_SIZE_X", init.x);
+    int _y = PTL::GetEnv<int>("TOMOPY_GRID_SIZE_Y", init.y);
+    int _z = PTL::GetEnv<int>("TOMOPY_GRID_SIZE_Z", init.z);
     return dim3(_x, _y, _z);
 }
 
@@ -501,8 +502,8 @@ reduce(float* _in, float* _out, int size);
 //======================================================================================//
 
 DLL int32_t*
-    cuda_rotate(const int32_t* src, const float theta_rad, const float theta_deg,
-                const int nx, const int ny, cudaStream_t stream, const int eInterp);
+cuda_rotate(const int32_t* src, const float theta_rad, const float theta_deg,
+            const int nx, const int ny, cudaStream_t stream, const int eInterp);
 
 //--------------------------------------------------------------------------------------//
 

--- a/source/libtomo/gridrec/CMakeLists.txt
+++ b/source/libtomo/gridrec/CMakeLists.txt
@@ -28,6 +28,8 @@ target_compile_options(
   tomo-gridrec PRIVATE $<$<COMPILE_LANGUAGE:C>:${${PROJECT_NAME}_C_FLAGS}>
                        $<$<COMPILE_LANGUAGE:CXX>:${${PROJECT_NAME}_CXX_FLAGS}>)
 
+set_property(TARGET tomo-gridrec PROPERTY CXX_STANDARD 14)
+
 install(TARGETS tomo-gridrec EXPORT libtomoTargets)
 
 install(


### PR DESCRIPTION
The USE_PTL CMake option has been slightly redundant for a while, since the accel module always includes PTL headers. This refactoring

- moves the PTL submodule to the latest release instead of using an old commit
- removes TOMOPY_USE_PTL as an option and always statically links to PTL
- changes some function calls and adds many PTL:: namespace markers to adapt to the PTL v2 API.

None of the API/ABIs should be affect by this change

Also fixed a missing CXX standard declaration for CXX gridrec