### PR TITLE
remove leftover Python2 code

### DIFF
--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -50,9 +50,6 @@
 PyCTest driver functions
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import os
 import sys
 import glob

--- a/benchmarking/rec.py
+++ b/benchmarking/rec.py
@@ -5,8 +5,6 @@
 TomoPy script to reconstruct a TomoBank file
 """
 
-from __future__ import print_function
-
 import os
 import sys
 import json

--- a/doc/demo/gridrec.py
+++ b/doc/demo/gridrec.py
@@ -50,7 +50,6 @@
 TomoPy example script to reconstruct the tomography data as
 with gridrec.
 """
-from __future__ import print_function
 import tomopy
 import dxchange
 

--- a/source/tomopy/__init__.py
+++ b/source/tomopy/__init__.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import sys
 import warnings
 

--- a/source/tomopy/_fft_loader.py
+++ b/source/tomopy/_fft_loader.py
@@ -50,9 +50,6 @@
 Tries the FFT implementation options in order until one imports without error.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import os
 import logging
 

--- a/source/tomopy/misc/__init__.py
+++ b/source/tomopy/misc/__init__.py
@@ -45,7 +45,3 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
-
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/source/tomopy/misc/benchmark.py
+++ b/source/tomopy/misc/benchmark.py
@@ -46,8 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import absolute_import
-
 __version__ = '1.2.1'
 
 __all__ = ['algorithms', 'image_quality', 'exit_action',

--- a/source/tomopy/misc/corr.py
+++ b/source/tomopy/misc/corr.py
@@ -49,8 +49,6 @@
 Module for data correction and masking functions.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 import scipy.ndimage
 import tomopy.util.mproc as mproc

--- a/source/tomopy/misc/morph.py
+++ b/source/tomopy/misc/morph.py
@@ -50,9 +50,6 @@
 Module for data size morphing functions.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import tomopy.util.mproc as mproc
 import tomopy.util.extern as extern

--- a/source/tomopy/misc/phantom.py
+++ b/source/tomopy/misc/phantom.py
@@ -50,9 +50,6 @@
 Module for generating synthetic phantoms.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import skimage
 import skimage.transform

--- a/source/tomopy/prep/__init__.py
+++ b/source/tomopy/prep/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/source/tomopy/prep/normalize.py
+++ b/source/tomopy/prep/normalize.py
@@ -47,9 +47,6 @@
 # #########################################################################
 """Module for data normalization."""
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import tomopy.util.mproc as mproc
 import tomopy.util.extern as extern

--- a/source/tomopy/prep/phase.py
+++ b/source/tomopy/prep/phase.py
@@ -50,9 +50,6 @@
 Module for phase retrieval.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 from tomopy.util.misc import (fft2, ifft2)
 

--- a/source/tomopy/prep/stripe.py
+++ b/source/tomopy/prep/stripe.py
@@ -49,9 +49,6 @@
 Module for pre-processing tasks.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import pywt
 import tomopy.util.extern as extern

--- a/source/tomopy/recon/__init__.py
+++ b/source/tomopy/recon/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/source/tomopy/recon/acceleration.py
+++ b/source/tomopy/recon/acceleration.py
@@ -50,9 +50,6 @@
 Module for hardware accelerated reconstruction algorithms.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 import importlib.util
 

--- a/source/tomopy/recon/rotation.py
+++ b/source/tomopy/recon/rotation.py
@@ -50,9 +50,6 @@
 Module for functions related to finding axis of rotation.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 import os.path
 

--- a/source/tomopy/recon/vector.py
+++ b/source/tomopy/recon/vector.py
@@ -50,9 +50,6 @@
 Module for reconstruction algorithms.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import tomopy.util.extern as extern
 import tomopy.util.dtype as dtype

--- a/source/tomopy/recon/wrappers.py
+++ b/source/tomopy/recon/wrappers.py
@@ -50,9 +50,6 @@
 Module for reconstruction software wrappers.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 from tomopy.util import mproc
 

--- a/source/tomopy/sim/__init__.py
+++ b/source/tomopy/sim/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/source/tomopy/sim/project.py
+++ b/source/tomopy/sim/project.py
@@ -50,9 +50,6 @@
 Module for simulation of x-rays.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import tomopy.util.extern as extern
 import tomopy.util.dtype as dtype

--- a/source/tomopy/sim/propagate.py
+++ b/source/tomopy/sim/propagate.py
@@ -50,9 +50,6 @@
 Module for simulation of x-rays.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import logging
 

--- a/source/tomopy/util/dtype.py
+++ b/source/tomopy/util/dtype.py
@@ -49,9 +49,6 @@
 Module for internal utility functions.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import ctypes
 import logging
 import multiprocessing as mp

--- a/source/tomopy/util/misc.py
+++ b/source/tomopy/util/misc.py
@@ -50,9 +50,6 @@
 Module for internal utility functions.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 import warnings
 import tifffile

--- a/source/tomopy/util/mproc.py
+++ b/source/tomopy/util/mproc.py
@@ -50,9 +50,6 @@
 Module for multiprocessing tasks.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import multiprocessing as mp
 import math

--- a/test/test_tomopy/__init__.py
+++ b/test/test_tomopy/__init__.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 if __name__ == "__main__":
     import nose
     nose.main()

--- a/test/test_tomopy/test_misc/__init__.py
+++ b/test/test_tomopy/test_misc/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/test/test_tomopy/test_misc/test_morph.py
+++ b/test/test_tomopy/test_misc/test_morph.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from ..util import read_file, loop_dim
 from tomopy.misc.morph import downsample, upsample, sino_360_to_180

--- a/test/test_tomopy/test_misc/test_phantom.py
+++ b/test/test_tomopy/test_misc/test_phantom.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from tomopy.misc.phantom import baboon, barbara, cameraman, checkerboard, \
     lena, peppers, shepp2d, shepp3d

--- a/test/test_tomopy/test_prep/__init__.py
+++ b/test/test_tomopy/test_prep/__init__.py
@@ -45,6 +45,3 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/test/test_tomopy/test_prep/test_alignment.py
+++ b/test/test_tomopy/test_prep/test_alignment.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
- 
 import os.path
 import unittest
 from numpy.testing import assert_allclose

--- a/test/test_tomopy/test_prep/test_normalize.py
+++ b/test/test_tomopy/test_prep/test_normalize.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from tomopy.prep.normalize import normalize, normalize_bg, normalize_nf
 from ..util import read_file

--- a/test/test_tomopy/test_prep/test_phase.py
+++ b/test/test_tomopy/test_prep/test_phase.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from tomopy.prep.phase import retrieve_phase
 from ..util import read_file

--- a/test/test_tomopy/test_prep/test_stripe.py
+++ b/test/test_tomopy/test_prep/test_stripe.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import unittest
 from ..util import read_file

--- a/test/test_tomopy/test_recon/__init__.py
+++ b/test/test_tomopy/test_recon/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/test/test_tomopy/test_recon/test_algorithm.py
+++ b/test/test_tomopy/test_recon/test_algorithm.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import os
 import unittest
 from ..util import read_file

--- a/test/test_tomopy/test_recon/test_rotation.py
+++ b/test/test_tomopy/test_recon/test_rotation.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from ..util import read_file
 from tomopy.recon.rotation import write_center, find_center, find_center_vo, \

--- a/test/test_tomopy/test_sim/__init__.py
+++ b/test/test_tomopy/test_sim/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/test/test_tomopy/test_sim/test_project.py
+++ b/test/test_tomopy/test_sim/test_project.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from ..util import read_file
 from tomopy.sim.project import *

--- a/test/test_tomopy/test_sim/test_propagate.py
+++ b/test/test_tomopy/test_sim/test_propagate.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import unittest
 from ..util import read_file
 # from tomopy.sim.propagate import ...

--- a/test/test_tomopy/test_util/__init__.py
+++ b/test/test_tomopy/test_util/__init__.py
@@ -46,5 +46,3 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/test/test_tomopy/test_util/test_mproc.py
+++ b/test/test_tomopy/test_util/test_mproc.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import tomopy.util.mproc as mproc
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal

--- a/test/test_tomopy/util.py
+++ b/test/test_tomopy/util.py
@@ -46,9 +46,6 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import os.path
 from numpy.testing import assert_array_almost_equal


### PR DESCRIPTION
these headers would confuse people into thinking that Py2 is still actively supported