### PR TITLE
Fix for remove_outlier3d #622

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,2 @@
-[submodule "src/PTL"]
-	path = source/PTL
-	url = https://github.com/jrmadsen/PTL.git
+[submodule "source/PTL"]
+	url = https://github.com/tomopy/PTL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,2 +1,3 @@
 [submodule "source/PTL"]
+	path = source/PTL
 	url = https://github.com/tomopy/PTL.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
   - script: |
-      conda env create -n tomopy --quiet -f envs/linux-$(python.version).yml
+      conda env create -n tomopy --quiet -f envs/linux-$(python.version).yml --solver=libmamba
     displayName: Create build environment
   - script: conda list -n tomopy
     displayName: List build environment
@@ -106,7 +106,7 @@ jobs:
   - bash: sudo chown -R $USER $CONDA
     displayName: Take ownership of conda installation
   - script: |
-      conda env create -n tomopy --quiet -f envs/osx-$(python.version).yml
+      conda env create -n tomopy --quiet -f envs/osx-$(python.version).yml --solver=libmamba
     displayName: Create build environment
   - script: conda list -n tomopy
     displayName: List build environment
@@ -134,7 +134,7 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
-      conda env create -n tomopy --quiet -f envs/win-ci.yml
+      conda env create -n tomopy --quiet -f envs/win-ci.yml --solver=libmamba
     displayName: Create build environment
   - script: conda list -n tomopy
     displayName: List build environment

--- a/source/libtomo/misc/median_filt3d.c
+++ b/source/libtomo/misc/median_filt3d.c
@@ -66,7 +66,7 @@ int uint16comp(const void* elem1, const void* elem2)
 
 void
 medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
-                float mu_threshold, long i, long j, long k, long index, long dimX,
+                float mu_threshold, long i, long j, long k, size_t index, long dimX,
                 long dimY, long dimZ)
 {
     float*    ValVec;
@@ -78,6 +78,7 @@ medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
     long      k1;
     long long counter;
     int       midval;
+    size_t    index1;
     midval = (sizefilter_total / 2);
     ValVec = (float*) calloc(sizefilter_total, sizeof(float));
 
@@ -98,7 +99,8 @@ medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
                 k1 = k + k_m;
                 if((k1 < 0) || (k1 >= dimZ))
                     k1 = k;
-                ValVec[counter] = Input[(dimX * dimY) * k1 + j1 * dimX + i1];
+                index1 = (size_t)(dimX * dimY * k1 ) + (size_t)(j1 * dimX + i1);
+                ValVec[counter] = Input[index1];
                 counter++;
             }
         }
@@ -122,7 +124,7 @@ medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
 
 void
 medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
-                float mu_threshold, long i, long j, long index, long dimX, long dimY)
+                float mu_threshold, long i, long j, size_t index, long dimX, long dimY)
 {
     float*    ValVec;
     long      i_m;
@@ -131,6 +133,7 @@ medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
     long      j1;
     long long counter;
     int       midval;
+    size_t    index1;
     midval = (sizefilter_total / 2);
     ValVec = (float*) calloc(sizefilter_total, sizeof(float));
 
@@ -146,7 +149,8 @@ medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
             j1 = j + j_m;
             if((j1 < 0) || (j1 >= dimY))
                 j1 = j;
-            ValVec[counter] = Input[j1 * dimX + i1];
+            index1 = (size_t)(j1 * dimX + i1);
+            ValVec[counter] = Input[index1];
             counter++;
         }
     }
@@ -169,7 +173,7 @@ medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
 void
 medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
                  int sizefilter_total, float mu_threshold, long i, long j, long k,
