### PR TITLE
Fix MacOS CI/CD Pipeline

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,7 @@
 # .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Forcing py==3.12 since Sphinx extension epub3 requires imghdr removed in 3.13
 version: 2
 sphinx:
   configuration: doc/source/conf.py
@@ -12,4 +13,4 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,10 +112,15 @@ jobs:
         python.version: '38'
     maxParallel: 4
   steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+  - script: |
+      mkdir -p ~/miniconda
+      curl https://repo.anaconda.com/miniconda/Miniconda3-py39_24.5.0-0-MacOSX-x86_64.sh -o ~/miniconda/miniconda.sh
+      bash ~/miniconda/miniconda.sh -b -u -p ~/miniconda
+      rm ~/miniconda/miniconda.sh
+      ~/miniconda/bin/conda init bash
+    displayName: Install miniconda in runner
+  - bash: echo "##vso[task.prependpath]~/miniconda/bin"
     displayName: Add conda to PATH
-  - bash: sudo chown -R $USER $CONDA
-    displayName: Take ownership of conda installation
   - script: |
       conda env create -n tomopy --quiet -f envs/osx-$(python.version).yml --solver=libmamba
     displayName: Create build environment


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/9262 MacOS 13 and 14 images do not support conda by default. 

The pipelines developers recommend installing miniconda from the site as part of the runtime. https://github.com/actions/runner-images/issues/9262#issuecomment-1918858684 

This patch replaces the initial conda setup with a step to install conda in the MacOS runner. 

Also, fixes a new error with sphinx build. With the transition to 3.13 python dropped imghdr which was required for a sphinx extension. For the time being, forcing sphinx builds to use 3.12. 