### PR TITLE
option `dtype` removed from np.median

### DIFF
--- a/source/tomopy/prep/normalize.py
+++ b/source/tomopy/prep/normalize.py
@@ -150,8 +150,8 @@ def normalize(
         flat = np.mean(flat, axis=0, dtype=np.float32)
         dark = np.mean(dark, axis=0, dtype=np.float32)
     elif averaging == 'median':
-        flat = np.median(flat, axis=0, dtype=np.float32)
-        dark = np.median(dark, axis=0, dtype=np.float32)
+        flat = np.median(flat, axis=0)
+        dark = np.median(dark, axis=0)
     else:
         raise ValueError(
             f"'averaging' must be 'mean' or 'median' not {averaging}")


### PR DESCRIPTION
possibly wrong call of [`np.median`](https://numpy.org/doc/stable/reference/generated/numpy.median.html) in `normalize.py` corrected removing the option `dtype=np.float32`