### PR TITLE
BLD: Have CMake manage CUDA architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # need CUDA as a first-class language; use newer FindCUDAToolkit
-cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+# need CMAKE_CUDA_ARCHITECTURES
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   set(MSG "")
@@ -19,7 +20,7 @@ endif()
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0042 NEW)
 cmake_policy(SET CMP0053 NEW)
-cmake_policy(SET CMP0104 OLD) # ignore CMAKE_CUDA_ARCHITECTURES
+cmake_policy(SET CMP0104 NEW)
 
 # get version from git if available; fall back to .gitarchival.txt
 execute_process(

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -212,22 +212,6 @@ if(TOMOPY_USE_CUDA)
   if("CUDA" IN_LIST LANGUAGES)
     list(APPEND ${PROJECT_NAME}_DEFINITIONS TOMOPY_USE_CUDA)
     add_feature(${PROJECT_NAME}_CUDA_FLAGS "CUDA NVCC compiler flags")
-    add_feature(CUDA_ARCH "CUDA architecture (e.g. '35' means '-arch=sm_35')")
-
-    # 30, 32      + Kepler support + Unified memory programming 35          +
-    # Dynamic parallelism support 50, 52, 53  + Maxwell support 60, 61, 62  +
-    # Pascal support 70, 72      + Volta support 75          + Turing support
-    if(NOT DEFINED CUDA_ARCH)
-      if(CUDAToolkit_VERSION_MAJOR VERSION_LESS 11)
-        set(CUDA_ARCH "30;32;35;37;50;52;53;60;61;62;70;72;75")
-      else()
-        if(CUDAToolkit_VERSION_MINOR VERSION_LESS 1)
-          set(CUDA_ARCH "35;37;50;52;53;60;61;62;70;72;75;80")
-        else()
-          set(CUDA_ARCH "35;37;50;52;53;60;61;62;70;72;75;80;86")
-        endif()
-      endif()
-    endif()
 
     if(TOMOPY_USE_NVTX)
       find_library(
@@ -248,11 +232,6 @@ if(TOMOPY_USE_CUDA)
         set(TOMOPY_USE_NVTX OFF)
       endif()
     endif()
-
-    foreach(ARCH IN ITEMS ${CUDA_ARCH})
-      list(APPEND ${PROJECT_NAME}_CUDA_FLAGS
-           -gencode=arch=compute_${ARCH},code=sm_${ARCH})
-    endforeach(ARCH)
 
     list(APPEND ${PROJECT_NAME}_CUDA_FLAGS --default-stream per-thread)
 

--- a/pyctest_tomopy.py
+++ b/pyctest_tomopy.py
@@ -204,7 +204,7 @@ def configure():
         args.cmake_args.append("-DSANITIZER_TYPE:STRING={}".format(args.sanitizer_type))
 
     if args.enable_cuda:
-        args.cmake_args.append("-DCUDA_ARCH={}".format(args.cuda_arch))
+        args.cmake_args.append("-DCMAKE_CUDA_ARCHITECTURES={}".format(args.cuda_arch))
 
     if len(args.cmake_args) > 0:
         print("\n\n\tCMake arguments set via command line: {}\n".format(


### PR DESCRIPTION
Cmake 3.18 adds the CMAKE_CUDA_ARCHITECTURES
variable, which defines the default cuda archs passed to the cuda compiler. Builders can now set this variable in the cache or use CUDAARCHS environment variable if using CMake >=3.20.