-                 long index, long dimX, long dimY, long dimZ)
+                 size_t index, long dimX, long dimY, long dimZ)
 {
     unsigned short* ValVec;
     long            i_m;
@@ -180,6 +184,7 @@ medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
     long            k1;
     long long       counter;
     int             midval;
+    size_t          index1;
     midval = (sizefilter_total / 2);
     ValVec = (unsigned short*) calloc(sizefilter_total, sizeof(unsigned short));
 
@@ -200,7 +205,8 @@ medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
                 k1 = k + k_m;
                 if((k1 < 0) || (k1 >= dimZ))
                     k1 = k;
-                ValVec[counter] = Input[(dimX * dimY) * k1 + j1 * dimX + i1];
+                index1 = (size_t)(dimX * dimY * k1 ) + (size_t)(j1 * dimX + i1);
+                ValVec[counter] = Input[index1];
                 counter++;
             }
         }
@@ -224,7 +230,7 @@ medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
 
 void
 medfilt2D_uint16(unsigned short* Input, unsigned short* Output, int radius,
-                 int sizefilter_total, float mu_threshold, long i, long j, long index,
+                 int sizefilter_total, float mu_threshold, long i, long j, size_t index,
                  long dimX, long dimY)
 {
     unsigned short* ValVec;
@@ -234,6 +240,7 @@ medfilt2D_uint16(unsigned short* Input, unsigned short* Output, int radius,
     long            j1;
     long long       counter;
     int             midval;
+    size_t          index1;
     midval = (sizefilter_total / 2);
     ValVec = (unsigned short*) calloc(sizefilter_total, sizeof(unsigned short));
 
@@ -249,7 +256,8 @@ medfilt2D_uint16(unsigned short* Input, unsigned short* Output, int radius,
             j1 = j + j_m;
             if((j1 < 0) || (j1 >= dimY))
                 j1 = j;
-            ValVec[counter] = Input[j1 * dimX + i1];
+            index1 = (size_t)(j1 * dimX + i1);
+            ValVec[counter] = Input[index1];
             counter++;
         }
     }
@@ -279,12 +287,14 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
     long      i;
     long      j;
     long      k;
-    long long index;
+    size_t    index;
+    size_t    totalvoxels;
 
+    totalvoxels = (size_t)(dimX * dimY * dimZ);
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
     if(mu_threshold != 0.0)
     {
-        memcpy(Output, Input, dimX * dimY * dimZ * sizeof(float));
+        memcpy(Output, Input, totalvoxels * sizeof(float));
     } /* copy input into output */
 
     /* dealing here with a custom given number of cpu threads */
@@ -304,7 +314,7 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
         {
             for(i = 0; i < dimX; i++)
             {
-                index = (j * dimX + i);
+                index = (size_t)(j * dimX + i);
                 medfilt2D_float(Input, Output, radius, sizefilter_total, mu_threshold, i,
                                 j, index, (long) (dimX), (long) (dimY));
             }
@@ -321,7 +331,7 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
             {
                 for(i = 0; i < dimX; i++)
                 {
-                    index = ((dimX * dimY) * k + j * dimX + i);
+                    index = (size_t)((dimX * dimY) * k) + (size_t)(j * dimX + i);
                     medfilt3D_float(Input, Output, radius, sizefilter_total, mu_threshold,
                                     i, j, k, index, (long) (dimX), (long) (dimY),
                                     (long) (dimZ));
@@ -342,12 +352,14 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
     long      i;
     long      j;
     long      k;
-    long long index;
+    size_t    index;
+    size_t    totalvoxels;
 
+    totalvoxels = (size_t)(dimX * dimY * dimZ);    
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
     if(mu_threshold != 0.0)
     {
-        memcpy(Output, Input, dimX * dimY * dimZ * sizeof(unsigned short));
+        memcpy(Output, Input, totalvoxels * sizeof(unsigned short));
     } /* copy input into output */
 
     /* dealing here with a custom given number of cpu threads */
@@ -367,7 +379,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
         {
             for(i = 0; i < dimX; i++)
             {
-                index = (j * dimX + i);
+                index = (size_t)(j * dimX + i);
                 medfilt2D_uint16(Input, Output, radius, sizefilter_total, mu_threshold, i,
                                  j, index, (long) (dimX), (long) (dimY));
             }
@@ -384,7 +396,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
             {
                 for(i = 0; i < dimX; i++)
                 {
-                    index = ((dimX * dimY) * k + j * dimX + i);
+                    index = (size_t)(dimX * dimY * k) + (size_t)(j * dimX + i);
                     medfilt3D_uint16(Input, Output, radius, sizefilter_total,
                                      mu_threshold, i, j, k, index, (long) (dimX),
                                      (long) (dimY), (long) (dimZ));

--- a/source/libtomo/misc/median_filt3d.c
+++ b/source/libtomo/misc/median_filt3d.c
@@ -48,7 +48,6 @@
 #include <omp.h>
 #include <stdlib.h>
 #include <string.h>
-#include "stdio.h"
 
 #include "libtomo/median_filt3d.h"
 

--- a/source/libtomo/misc/median_filt3d.c
+++ b/source/libtomo/misc/median_filt3d.c
@@ -67,8 +67,8 @@ int uint16comp(const void* elem1, const void* elem2)
 
 void
 medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
-                float mu_threshold, long i, long j, long k, size_t index, long dimX,
-                long dimY, long dimZ)
+                float mu_threshold, long i, long j, long k, size_t index, size_t dimX,
+                size_t dimY, size_t dimZ)
 {
     float*    ValVec;
     long      i_m;
@@ -125,7 +125,7 @@ medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
 
 void
 medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
-                float mu_threshold, long i, long j, size_t index, long dimX, long dimY)
+                float mu_threshold, long i, long j, size_t index, size_t dimX, size_t dimY)
 {
     float*    ValVec;
     long      i_m;
@@ -174,7 +174,7 @@ medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
 void
 medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
                  int sizefilter_total, float mu_threshold, long i, long j, long k,
-                 size_t index, long dimX, long dimY, long dimZ)
+                 size_t index, size_t dimX, size_t dimY, size_t dimZ)
 {
     unsigned short* ValVec;
     long            i_m;
@@ -205,14 +205,14 @@ medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
             {
                 k1 = k + k_m;
                 if((k1 < 0) || (k1 >= dimZ))
-                    k1 = k;                
+                    k1 = k;
                 index1 = dimX * dimY * (size_t)k1 + (size_t)j1 * dimX + (size_t)i1;
                 ValVec[counter] = Input[index1];
                 counter++;
             }
         }
     }
- 
+
     qsort(ValVec, sizefilter_total, sizeof(unsigned short), uint16comp);
 
     if(mu_threshold == 0.0F)
@@ -232,7 +232,7 @@ medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
 void
 medfilt2D_uint16(unsigned short* Input, unsigned short* Output, int radius,
                  int sizefilter_total, float mu_threshold, long i, long j, size_t index,
-                 long dimX, long dimY)
+                 size_t dimX, size_t dimY)
 {
     unsigned short* ValVec;
     long            i_m;
@@ -313,7 +313,7 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
             {
                 index = (size_t)(j) * dimX + (size_t)(i);
                 medfilt2D_float(Input, Output, radius, sizefilter_total, mu_threshold, i,
-                                j, index, (long) (dimX), (long) (dimY));
+                                j, index, (size_t) dimX, (size_t) dimY);
             }
         }
     }
