### PR TITLE
BUG: vector reconstruction update fixed

### DIFF
--- a/source/libtomo/recon/vector.c
+++ b/source/libtomo/recon/vector.c
@@ -174,7 +174,7 @@ vector(const float* data, int dy, int dt, int dx, const float* center, const flo
                     recon1[n + m * ngridy + s * ngridx * ngridy] +=
                         update1[n + m * ngridy] / sum_dist[n + m * ngridy];
                     recon2[n + m * ngridy + s * ngridx * ngridy] +=
-                        update1[n + m * ngridy] / sum_dist[n + m * ngridy];
+                        update2[n + m * ngridy] / sum_dist[n + m * ngridy];
                 }
             }
 


### PR DESCRIPTION
This is somehow missed because it was never tested. The issue is not visible for ```vector2``` and ```vector3``` functions, that were used in the tutorials.