### PR TITLE
BLD: Update dependency contraints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ with-coverage=1
 
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 include_package_data = True
 zip_safe = False
 packages = find:
@@ -46,7 +46,8 @@ install_requires =
     numpy~=1.12,!=1.22.4
     pywavelets==1.*
     scikit-image~=0.17
-    scipy==1.*
+    # scipy 1.14 removes deprecated interpolation API
+    scipy==1.*,<1.14
     tifffile>=2019
 
 [options.packages.find]


### PR DESCRIPTION
Update minimum python version to keep up with EOL.

Limit scipy version to prevent deprecation breaks with the SciPy interpolation API. #635