@@ -330,8 +330,8 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
                 {
                     index = dimX * dimY * (size_t)(k) + (size_t)(j) * dimX + (size_t)(i);
                     medfilt3D_float(Input, Output, radius, sizefilter_total, mu_threshold,
-                                    i, j, k, index, (long) (dimX), (long) (dimY),
-                                    (long) (dimZ));
+                                    i, j, k, index, (size_t) dimX, (size_t) dimY,
+                                    (size_t) dimZ);
                 }
             }
         }
@@ -352,7 +352,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
     size_t    index;
     size_t    totalvoxels;
 
-    totalvoxels = (size_t)(dimX) * (size_t)(dimY) * (size_t)(dimZ);  
+    totalvoxels = (size_t)(dimX) * (size_t)(dimY) * (size_t)(dimZ);
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
 
     /* dealing here with a custom given number of cpu threads */
@@ -374,7 +374,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
             {
                 index = (size_t)(j) * dimX + (size_t)(i);
                 medfilt2D_uint16(Input, Output, radius, sizefilter_total, mu_threshold, i,
-                                 j, index, (long) (dimX), (long) (dimY));
+                                 j, index, (size_t) dimX,  (size_t) dimY);
             }
         }
     }
@@ -391,8 +391,8 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
                 {
                     index = dimX * dimY * (size_t)(k) + (size_t)(j) * dimX + (size_t)(i);
                     medfilt3D_uint16(Input, Output, radius, sizefilter_total,
-                                     mu_threshold, i, j, k, index, (long) (dimX),
-                                     (long) (dimY), (long) (dimZ));
+                                     mu_threshold, i, j, k, index,(size_t) dimX,
+                                     (size_t)dimY, (size_t)dimZ);
                 }
             }
         }

