### PR TITLE
BUG: Add CUDA back into CI build matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,8 +95,8 @@ jobs:
       echo "C++ compiler is ${CXX}"
       pip install . --no-deps
       cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DTOMOPY_USE_MKL:BOOL=$(use.mkl) -DTOMOPY_USE_CUDA:BOOL=$(use.cuda)
-      cmake --build build
-      cmake --install build
+      cmake --build build -v
+      cmake --install build -v
     displayName: Setup and install
   - script: |
       source activate tomopy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,9 +68,15 @@ jobs:
       Python-nomkl:
         python.version: 'nomkl'
         use.mkl: 'OFF'
+        use.cuda: 'OFF'
       Python-38:
         python.version: '38'
         use.mkl: 'ON'
+        use.cuda: 'OFF'
+      Python-cuda:
+        python.version: 'cuda'
+        use.mkl: 'ON'
+        use.cuda: 'ON'
     maxParallel: 4
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -88,7 +94,7 @@ jobs:
       echo "C compiler is ${CC}"
       echo "C++ compiler is ${CXX}"
       pip install . --no-deps
-      cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DTOMOPY_USE_MKL:BOOL=$(use.mkl)
+      cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DTOMOPY_USE_MKL:BOOL=$(use.mkl) -DTOMOPY_USE_CUDA:BOOL=$(use.cuda)
       cmake --build build
       cmake --install build
     displayName: Setup and install

--- a/envs/linux-cuda.yml
+++ b/envs/linux-cuda.yml
@@ -6,6 +6,7 @@ dependencies:
   - cmake
   - gxx_linux-64
   - cuda-nvcc_linux-64
+  - libgomp
   - libnpp-dev
   - dxchange
   - git

--- a/envs/linux-cuda.yml
+++ b/envs/linux-cuda.yml
@@ -2,15 +2,15 @@ name: tomopy
 channels:
   - conda-forge
 dependencies:
-  - gcc_linux-64
   - cmake
-  - gxx_linux-64
   - cuda-nvcc_linux-64
+  - dxchange
+  - gcc_linux-64
+  - git
+  - gxx_linux-64
+  - h5py
   - libgomp
   - libnpp-dev
-  - dxchange
-  - git
-  - h5py
   - ninja
   - numexpr
   - numpy<1.22.4|>=1.23.0

--- a/envs/linux-cuda.yml
+++ b/envs/linux-cuda.yml
@@ -2,12 +2,12 @@ name: tomopy
 channels:
   - conda-forge
 dependencies:
+  - c-compiler
   - cmake
   - cuda-nvcc_linux-64
+  - cxx-compiler
   - dxchange
-  - gcc_linux-64
   - git
-  - gxx_linux-64
   - h5py
   - libgomp
   - libnpp-dev

--- a/envs/linux-cuda.yml
+++ b/envs/linux-cuda.yml
@@ -1,0 +1,29 @@
+name: tomopy
+channels:
+  - conda-forge
+dependencies:
+  - gcc_linux-64
+  - cmake
+  - gxx_linux-64
+  - cuda-nvcc_linux-64
+  - libnpp-dev
+  - dxchange
+  - git
+  - h5py
+  - ninja
+  - numexpr
+  - numpy<1.22.4|>=1.23.0
+  - python
+  - pywavelets
+  - scikit-image>=0.17
+  - scipy
+  - setuptools_scm
+  - setuptools_scm_git_archive
+# Optional packages
+  # - pyctest>0.0.10
+  # - timemory=*=py37h* # the nompi build
+  - mkl
+  - mkl-devel
+  - mkl_fft
+  - pytest
+  - pytest-cov

--- a/source/libtomo/accel/utils.hh
+++ b/source/libtomo/accel/utils.hh
@@ -52,14 +52,6 @@ END_EXTERN_C
 #    define _Complex
 #endif
 
-#if defined(TOMOPY_USE_OPENCV)
-
-#    define CPU_NN CV_INTER_NN
-#    define CPU_LINEAR CV_INTER_LINEAR
-#    define CPU_AREA CV_INTER_AREA
-#    define CPU_CUBIC CV_INTER_CUBIC
-#    define CPU_LANCZOS CV_INTER_LANCZOS4
-
 //--------------------------------------------------------------------------------------//
 
 // a non-string environment option with a string identifier
@@ -115,6 +107,14 @@ GetChoice(const EnvChoiceList<Tp>& _choices, const std::string& str_var)
     std::cerr << ss.str() << std::endl;
     abort();
 }
+
+#if defined(TOMOPY_USE_OPENCV)
+
+#    define CPU_NN CV_INTER_NN
+#    define CPU_LINEAR CV_INTER_LINEAR
+#    define CPU_AREA CV_INTER_AREA
+#    define CPU_CUBIC CV_INTER_CUBIC
+#    define CPU_LANCZOS CV_INTER_LANCZOS4
 
 //--------------------------------------------------------------------------------------//
 

--- a/test/test_tomopy/test_recon/test_rotation.py
+++ b/test/test_tomopy/test_recon/test_rotation.py
@@ -55,7 +55,7 @@ from tomopy.recon.rotation import write_center, find_center, find_center_vo, \
     find_center_pc
 #from tomopy.util.mproc import get_rank, get_nproc, barrier
 import numpy as np
-from scipy.ndimage.interpolation import shift as image_shift
+from scipy.ndimage import shift as image_shift
 from scipy.ndimage import zoom
 import os.path
 import shutil


### PR DESCRIPTION
A recent PR was merged that broke CUDA builds. This should have been avoided with CI CUDA build checks. This PR tries to re-enable CUDA builds on the CI using the conda-forge cuda compiler packages. The binaries will not be tested, just compiled.