--- a/source/libtomo/misc/median_filt3d.c
+++ b/source/libtomo/misc/median_filt3d.c
@@ -100,7 +100,7 @@ medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
                 k1 = k + k_m;
                 if((k1 < 0) || (k1 >= dimZ))
                     k1 = k;
-                index1 = (size_t)(dimX * dimY * k1 ) + (size_t)(j1 * dimX + i1);
+                index1 = dimX * dimY * (size_t)k1 + (size_t)j1 * dimX + (size_t)i1;
                 ValVec[counter] = Input[index1];
                 counter++;
             }
@@ -150,7 +150,7 @@ medfilt2D_float(float* Input, float* Output, int radius, int sizefilter_total,
             j1 = j + j_m;
             if((j1 < 0) || (j1 >= dimY))
                 j1 = j;
-            index1 = (size_t)(j1 * dimX + i1);
+            index1 = (size_t)(j1) * dimX + (size_t)(i1);
             ValVec[counter] = Input[index1];
             counter++;
         }
@@ -205,8 +205,8 @@ medfilt3D_uint16(unsigned short* Input, unsigned short* Output, int radius,
             {
                 k1 = k + k_m;
                 if((k1 < 0) || (k1 >= dimZ))
-                    k1 = k;
-                index1 = (size_t)(dimX * dimY * k1 ) + (size_t)(j1 * dimX + i1);
+                    k1 = k;                
+                index1 = dimX * dimY * (size_t)k1 + (size_t)j1 * dimX + (size_t)i1;
                 ValVec[counter] = Input[index1];
                 counter++;
             }
@@ -257,7 +257,7 @@ medfilt2D_uint16(unsigned short* Input, unsigned short* Output, int radius,
             j1 = j + j_m;
             if((j1 < 0) || (j1 >= dimY))
                 j1 = j;
-            index1 = (size_t)(j1 * dimX + i1);
+            index1 = (size_t)(j1) * dimX + (size_t)(i1);
             ValVec[counter] = Input[index1];
             counter++;
         }
@@ -291,7 +291,7 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
     size_t    index;
     size_t    totalvoxels;
 
-    totalvoxels = (size_t)(dimX * dimY * dimZ);
+    totalvoxels = (size_t)(dimX) * (size_t)(dimY) * (size_t)(dimZ);
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
 
     /* dealing here with a custom given number of cpu threads */
@@ -311,7 +311,7 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
         {
             for(i = 0; i < dimX; i++)
             {
-                index = (size_t)(j * dimX + i);
+                index = (size_t)(j) * dimX + (size_t)(i);
                 medfilt2D_float(Input, Output, radius, sizefilter_total, mu_threshold, i,
                                 j, index, (long) (dimX), (long) (dimY));
             }
@@ -328,7 +328,7 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
             {
                 for(i = 0; i < dimX; i++)
                 {
-                    index = (size_t)((dimX * dimY) * k) + (size_t)(j * dimX + i);
+                    index = dimX * dimY * (size_t)(k) + (size_t)(j) * dimX + (size_t)(i);
                     medfilt3D_float(Input, Output, radius, sizefilter_total, mu_threshold,
                                     i, j, k, index, (long) (dimX), (long) (dimY),
                                     (long) (dimZ));
@@ -352,7 +352,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
     size_t    index;
     size_t    totalvoxels;
 
-    totalvoxels = (size_t)(dimX * dimY * dimZ);    
+    totalvoxels = (size_t)(dimX) * (size_t)(dimY) * (size_t)(dimZ);  
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
 
     /* dealing here with a custom given number of cpu threads */
@@ -372,7 +372,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
         {
             for(i = 0; i < dimX; i++)
             {
-                index = (size_t)(j * dimX + i);
+                index = (size_t)(j) * dimX + (size_t)(i);
                 medfilt2D_uint16(Input, Output, radius, sizefilter_total, mu_threshold, i,
                                  j, index, (long) (dimX), (long) (dimY));
             }
@@ -389,7 +389,7 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
             {
                 for(i = 0; i < dimX; i++)
                 {
-                    index = (size_t)(dimX * dimY * k) + (size_t)(j * dimX + i);
+                    index = dimX * dimY * (size_t)(k) + (size_t)(j) * dimX + (size_t)(i);
                     medfilt3D_uint16(Input, Output, radius, sizefilter_total,
                                      mu_threshold, i, j, k, index, (long) (dimX),
                                      (long) (dimY), (long) (dimZ));

--- a/source/libtomo/misc/median_filt3d.c
+++ b/source/libtomo/misc/median_filt3d.c
@@ -48,6 +48,7 @@
 #include <omp.h>
 #include <stdlib.h>
 #include <string.h>
+#include "stdio.h"
 
 #include "libtomo/median_filt3d.h"
 
@@ -63,6 +64,7 @@ int uint16comp(const void* elem1, const void* elem2)
         return -1;
     return *(const unsigned short*)elem1 > *(const unsigned short*)elem2;
 }
+
 
 void
 medfilt3D_float(float* Input, float* Output, int radius, int sizefilter_total,
@@ -292,10 +294,6 @@ medianfilter_main_float(float* Input, float* Output, int radius, float mu_thresh
 
     totalvoxels = (size_t)(dimX * dimY * dimZ);
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
-    if(mu_threshold != 0.0)
-    {
-        memcpy(Output, Input, totalvoxels * sizeof(float));
-    } /* copy input into output */
 
     /* dealing here with a custom given number of cpu threads */
     if(ncores > 0)
@@ -357,10 +355,6 @@ medianfilter_main_uint16(unsigned short* Input, unsigned short* Output, int radi
 
     totalvoxels = (size_t)(dimX * dimY * dimZ);    
     diameter = (2 * radius + 1); /* diameter of the filter's kernel */
-    if(mu_threshold != 0.0)
-    {
-        memcpy(Output, Input, totalvoxels * sizeof(unsigned short));
-    } /* copy input into output */
 
     /* dealing here with a custom given number of cpu threads */
     if(ncores > 0)

--- a/source/tomopy/misc/corr.py
+++ b/source/tomopy/misc/corr.py
@@ -62,6 +62,7 @@ import warnings
 import numexpr as ne
 import concurrent.futures as cf
 from scipy.signal import medfilt2d
+import copy
 
 logger = logging.getLogger(__name__)
 
@@ -441,8 +442,8 @@ def remove_outlier3d(arr, dif, size=3, ncore=None):
     input_type = arr.dtype
     if (input_type != 'float32') and (input_type != 'uint16'):
         arr = dtype.as_float32(arr)  # silent convertion to float32 data type
-    out = np.empty_like(arr)
-
+    out = copy.deepcopy(arr)
+    
     # convert the full kernel size (odd int) to a half size as the C function requires it
     kernel_half_size = (max(int(size), 3) - 1) // 2
 
@@ -455,10 +456,10 @@ def remove_outlier3d(arr, dif, size=3, ncore=None):
 
     # perform full 3D filtering
     if (input_type == 'float32'):
-        extern.c_median_filt3d_float32(np.ascontiguousarray(arr), out, kernel_half_size, dif, ncore,
+        extern.c_median_filt3d_float32(np.ascontiguousarray(arr), np.ascontiguousarray(out), kernel_half_size, dif, ncore,
                                     dx, dy, dz)
     else:
-        extern.c_median_filt3d_uint16(np.ascontiguousarray(arr), out, kernel_half_size, dif, ncore,
+        extern.c_median_filt3d_uint16(np.ascontiguousarray(arr), np.ascontiguousarray(out), kernel_half_size, dif, ncore,
                                     dx, dy, dz)
     return out
 

--- a/source/tomopy/misc/corr.py
+++ b/source/tomopy/misc/corr.py
@@ -62,7 +62,6 @@ import warnings
 import numexpr as ne
 import concurrent.futures as cf
 from scipy.signal import medfilt2d
-import copy
 
 logger = logging.getLogger(__name__)
 
@@ -442,7 +441,7 @@ def remove_outlier3d(arr, dif, size=3, ncore=None):
     input_type = arr.dtype
     if (input_type != 'float32') and (input_type != 'uint16'):
         arr = dtype.as_float32(arr)  # silent convertion to float32 data type
-    out = copy.deepcopy(arr)
+    out = np.copy(arr, order='C')
     
     # convert the full kernel size (odd int) to a half size as the C function requires it
     kernel_half_size = (max(int(size), 3) - 1) // 2
@@ -456,10 +455,10 @@ def remove_outlier3d(arr, dif, size=3, ncore=None):
 
     # perform full 3D filtering
     if (input_type == 'float32'):
-        extern.c_median_filt3d_float32(np.ascontiguousarray(arr), np.ascontiguousarray(out), kernel_half_size, dif, ncore,
+        extern.c_median_filt3d_float32(np.ascontiguousarray(arr), out, kernel_half_size, dif, ncore,
                                     dx, dy, dz)
     else:
-        extern.c_median_filt3d_uint16(np.ascontiguousarray(arr), np.ascontiguousarray(out), kernel_half_size, dif, ncore,
+        extern.c_median_filt3d_uint16(np.ascontiguousarray(arr), out, kernel_half_size, dif, ncore,
                                     dx, dy, dz)
     return out
 

--- a/source/tomopy/util/dtype.py
+++ b/source/tomopy/util/dtype.py
@@ -79,6 +79,7 @@ __all__ = [
     'as_c_float',
     'as_c_char_p',
     'as_c_void_p',
+    'as_c_size_t',
 ]
 
 
@@ -155,6 +156,10 @@ def as_c_char_p(arr):
 
 def as_c_void_p():
     return ctypes.POINTER(ctypes.c_void_p)
+
+
+def as_c_size_t(arr):
+    return ctypes.c_size_t(arr)
 
 
 def as_sharedmem(arr, copy=False):


### PR DESCRIPTION
The main issue was around `memcpy` seg faulting, possibly when the total index size overflows `int`. 

But in fact, there were multiple issues:
- as previously the index could overflow I introduced `size_t` data type, which should work well across different OS.
- In the wrapper there was `np.ascontiguousarray(arr), out` but should be `np.ascontiguousarray(arr), np.ascontiguousarray(out)`.
- Removed memcpy in the C code and copied array directly in the Python wrapper.

The combination of above seemed solved the problem.

Fixes #622
Closes #624